### PR TITLE
master Fix Intel build on Cheyenne and ReadTheDocs build

### DIFF
--- a/docs/README_cheyenne_intel.txt
+++ b/docs/README_cheyenne_intel.txt
@@ -9,8 +9,8 @@ module load cmake/3.16.4
 
 module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-nco-20201113/modulefiles/stack
 module load hpc/1.0.0-beta1
-module load hpc-intel/18.0.5.274
-module load hpc-impi/2018.0.4
+module load hpc-intel/19.1.1
+module load hpc-mpt/2.22
 module load jasper/2.0.22
 module load zlib/1.2.11
 module load png/1.6.35

--- a/docs/README_orion_intel.txt
+++ b/docs/README_orion_intel.txt
@@ -1,4 +1,4 @@
-#Setup instructions for MSU Orion using Intel-19.1.0.166 (bash shell)
+#Setup instructions for MSU Orion using Intel-18.0.5 (bash shell)
 
 module load contrib noaatools
 
@@ -7,8 +7,9 @@ module load cmake/3.17.3
 module use /apps/contrib/NCEP/test/hpc-stack-nco/modulefiles/stack
 
 module load hpc/1.0.0-beta1
-module load hpc-intel/18.0.5.274
-module load hpc-impi/2018.0.4
+module load hpc-intel/2018.4
+module load hpc-impi/2018.4
+
 module load jasper/2.0.22
 module load zlib/1.2.11
 module load png/1.6.35

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,1 +1,1 @@
-sphinxcontrib-bibtex = {version = "<2.0.0"}
+sphinxcontrib-bibtex<2.0.0

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,1 +1,1 @@
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex = {version = "<2.0.0"}


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Modify README_cheyenne_intel.txt to build with Intel
- Use older version of sphinx-bibtex 1.0.0, since latest release 2.0.0 is incompatible and ReadTheDocs build fails.
- Modify README_orion_intel.txt to build with intel


## TESTS CONDUCTED: 
Intel build on Cheyenne works, GNU build does not.


