### PR TITLE
Add build script for developers, update Orion NCEPLIBS location

### DIFF
--- a/devbuild.sh
+++ b/devbuild.sh
@@ -6,7 +6,7 @@ MYDIR=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
 
 usage () {
   echo "Usage: "
-  echo "  ./build.sh PLATFORM COMPILER"
+  echo "  $0 PLATFORM COMPILER"
   echo ""
   echo "PLATFORM: Name of machine you are building on"
   echo "COMPILER: (optional) compiler to use; valid options are 'intel', 'gnu'"

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -45,6 +45,7 @@ if [ ! -f "$ENV_FILE" ]; then
   exit 64
 fi
 
+# If build directory already exists, offer a choice
 BUILD_DIR=${MYDIR}/build
 
 if [ -d "${BUILD_DIR}" ]; then
@@ -64,7 +65,12 @@ if [ -d "${BUILD_DIR}" ]; then
   done
 fi
 
-# Sourcing the README file for this platform/compiler combination will execute all the build commands
+# Source the README file for this platform/compiler combination, then build the code
 . $ENV_FILE
+
+mkdir -p ${BUILD_DIR}
+cd ${BUILD_DIR}
+cmake .. -DCMAKE_INSTALL_PREFIX=..
+make -j ${BUILD_JOBS:-4}
 
 exit 0

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -eu
+
+#cd to location of script
+MYDIR=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
+
+usage () {
+  echo "Usage: "
+  echo "  ./build.sh PLATFORM COMPILER"
+  echo ""
+  echo "PLATFORM: Name of machine you are building on"
+  echo "COMPILER: (optional) compiler to use; valid options are 'intel', 'gnu'"
+  echo ""
+  echo "NOTE: This script is for internal developer use only;"
+  echo "See User's Guide for detailed build instructions"
+}
+
+PLATFORM="${1:-NONE}"
+COMPILER="${2:-intel}"
+
+
+if [ $# -lt 1 ]; then 
+  echo "ERROR: not enough arguments"
+  usage
+  exit 1
+fi
+if [ $# -gt 2 ]; then
+  echo "ERROR: too many arguments"
+  usage
+  exit 1
+fi
+
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then 
+  usage
+  exit 0
+fi
+
+ENV_FILE="docs/README_${PLATFORM}_${COMPILER}.txt"
+if [ ! -f "$ENV_FILE" ]; then
+  echo "ERROR: environment file ($ENV_FILE) does not exist for this platform/compiler combination"
+  echo "PLATFORM=$PLATFORM"
+  echo "COMPILER=$COMPILER"
+  echo ""
+  echo "See User's Guide for detailed build instructions"
+  exit 64
+fi
+
+BUILD_DIR=${MYDIR}/build
+
+if [ -d "${BUILD_DIR}" ]; then
+  while true; do
+    echo "Build directory (${BUILD_DIR}) already exists! Please choose what to do:"
+    echo ""
+    echo "[R]emove the existing directory"
+    echo "[C]ontinue building in the existing directory"
+    echo "[Q]uit this build script"
+    read -p "Choose an option (R/C/Q):" choice
+    case $choice in
+      [Rr]* ) rm -rf ${BUILD_DIR}; break;;
+      [Cc]* ) break;;
+      [Qq]* ) exit;;
+      * ) echo "Invalid option selected.\n";;
+    esac
+  done
+fi
+
+# Sourcing the README file for this platform/compiler combination will execute all the build commands
+. $ENV_FILE
+
+exit 0

--- a/docs/README_orion_intel.txt
+++ b/docs/README_orion_intel.txt
@@ -5,7 +5,7 @@ module load intel/2020
 module load impi/2020
 module load cmake/3.15.4
 
-module use /work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v2.0.0/intel-19.1.0.166/impi-2020.0.166/modules
+module use /apps/contrib/NCEP/libs/NCEPLIBS-ufs-v2.0.0/intel-19.1.0.166/impi-2020.0.166/modules
 
 module load NCEPLIBS/2.0.0
 module load esmf/8.0.0


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Per discussion on #45, adding a build script for developer use. This will not be supported for community use, but limited to official platforms for testing purposes.

The build script should be invoked with the platform name and compiler as arguments, and works by sourcing the README files in the docs/ directory that describe the environment setup for each platform.

The README file for Orion also needed to be updated due to a change in the NCEPLIBS location to a more official spot.

## TESTS CONDUCTED: 
Built successfully on Cheyenne (gnu, intel) and Orion (intel). Should work for any platform with the appropriate README_[platform]_[compiler].txt file.

