### PR TITLE
Change branch of regional_workflow from develop to release/public-v1.

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
-branch = develop
+branch = release/public-v1
 local_path = regional_workflow
 required = True
 


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
Set branch of regional_workflow in Externals.cfg to release/public-v1.

## TESTS CONDUCTED: 
None

## ISSUE (optional): 
None

## CONTRIBUTORS (optional): 


