### PR TITLE
Update source of ufs_weather_model to be the release/public-v2 branch of authoritative repo; update physics suites for which to build FV3

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -26,10 +26,10 @@ required = True
 
 [ufs_weather_model]
 protocol = git
-repo_url = https://github.com/NCAR/ufs-weather-model
+repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
-#branch = dtc/develop
-hash = 8165575
+branch = release/public-v2
+#hash = 8165575
 local_path = src/ufs_weather_model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,9 +2,7 @@
 protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
-#branch = develop
-#hash = b2b7e959
-hash = 3ff7704e
+branch = develop
 local_path = regional_workflow
 required = True
 
@@ -31,7 +29,7 @@ protocol = git
 repo_url = https://github.com/NCAR/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = dtc/develop
-hash = 43ce0c4
+hash = 8165575
 local_path = src/ufs_weather_model
 required = True
 

--- a/src/build_forecast.sh
+++ b/src/build_forecast.sh
@@ -47,7 +47,16 @@ fi
 # Build static executable using cmake for all valid suites in workflow
 # defined in regional_workflow/ush/valid_param_vals.sh
 #---------------------------------------------------------------------------------
-export CCPP_SUITES="FV3_GFS_2017_gfdlmp,FV3_GSD_v0,FV3_GSD_SAR,FV3_CPT_v0,FV3_GFS_v15p2,FV3_GFS_v16beta"
+export CCPP_SUITES="\
+FV3_CPT_v0,\
+FV3_GFS_2017_gfdlmp,\
+FV3_GFS_2017_gfdlmp_regional,\
+FV3_GSD_SAR,\
+FV3_GSD_v0,\
+FV3_GFS_v15p2,\
+FV3_GFS_v16beta,\
+FV3_RRFS_v1beta\
+"
 
 ./build.sh || echo "FAIL:  build_forecast.sh failed, see ${cwd}/logs/build_forecast.log"
 


### PR DESCRIPTION
This PR must be merged simultaneously with PR#[287](https://github.com/NOAA-EMC/regional_workflow/pull/287) into NOAA-EMC/regional_workflow.

Summary of Modifications:
------------------------
* In Externals.cfg:
  * Update the source of the ufs_weather_app external to be the release/public-v2 branch of the ufs-community/ufs-weather-model repo (which is the authoritative repo).
  * Update the regional_workflow external so it points to the HEAD of the develop branch of the NOAA-EMC/regional_workflow repo.
* In build_forecast.sh, add the suites FV3_GFS_2017_gfdlmp_regional and FV3_RRFS_v1beta to the list of suites for which to build the forecast model.

