### PR TITLE
Change UFS_UTILS location to point to a branch in the NCAR fork that …

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,10 +8,12 @@ required = True
 
 [ufs_utils]
 protocol = git
-repo_url = https://github.com/JeffBeck-NOAA/UFS_UTILS
+#repo_url = https://github.com/JeffBeck-NOAA/UFS_UTILS
+repo_url = https://github.com/NCAR/UFS_UTILS
 # Specify either a branch name or a hash but not both.
 #branch = feature/regional_release
-hash = e5419633
+branch = feature/regional_release_STRING
+#hash = e5419633
 local_path = src/UFS_UTILS
 required = True
 


### PR DESCRIPTION
This PR must be merged **BEFORE** PR #[300](https://github.com/NOAA-EMC/regional_workflow/pull/300) into NOAA-EMC/regional_workflow can be merged.

## DESCRIPTION OF CHANGES:
This updates the repo and branch of the ufs_utils external in Externals.cfg.  Previous repo/branch were:
```
repo_url = https://github.com/JeffBeck-NOAA/UFS_UTILS
branch = feature/regional_release
```
However, this doesn't work due to recent commits to this branch.  Thus, switch to an older version of the above branch (that also has one extra small [commit](https://github.com/gsketefian/UFS_UTILS/commit/13799b763960345c921bec0b0c2f515a0a16f7be)):
```
repo_url = https://github.com/NCAR/UFS_UTILS
branch = feature/regional_release_STRING
```

## TESTS CONDUCTED:
See PR #[300](https://github.com/NOAA-EMC/regional_workflow/pull/300) into NOAA-EMC/regional_workflow) into regional_workflow for a description of tests conducted.
