### PR TITLE
Update hash for regional_workflow to latest fix that runs on Hera

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 706c94f
+hash = 9b32ce314
 local_path = regional_workflow
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Currently the workflow fails on hera at the make_ics and/or make_lbcs step because the wgrib2 module is not loaded. A PR was accepted in regional_workflow to fix this problem, but the hash was never updated here in the top-level app. This change updates regional_workflow to 9b32ce314, which includes the relevant bug fix.

## TESTS CONDUCTED: 
Ran the test suite on Hera...all pre-processing steps are now successful, although there are some known failures in the forecast step (regional_003, regional_004, and regional_010) that will be addressed in a follow-up PR.

