### PR TITLE
Update manage_externals for Python 3+ bug fix, support for 3.7 and 3.8

### DIFF
--- a/manage_externals/.gitignore
+++ b/manage_externals/.gitignore
@@ -12,3 +12,6 @@ components/
 
 # generated python files
 *.pyc
+
+# test tmp file
+test/tmp

--- a/manage_externals/.travis.yml
+++ b/manage_externals/.travis.yml
@@ -1,7 +1,3 @@
-# NOTE(bja, 2017-11) travis-ci dosen't support python language builds
-#  on mac os. As a work around, we use built-in python on linux, and
-#  declare osx a 'generic' language, and create our own python env.
-
 language: python
 os: linux
 python: 
@@ -9,17 +5,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-matrix:
-  include:
-  - os: osx
-    language: generic
-    before_install:
-      # NOTE(bja, 2017-11) update is slow, 2.7.12 installed by default, good enough!
-      # - brew update
-      # - brew outdated python2 || brew upgrade python2
-      - pip install virtualenv
-      - virtualenv env -p python2
-      - source env/bin/activate
+  - "3.7"
+  - "3.8"
 install:
   - pip install -r test/requirements.txt
 before_script:

--- a/manage_externals/manic/checkout.py
+++ b/manage_externals/manic/checkout.py
@@ -279,6 +279,9 @@ of the externals description file or examine the output of
                         help='The externals description filename. '
                         'Default: %(default)s.')
 
+    parser.add_argument('-x', '--exclude', nargs='*',
+                        help='Component(s) listed in the externals file which should be ignored.')
+
     parser.add_argument('-o', '--optional', action='store_true', default=False,
                         help='By default only the required externals '
                         'are checked out. This flag will also checkout the '
@@ -362,7 +365,7 @@ def main(args):
     root_dir = os.path.abspath(os.getcwd())
     external_data = read_externals_description_file(root_dir, args.externals)
     external = create_externals_description(
-        external_data, components=args.components)
+        external_data, components=args.components, exclude=args.exclude)
 
     for comp in args.components:
         if comp not in external.keys():
@@ -389,17 +392,25 @@ def main(args):
             # exit gracefully
             msg = """The external repositories labeled with 'M' above are not in a clean state.
 
-The following are two options for how to proceed:
+The following are three options for how to proceed:
 
-(1) Go into each external that is not in a clean state and issue either
-    an 'svn status' or a 'git status' command. Either revert or commit
-    your changes so that all externals are in a clean state. (Note,
-    though, that it is okay to have untracked files in your working
+(1) Go into each external that is not in a clean state and issue either a 'git status' or
+    an 'svn status' command (depending on whether the external is managed by git or
+    svn). Either revert or commit your changes so that all externals are in a clean
+    state. (To revert changes in git, follow the instructions given when you run 'git
+    status'.) (Note, though, that it is okay to have untracked files in your working
     directory.) Then rerun {program_name}.
 
-(2) Alternatively, you do not have to rely on {program_name}. Instead, you
-    can manually update out-of-sync externals (labeled with 's' above)
-    as described in the configuration file {config_file}.
+(2) Alternatively, you do not have to rely on {program_name}. Instead, you can manually
+    update out-of-sync externals (labeled with 's' above) as described in the
+    configuration file {config_file}. (For example, run 'git fetch' and 'git checkout'
+    commands to checkout the appropriate tags for each external, as given in
+    {config_file}.)
+
+(3) You can also use {program_name} to manage most, but not all externals: You can specify
+    one or more externals to ignore using the '-x' or '--exclude' argument to
+    {program_name}. Excluding externals labeled with 'M' will allow {program_name} to
+    update the other, non-excluded externals.
 
 
 The external repositories labeled with '?' above are not under version

--- a/manage_externals/manic/repository_svn.py
+++ b/manage_externals/manic/repository_svn.py
@@ -220,9 +220,8 @@ then rerun checkout_externals.
                 continue
             if item == SVN_UNVERSIONED:
                 continue
-            else:
-                is_dirty = True
-                break
+            is_dirty = True
+            break
         return is_dirty
 
     # ----------------------------------------------------------------

--- a/manage_externals/manic/sourcetree.py
+++ b/manage_externals/manic/sourcetree.py
@@ -299,18 +299,20 @@ class SourceTree(object):
         for comp in load_comps:
             printlog('{0}, '.format(comp), end='')
             stat = self._all_components[comp].status()
+            stat_final = {}
             for name in stat.keys():
                 # check if we need to append the relative_path_base to
                 # the path so it will be sorted in the correct order.
-                if not stat[name].path.startswith(relative_path_base):
-                    stat[name].path = os.path.join(relative_path_base,
-                                                   stat[name].path)
-                    # store under key = updated path, and delete the
-                    # old key.
-                    comp_stat = stat[name]
-                    del stat[name]
-                    stat[comp_stat.path] = comp_stat
-            summary.update(stat)
+                if stat[name].path.startswith(relative_path_base):
+                    # use as is, without any changes to path
+                    stat_final[name] = stat[name]
+                else:
+                    # append relative_path_base to path and store under key = updated path
+                    modified_path = os.path.join(relative_path_base,
+                                                 stat[name].path)
+                    stat_final[modified_path] = stat[name]
+                    stat_final[modified_path].path = modified_path
+            summary.update(stat_final)
 
         return summary
 

--- a/manage_externals/test/test_sys_checkout.py
+++ b/manage_externals/test/test_sys_checkout.py
@@ -819,8 +819,13 @@ class BaseTestSysCheckout(unittest.TestCase):
 
     def _check_container_component_post_checkout2(self, overall, tree):
         self.assertEqual(overall, 0)
-        self._check_simple_opt_ok(tree)
         self._check_simple_tag_empty(tree)
+        self._check_simple_branch_ok(tree)
+
+    def _check_container_component_post_checkout3(self, overall, tree):
+        self.assertEqual(overall, 0)
+        self.assertFalse("simp_opt" in tree)
+        self._check_simple_tag_ok(tree)
         self._check_simple_branch_ok(tree)
 
     def _check_container_full_post_checkout(self, overall, tree):
@@ -1346,6 +1351,23 @@ class TestSysCheckout(BaseTestSysCheckout):
         overall, tree = self.execute_cmd_in_dir(under_test_dir,
                                                 self.status_args)
         self._check_container_component_post_checkout2(overall, tree)
+
+    def test_container_exclude_component(self):
+        """Verify that exclude component checkout works
+        """
+        # create the test repository
+        under_test_dir = self.setup_test_repo(CONTAINER_REPO_NAME)
+
+        # create the top level externals file
+        self._generator.container_full(under_test_dir)
+
+        # inital checkout, exclude simp_opt
+        checkout_args = ['--exclude', 'simp_opt']
+        checkout_args.extend(self.checkout_args)
+        overall, tree = self.execute_cmd_in_dir(under_test_dir, checkout_args)
+        checkout_args.append("--status")
+        overall, tree = self.execute_cmd_in_dir(under_test_dir, checkout_args)
+        self._check_container_component_post_checkout3(overall, tree)
 
     def test_mixed_simple(self):
         """Verify that a mixed use repo can serve as a 'full' container,

--- a/manage_externals/test/test_unit_externals_description.py
+++ b/manage_externals/test/test_unit_externals_description.py
@@ -342,6 +342,40 @@ class TestCreateExternalsDescription(unittest.TestCase):
         # NOTE(goldy, 2019-03) Should test other possible keywords such as
         # fetchRecurseSubmodules, ignore, and shallow
 
+    @staticmethod
+    def setup_dict_config():
+        """Create the full container dictionary with simple and mixed use
+        externals
+
+        """
+        rdatat = {ExternalsDescription.PROTOCOL: 'git',
+                  ExternalsDescription.REPO_URL: 'simple-ext.git',
+                  ExternalsDescription.TAG: 'tag1'}
+        rdatab = {ExternalsDescription.PROTOCOL: 'git',
+                  ExternalsDescription.REPO_URL: 'simple-ext.git',
+                  ExternalsDescription.BRANCH: 'feature2'}
+        rdatam = {ExternalsDescription.PROTOCOL: 'git',
+                  ExternalsDescription.REPO_URL: 'mixed-cont-ext.git',
+                  ExternalsDescription.BRANCH: 'master'}
+        desc = {'simp_tag': {ExternalsDescription.REQUIRED: True,
+                             ExternalsDescription.PATH: 'simp_tag',
+                             ExternalsDescription.EXTERNALS: EMPTY_STR,
+                             ExternalsDescription.REPO: rdatat},
+                'simp_branch' : {ExternalsDescription.REQUIRED: True,
+                                 ExternalsDescription.PATH: 'simp_branch',
+                                 ExternalsDescription.EXTERNALS: EMPTY_STR,
+                                 ExternalsDescription.REPO: rdatab},
+                'simp_opt': {ExternalsDescription.REQUIRED: False,
+                             ExternalsDescription.PATH: 'simp_opt',
+                             ExternalsDescription.EXTERNALS: EMPTY_STR,
+                             ExternalsDescription.REPO: rdatat},
+                'mixed_req': {ExternalsDescription.REQUIRED: True,
+                              ExternalsDescription.PATH: 'mixed_req',
+                              ExternalsDescription.EXTERNALS: 'sub-ext.cfg',
+                              ExternalsDescription.REPO: rdatam}}
+
+        return desc
+
     def test_cfg_v1_ok(self):
         """Test that a correct cfg v1 object is created by create_externals_description
 
@@ -378,6 +412,49 @@ class TestCreateExternalsDescription(unittest.TestCase):
 
         ext = create_externals_description(desc, model_format='dict')
         self.assertIsInstance(ext, ExternalsDescriptionDict)
+
+    def test_cfg_component_dict(self):
+        """Verify that create_externals_description works with a dictionary
+        """
+        # create the top level externals file
+        desc = self.setup_dict_config()
+        # Check external with all repos
+        external = create_externals_description(desc, model_format='dict')
+        self.assertIsInstance(external, ExternalsDescriptionDict)
+        self.assertTrue('simp_tag' in external)
+        self.assertTrue('simp_branch' in external)
+        self.assertTrue('simp_opt' in external)
+        self.assertTrue('mixed_req' in external)
+
+    def test_cfg_exclude_component_dict(self):
+        """Verify that exclude component checkout works with a dictionary
+        """
+        # create the top level externals file
+        desc = self.setup_dict_config()
+        # Test an excluded repo
+        external = create_externals_description(desc, model_format='dict',
+                                                exclude=['simp_tag',
+                                                         'simp_opt'])
+        self.assertIsInstance(external, ExternalsDescriptionDict)
+        self.assertFalse('simp_tag' in external)
+        self.assertTrue('simp_branch' in external)
+        self.assertFalse('simp_opt' in external)
+        self.assertTrue('mixed_req' in external)
+
+    def test_cfg_opt_component_dict(self):
+        """Verify that exclude component checkout works with a dictionary
+        """
+        # create the top level externals file
+        desc = self.setup_dict_config()
+        # Test an excluded repo
+        external = create_externals_description(desc, model_format='dict',
+                                                components=['simp_tag',
+                                                            'simp_opt'])
+        self.assertIsInstance(external, ExternalsDescriptionDict)
+        self.assertTrue('simp_tag' in external)
+        self.assertFalse('simp_branch' in external)
+        self.assertTrue('simp_opt' in external)
+        self.assertFalse('mixed_req' in external)
 
     def test_cfg_unknown_version(self):
         """Test that a runtime error is raised when an unknown file version is


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updates manage_externals to the most recent release which includes a critical Python 3+ bug fix and supports 3.7 and 3.8.  This new version avoids the previous incompatibility between manage_externals and the YAML namelist generation/Jinja templating for XML and diag_table files.  Users will no longer have to load different versions of Python in-between manage_externals and running the workflow.

## TESTS CONDUCTED: 
Tested successfully on Hera.  All repos are cloned correctly.  @JulieSchramm tested on Cheyenne.

