### PR TITLE
Only build the two supported CCPP suites; allow user to overwrite default suites

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,8 +7,9 @@ ExternalProject_Add(UFS_UTILS
   CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
   )
 
-
-set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_RRFS_v1beta")
+if(NOT CCPP_SUITES)
+  set(CCPP_SUITES "FV3_GFS_v15p2,FV3_RRFS_v1beta")
+endif()
 
 ExternalProject_Add(ufs_weather_model
   PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ufs_weather_model


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The fv3 dycore release/public-v2 branch is being updated (https://github.com/NOAA-EMC/fv3atm/pull/190) to only include the two supported CCPP suites (FV3_GFS_v15p2 and FV3_RRFS_v1beta). Since CMake is currently hardcoded to build many more suites than this, I need to update the list to only include these two.

Additionally, I included logic to allow the user to overwrite the default suites on the command line, by including the line "-DCCPP_SUITES=suite1,suite2,etc." in the cmake command.

## TESTS CONDUCTED: 

**NOTE: After this change is committed, all tests that do not use one of the above two CCPP suites will fail unless you specify a different set of suites at build time!**

Successfully built the app on MacOS with gnu-10 compilers (using a pending UFS_UTILS change) and on Hera with intel. Ran the suggested core suite of tests on Hera, and all passed:
 - grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
 - grid_RRFS_CONUS_13km_ics_HRRRX_lbcs_RAPX_suite_RRFS_v1beta
 - grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
 - grid_RRFS_CONUS_25km_ics_HRRRX_lbcs_RAPX_suite_RRFS_v1beta
 - grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
 - grid_RRFS_CONUS_3km_ics_HRRRX_lbcs_RAPX_suite_RRFS_v1beta

When I pass the flag "-DCCPP_SUITES=FV3_GFS_v15p2 " at the cmake step, the "RRFS_v1beta" tests fail as expected, since that suite is not built.

## ISSUE:

I could have sworn there was an issue for removing the unsupported CCPP suites from the release branch, but I can't find it if it still exists...