### PR TITLE
Moved CMAKE_Platform 5 lines after so that it will contains {target}.…

### DIFF
--- a/src/build_forecast.sh
+++ b/src/build_forecast.sh
@@ -23,12 +23,12 @@ else
 fi
 
 export COMPILER=intel
-export CMAKE_Platform=${target}
 if [ $target = 'wcoss_cray' -o $target = 'wcoss_dell_p3' ]; then
   target=${target}
 else
   target=${target}.${COMPILER}
 fi
+export CMAKE_Platform=${target}
 
 cd ufs_weather_model
 model_top_dir=`pwd`
@@ -53,8 +53,8 @@ fi
 # is the valid values for CCPP_PHYS_SUITE.  Note that the result (stored
 # in CCPP_SUITES) is a string consisting of a comma-separated list of all
 # the valid (allowed) CCPP physics suites.
-CCPP_SUITES=$( 
-  . ../../regional_workflow/ush/valid_param_vals.sh 
+CCPP_SUITES=$(
+  . ../../regional_workflow/ush/valid_param_vals.sh
   printf "%s," "${valid_vals_CCPP_PHYS_SUITE[@]}"
 )
 export CCPP_SUITES="${CCPP_SUITES:0: -1}"  # Remove comma after last suite.


### PR DESCRIPTION
Moved CMAKE_Platform 5 lines after so that it will contain {target}.{COMPILER} now.

- In file src/build_forecast.sh, moved this line
   `export CMAKE_Platform=${target}`
   5 lines after. So that it will contain "${host}.${COMPILER}" now.
   It is for CMake to pick up the platform-specific configurations in _ufs_weather_model/cmake_. The file convention in _ufs_weather_model/cmake_ is _configure__**{host}**.**{COMPILER}**._cmake_.

## ISSUE (optional): 

Note that this is a suggested change and should be tested on Other platforms. I only tested it on Odin and Stampede.

