### PR TITLE
Update hash for ufs_utils to point to latest version of release/public-v2

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -11,7 +11,7 @@ required = True
 protocol = git
 repo_url = https://github.com/NOAA-EMC/UFS_UTILS
 #branch = release/public-v2
-hash = 6891c8a
+hash = 879dc76
 local_path = src/UFS_UTILS
 required = True
 


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
This latest release builds only the executables needed by the SRW App.

## TESTS CONDUCTED: 
Built on Cheyenne with Intel and GNU compilers.  Intel out-of-the-box case workflow runs to completion, a fix to run with the GNU build is in PR "https://github.com/NOAA-EMC/regional_workflow/pull/363"



