### PR TITLE
release/public-v1: fix Cheyenne build, update CCPP suites etc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,6 @@
 # This is the main cmake file for ufs-srweather-app.
-#
-# Ed Hartnett 5/14/20
 
-# This will use any cmake between 3.1 and 3.15, prefering later
-# versions with updated policies.
-cmake_minimum_required(VERSION 3.1...3.15)
-if (${CMAKE_VERSION} VERSION_LESS 3.12)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-endif()
+cmake_minimum_required(VERSION 3.15)
 
 # Set the project name and version.
 project(ufs-srweather-app VERSION 1.0 LANGUAGES C CXX Fortran)
@@ -20,10 +13,6 @@ SET(SRWA_VERSION_MINOR 0)
 SET(SRWA_VERSION_PATCH 0)
 SET(SRWA_VERSION_NOTE "-development")
 SET(SRWA_VERSION ${SRWA_VERSION_MAJOR}.${SRWA_VERSION_MINOR}.${SRWA_VERSION_PATCH}${SRWA_VERSION_NOTE})
-
-#Add custom CMake Module
-SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/"
-  CACHE INTERNAL "Location of our custom CMake modules.")
 
 # A function used to create autotools-style 'yes/no' definitions.
 # If a variable is set, it 'yes' is returned. Otherwise, 'no' is
@@ -69,15 +58,15 @@ include(CTest)
 
 # Determine the configure date.
 IF(DEFINED ENV{SOURCE_DATE_EPOCH})
-	EXECUTE_PROCESS(
-	  COMMAND "date" "-u" "-d" "@$ENV{SOURCE_DATE_EPOCH}"
-	  OUTPUT_VARIABLE CONFIG_DATE
-	  )
+  EXECUTE_PROCESS(
+    COMMAND "date" "-u" "-d" "@$ENV{SOURCE_DATE_EPOCH}"
+    OUTPUT_VARIABLE CONFIG_DATE
+    )
 ELSE()
-	EXECUTE_PROCESS(
-	  COMMAND date
-	  OUTPUT_VARIABLE CONFIG_DATE
-	  )
+  EXECUTE_PROCESS(
+    COMMAND date
+    OUTPUT_VARIABLE CONFIG_DATE
+    )
 ENDIF()
 IF(CONFIG_DATE)
 	string(STRIP ${CONFIG_DATE} CONFIG_DATE)

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -17,8 +17,8 @@ required = True
 protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
-branch = release/public-v2
-#hash = 8165575
+#branch = release/public-v2
+hash = fa29a21
 local_path = src/ufs_weather_model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,14 +2,16 @@
 protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
-branch = release/public-v1
+#branch = release/public-v1
+hash = 71c2058
 local_path = regional_workflow
 required = True
 
 [ufs_utils]
 protocol = git
 repo_url = https://github.com/NOAA-EMC/UFS_UTILS
-tag = release/public-v2
+#branch = release/public-v2
+hash = 6891c8a
 local_path = src/UFS_UTILS
 required = True
 
@@ -26,8 +28,8 @@ required = True
 protocol = git
 repo_url = https://github.com/NOAA-EMC/EMC_post
 # Specify either a branch name or a hash but not both.
-branch = release/public-v2
-#hash =
+#branch = release/public-v2
+hash = c0899ed
 local_path = src/EMC_post
 required = True
 

--- a/docs/README_cheyenne_gnu.txt
+++ b/docs/README_cheyenne_gnu.txt
@@ -7,12 +7,10 @@ module load mpt/2.19
 module load ncarcompilers/0.5.0
 module load cmake/3.16.4
 
-module use -a /glade/p/ral/jntp/UFS_SRW_app/temp/NCEPLIBS-ufs-v2.0.0/gnu-9.1.0/mpt-2.19/modules/
-module load esmf/8.0.0
+module use /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v2.0.0/gnu-9.1.0/mpt-2.19/modules
 module load NCEPLIBS/2.0.0
 
 export CMAKE_C_COMPILER=mpicc
 export CMAKE_CXX_COMPILER=mpicxx
 export CMAKE_Fortran_COMPILER=mpif90
-export CMAKE_Platform=cheyenne.intel
-
+export CMAKE_Platform=cheyenne.gnu

--- a/docs/README_cheyenne_intel.txt
+++ b/docs/README_cheyenne_intel.txt
@@ -7,13 +7,10 @@ module load mpt/2.19
 module load ncarcompilers/0.5.0
 module load cmake/3.16.4
 
-module use -a /glade/p/ral/jntp/UFS_SRW_app/temp/NCEPLIBS-ufs-v2.0.0/intel-19.1.1/mpt-2.19/modules/
-
-module load esmf/8.0.0
+module use /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v2.0.0/intel-19.1.1/mpt-2.19/modules
 module load NCEPLIBS/2.0.0
 
 export CMAKE_C_COMPILER=mpicc
 export CMAKE_CXX_COMPILER=mpicxx
 export CMAKE_Fortran_COMPILER=mpif90
 export CMAKE_Platform=cheyenne.intel
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 
-set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_RRFS_v1beta")
+set(CCPP_SUITES "FV3_GFS_v15p2,FV3_RRFS_v1beta")
 
 ExternalProject_Add(ufs_weather_model
   PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ufs_weather_model
@@ -16,10 +16,10 @@ ExternalProject_Add(ufs_weather_model
   INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
   CMAKE_ARGS   "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
                "-DCCPP_SUITES=${CCPP_SUITES}"
-	       "-DCMAKE_C_COMPILER=${MPI_C_COMPILER}"
-	       "-DCMAKE_CXX_COMPILER=${MPI_CXX_COMPILER}"
-	       "-DCMAKE_Fortran_COMPILER=${MPI_Fortran_COMPILER}"
-	       "-DNETCDF_DIR=$ENV{NETCDF}"
+               "-DCMAKE_C_COMPILER=${MPI_C_COMPILER}"
+               "-DCMAKE_CXX_COMPILER=${MPI_CXX_COMPILER}"
+               "-DCMAKE_Fortran_COMPILER=${MPI_Fortran_COMPILER}"
+               "-DNETCDF_DIR=$ENV{NETCDF}"
   INSTALL_COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/bin && cp ${CMAKE_CURRENT_BINARY_DIR}/ufs_weather_model/src/ufs_weather_model-build/NEMS.exe ${CMAKE_INSTALL_PREFIX}/bin/
   )
 


### PR DESCRIPTION
This PR fixes a number of issues with building the latest version of the ufs-weather-model and supersedes https://github.com/ufs-community/ufs-srweather-app/pull/48. It also fixes https://github.com/ufs-community/ufs-srweather-app/issues/49.

Changes:
- Use fixed hash instead of branch for ufs-weather-model in Externals.cfg
- CMakeLists.txt: cmake 3.15 is required by the submodules
- src/CMakeLists.txt: update CCPP suites
- Update documentation for cheyenne.intel and cheyenne.gnu
- Also: convert tabs in various `CMakeLists.txt` files into spaces and remove unnecessary CMake modules import (this directory doesn't exist)

This has been tested successfully on Cheyenne with the Intel compiler. Somebody else should try to test this with GNU on Cheyenne, and on other platforms if possible.