### PR TITLE
Update the hash of the ufs_utils_chgres external in Externals.cfg

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,8 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = b2b7e959
+#hash = b2b7e959
+hash = 3ff7704e
 local_path = regional_workflow
 required = True
 
@@ -21,7 +22,7 @@ protocol = git
 repo_url = https://github.com/NCAR/UFS_UTILS
 # Specify either a branch name or a hash but not both.
 #branch = feature/chgres_grib2
-hash = d8aa2e44
+hash = 53193694
 local_path = src/UFS_UTILS_chgres_grib2
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update the hash of the ufs_utils_chgres external in Externals.cfg to new one that has a bug fix for an ESMF library version used by chgres_cube on hera.

## TESTS CONDUCTED:
The WE2E tests in the regional_workflow repo were tested on hera and all except regional_010 passed (regional_010 was already broken).