### PR TITLE
Add the RRFS_v1alpha suite to the list of suites to build for

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,8 +2,8 @@
 protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
-#branch = release/public-v1
-hash = 856ea00
+branch = release/public-v1
+#hash = 856ea00
 local_path = regional_workflow
 required = True
 
@@ -11,7 +11,7 @@ required = True
 protocol = git
 repo_url = https://github.com/NOAA-EMC/UFS_UTILS
 #branch = release/public-v2
-hash = 879dc76
+hash = 0b68195
 local_path = src/UFS_UTILS
 required = True
 
@@ -20,7 +20,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = release/public-v2
-hash = fa29a21
+hash = 0ad7487
 local_path = src/ufs_weather_model
 required = True
 
@@ -29,7 +29,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/EMC_post
 # Specify either a branch name or a hash but not both.
 #branch = release/public-v2
-hash = c0899ed
+hash = cbcca75
 local_path = src/EMC_post
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,8 +2,8 @@
 protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
-branch = release/public-v1
-#hash = 856ea00
+#branch = release/public-v1
+hash = 5a4b90e
 local_path = regional_workflow
 required = True
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "FV3_GFS_v15p2,FV3_RRFS_v1beta")
+  set(CCPP_SUITES "FV3_GFS_v15p2,FV3_RRFS_v1alpha")
 endif()
 
 ExternalProject_Add(ufs_weather_model


### PR DESCRIPTION
This PR should be merged at the same time as PR #[361](https://github.com/NOAA-EMC/regional_workflow/pull/361) into regional_workflow:release/public-v1.

## DESCRIPTION OF CHANGES:
* Change the hashes in Externals.cfg to be those of the current HEADs of the release branches of the regional_workflow UFS_UTILS, ufs-weather-model, and EMC_post repos.
* Add the RRFS_v1alpha suite to and remove the RRFS_v1beta suite from the list of suites for which to build the forecast model code.

## TESTS CONDUCTED: 
See PR #[361](https://github.com/NOAA-EMC/regional_workflow/pull/361).
