### PR TITLE
src/machine-setup.sh: don't purge on gaea

### DIFF
--- a/src/machine-setup.sh
+++ b/src/machine-setup.sh
@@ -148,7 +148,8 @@ elif [ "$target" = "gaea" ] ; then
 	echo load the module command 1>&2
         source /etc/profile
     fi
-    module purge
+    # Don't purge on gaea, or hell will break loose
+    #module purge
 elif [ "$target" = "odin" ] ; then
     echo "Not doing anything for 'odin', if statement reserved for future use"
 elif [[ "$target" =~ "stampede" ]] ; then


### PR DESCRIPTION
Change `src/machine-setup.sh` so that no `module purge` is done on gaea, or hell will break loose.

This PR is for the upcoming SRW App public release 1.0, not sure to which branch should go to. 

A corresponding PR is required for UFS_UTILS (https://github.com/NOAA-EMC/UFS_UTILS/pull/189). There is also an update for the ufs-weather-model, which will be part of this PR (not yet): https://github.com/ufs-community/ufs-weather-model/pull/248