### PR TITLE
Remove hard-coded executables directory names

### DIFF
--- a/src/build_all.sh
+++ b/src/build_all.sh
@@ -32,7 +32,7 @@ fi
 # Set the full path of the directory where the binaries (executables) 
 # will be placed (and where the workflow scripts will look for them).
 #
-BIN_DIR=$( readlink -m "../bin" )
+export BIN_DIR=$( readlink -m "../bin" )
 #
 # If the binaries directory doesn't already exist, create it.
 #

--- a/src/build_all.sh
+++ b/src/build_all.sh
@@ -28,10 +28,17 @@ if [ ! -d $logs_dir  ]; then
   mkdir $logs_dir
 fi
 
-# Check final bin folder exists
-if [ ! -d "../" ]; then
-  echo "Creating ../bin folder"
-  mkdir ../bin
+#
+# Set the full path of the directory where the binaries (executables) 
+# will be placed (and where the workflow scripts will look for them).
+#
+BIN_DIR=$( readlink -m "../bin" )
+#
+# If the binaries directory doesn't already exist, create it.
+#
+if [ ! -d "${BIN_DIR}" ]; then
+  echo "Creating binaries directory: BIN_DIR = \"${BIN_DIR}\""
+  mkdir "${BIN_DIR}"
 fi
 
 #------------------------------------

--- a/src/build_post.sh
+++ b/src/build_post.sh
@@ -11,11 +11,6 @@ else
   export MOD_PATH=${cwd}/lib/modulefiles
 fi
 
-# Check final exec folder exists
-if [ ! -d "../exec" ]; then
-  mkdir ../exec
-fi
-
 cd EMC_post
 
 if [ "$target" = "jet" ] ; then

--- a/src/install_all.sh
+++ b/src/install_all.sh
@@ -5,12 +5,6 @@ build_dir=`pwd`
 
 CP='cp -rp'
 
-# Check final bin folder exists
-if [ ! -d "../bin" ]; then
-  echo "Creating ../bin folder"
-  mkdir ../bin
-fi
-
 #------------------------------------
 # INCLUDE PARTIAL BUILD 
 #------------------------------------
@@ -20,59 +14,59 @@ fi
 #------------------------------------
 # install forecast
 #------------------------------------
-#${CP} NEMSfv3gfs/fv3.exe                               ../bin/regional_forecast.x
+#${CP} NEMSfv3gfs/fv3.exe                               ${BIN_DIR}/regional_forecast.x
 
 #------------------------------------
 # install post
 #------------------------------------
 $Build_post && {
- ${CP} EMC_post/exec/*                                 ../bin/ncep_post
+ ${CP} EMC_post/exec/*                                 ${BIN_DIR}/ncep_post
 }
 
 #------------------------------------
 # install needed utilities from UFS_UTILS.
 #------------------------------------
 $Build_UFS_UTILS && {
-# ${CP} regional_utils.fd/exec/global_chgres            ../bin/regional_chgres.x
- ${CP} UFS_UTILS/exec/chgres_cube                      ../bin/chgres_cube
- ${CP} UFS_UTILS/exec/orog                             ../bin/orog
- ${CP} UFS_UTILS/exec/sfc_climo_gen                    ../bin/sfc_climo_gen
- ${CP} UFS_UTILS/exec/regional_esg_grid                ../bin/regional_esg_grid
- ${CP} UFS_UTILS/exec/make_hgrid                       ../bin/make_hgrid
- ${CP} UFS_UTILS/exec/make_solo_mosaic                 ../bin/make_solo_mosaic
- ${CP} UFS_UTILS/exec/fregrid                          ../bin/fregrid
- ${CP} UFS_UTILS/exec/filter_topo                      ../bin/filter_topo
- ${CP} UFS_UTILS/exec/shave                            ../bin/shave
- ${CP} UFS_UTILS/exec/global_equiv_resol               ../bin/global_equiv_resol
+# ${CP} regional_utils.fd/exec/global_chgres            ${BIN_DIR}/regional_chgres.x
+ ${CP} UFS_UTILS/exec/chgres_cube                      ${BIN_DIR}/chgres_cube
+ ${CP} UFS_UTILS/exec/orog                             ${BIN_DIR}/orog
+ ${CP} UFS_UTILS/exec/sfc_climo_gen                    ${BIN_DIR}/sfc_climo_gen
+ ${CP} UFS_UTILS/exec/regional_esg_grid                ${BIN_DIR}/regional_esg_grid
+ ${CP} UFS_UTILS/exec/make_hgrid                       ${BIN_DIR}/make_hgrid
+ ${CP} UFS_UTILS/exec/make_solo_mosaic                 ${BIN_DIR}/make_solo_mosaic
+ ${CP} UFS_UTILS/exec/fregrid                          ${BIN_DIR}/fregrid
+ ${CP} UFS_UTILS/exec/filter_topo                      ${BIN_DIR}/filter_topo
+ ${CP} UFS_UTILS/exec/shave                            ${BIN_DIR}/shave
+ ${CP} UFS_UTILS/exec/global_equiv_resol               ${BIN_DIR}/global_equiv_resol
 }
 
 #------------------------------------
 # install gsi
 #------------------------------------
 $Build_gsi && {
- ${CP} regional_gsi.fd/exec/global_gsi.x               ../exec/regional_gsi.x
- ${CP} regional_gsi.fd/exec/global_enkf.x              ../exec/regional_enkf.x
- ${CP} regional_gsi.fd/exec/adderrspec.x               ../exec/regional_adderrspec.x
- ${CP} regional_gsi.fd/exec/adjustps.x                 ../exec/regional_adjustps.x
- ${CP} regional_gsi.fd/exec/calc_increment_ens.x       ../exec/regional_calc_increment_ens.x
- ${CP} regional_gsi.fd/exec/calc_increment_serial.x    ../exec/regional_calc_increment_serial.x
- ${CP} regional_gsi.fd/exec/getnstensmeanp.x           ../exec/regional_getnstensmeanp.x
- ${CP} regional_gsi.fd/exec/getsfcensmeanp.x           ../exec/regional_getsfcensmeanp.x
- ${CP} regional_gsi.fd/exec/getsfcnstensupdp.x         ../exec/regional_getsfcnstensupdp.x
- ${CP} regional_gsi.fd/exec/getsigensmeanp_smooth.x    ../exec/regional_getsigensmeanp_smooth.x
- ${CP} regional_gsi.fd/exec/getsigensstatp.x           ../exec/regional_getsigensstatp.x
- ${CP} regional_gsi.fd/exec/gribmean.x                 ../exec/regional_gribmean.x
- ${CP} regional_gsi.fd/exec/nc_diag_cat.x              ../exec/regional_nc_diag_cat.x
- ${CP} regional_gsi.fd/exec/nc_diag_cat_serial.x       ../exec/regional_nc_diag_cat_serial.x
- ${CP} regional_gsi.fd/exec/oznmon_horiz.x             ../exec/regional_oznmon_horiz.x
- ${CP} regional_gsi.fd/exec/oznmon_time.x              ../exec/regional_oznmon_time.x
- ${CP} regional_gsi.fd/exec/radmon_angle.x             ../exec/regional_radmon_angle.x
- ${CP} regional_gsi.fd/exec/radmon_bcoef.x             ../exec/regional_radmon_bcoef.x
- ${CP} regional_gsi.fd/exec/radmon_bcor.x              ../exec/regional_radmon_bcor.x
- ${CP} regional_gsi.fd/exec/radmon_time.x              ../exec/regional_radmon_time.x
- ${CP} regional_gsi.fd/exec/recenternemsiop_hybgain.x  ../exec/regional_recenternemsiop_hybgain.x
- ${CP} regional_gsi.fd/exec/recentersigp.x             ../exec/regional_recentersigp.x
- ${CP} regional_gsi.fd/exec/test_nc_unlimdims.x        ../exec/regional_test_nc_unlimdims.x
+ ${CP} regional_gsi.fd/exec/global_gsi.x               ${BIN_DIR}/regional_gsi.x
+ ${CP} regional_gsi.fd/exec/global_enkf.x              ${BIN_DIR}/regional_enkf.x
+ ${CP} regional_gsi.fd/exec/adderrspec.x               ${BIN_DIR}/regional_adderrspec.x
+ ${CP} regional_gsi.fd/exec/adjustps.x                 ${BIN_DIR}/regional_adjustps.x
+ ${CP} regional_gsi.fd/exec/calc_increment_ens.x       ${BIN_DIR}/regional_calc_increment_ens.x
+ ${CP} regional_gsi.fd/exec/calc_increment_serial.x    ${BIN_DIR}/regional_calc_increment_serial.x
+ ${CP} regional_gsi.fd/exec/getnstensmeanp.x           ${BIN_DIR}/regional_getnstensmeanp.x
+ ${CP} regional_gsi.fd/exec/getsfcensmeanp.x           ${BIN_DIR}/regional_getsfcensmeanp.x
+ ${CP} regional_gsi.fd/exec/getsfcnstensupdp.x         ${BIN_DIR}/regional_getsfcnstensupdp.x
+ ${CP} regional_gsi.fd/exec/getsigensmeanp_smooth.x    ${BIN_DIR}/regional_getsigensmeanp_smooth.x
+ ${CP} regional_gsi.fd/exec/getsigensstatp.x           ${BIN_DIR}/regional_getsigensstatp.x
+ ${CP} regional_gsi.fd/exec/gribmean.x                 ${BIN_DIR}/regional_gribmean.x
+ ${CP} regional_gsi.fd/exec/nc_diag_cat.x              ${BIN_DIR}/regional_nc_diag_cat.x
+ ${CP} regional_gsi.fd/exec/nc_diag_cat_serial.x       ${BIN_DIR}/regional_nc_diag_cat_serial.x
+ ${CP} regional_gsi.fd/exec/oznmon_horiz.x             ${BIN_DIR}/regional_oznmon_horiz.x
+ ${CP} regional_gsi.fd/exec/oznmon_time.x              ${BIN_DIR}/regional_oznmon_time.x
+ ${CP} regional_gsi.fd/exec/radmon_angle.x             ${BIN_DIR}/regional_radmon_angle.x
+ ${CP} regional_gsi.fd/exec/radmon_bcoef.x             ${BIN_DIR}/regional_radmon_bcoef.x
+ ${CP} regional_gsi.fd/exec/radmon_bcor.x              ${BIN_DIR}/regional_radmon_bcor.x
+ ${CP} regional_gsi.fd/exec/radmon_time.x              ${BIN_DIR}/regional_radmon_time.x
+ ${CP} regional_gsi.fd/exec/recenternemsiop_hybgain.x  ${BIN_DIR}/regional_recenternemsiop_hybgain.x
+ ${CP} regional_gsi.fd/exec/recentersigp.x             ${BIN_DIR}/regional_recentersigp.x
+ ${CP} regional_gsi.fd/exec/test_nc_unlimdims.x        ${BIN_DIR}/regional_test_nc_unlimdims.x
 }
 
 echo;echo " .... Install system finished .... "


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:
* Remove hard-coded executable directory names by replacing them with the new variable BIN_DIR that gets set only in one place.
* This removes the bug where an empty "exec" directory is created in addition to the "bin" directory in which the executables are placed.

## TESTS CONDUCTED: 
Built on hera successfully.  The executables are identical to the ones created before these changes, and an empty "exec" directory is no longer created.

