### PR TITLE
release/public-v1: port to WCOSS Dell and Cray

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,9 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/chan-hoo/regional_workflow
+repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
-branch = feature/rv1_wcoss
-#hash = 5a4b90e
+#branch = release/public-v1
+hash = 5a4b90e
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = release/public-v1
-hash = 5a4b90e
+hash = 46e9631
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,9 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/regional_workflow
+repo_url = https://github.com/chan-hoo/regional_workflow
 # Specify either a branch name or a hash but not both.
-#branch = release/public-v1
-hash = 5a4b90e
+branch = feature/rv1_wcoss
+#hash = 5a4b90e
 local_path = regional_workflow
 required = True
 

--- a/docs/README_wcoss_cray_intel.txt
+++ b/docs/README_wcoss_cray_intel.txt
@@ -1,26 +1,53 @@
-#Setup instructions for WCOSS-Cray using Intel-19.0.5.281 (bash shell)
+#Setup instructions for WCOSS-Cray using Intel-18.1.163 (bash shell)
 
-. /opt/modules/3.2.10.3/init/sh
 module purge
-module load PrgEnv-intel/5.2.82
+
+module load PrgEnv-intel
 module rm intel
+module load intel/18.1.163
 module rm NetCDF-intel-sandybridge/4.2
-module load intel/19.0.5.281
 module load xt-lsfhpc/9.1.3
-module load craype-sandybridge
+module load craype-haswell
 module load python/3.6.3
 module load cmake/3.16.2
-module load git/2.18.0
+module load gcc/5.3.0
+#
+module use /usrx/local/dev/modulefiles
+module load NetCDF-intel-sandybridge/4.7.4
+module load HDF5-parallel-intel-sandybridge/1.10.6
 
-module use /usrx/local/nceplibs/NCEPLIBS/NCEPLIBS-ufs-v2.0.0/intel-19.0.5.281/impi-2019/modules
-module load NCEPLIBS/2.0.0
-module load esmf jasper libpng libjpeg netcdf
+## WCOSS cray for WW3
+module load jasper-gnu-sandybridge/1.900.1
+module load zlib-intel-sandybridge/1.2.7
+module load png-intel-sandybridge/1.2.49
+export PNG_ROOT="/usrx/local/prod//png/1.2.49/intel/sandybridge"
 
-export CC=cc
-export FC=ftn
-export CXX=CC
+## NCEP libraries
+module use /usrx/local/nceplibs/NCEPLIBS/cmake/install/NCEPLIBS-v1.3.0/modules
+module load bacio/2.4.1
+module load crtm/2.3.0
+module load g2/3.4.1
+module load g2tmpl/1.9.1
+module load ip/3.3.3
+module load nemsio/2.5.2
+module load sp/2.3.3
+module load w3emc/2.7.3
+module load w3nco/2.4.1
+module load upp/10.0.0
+module load gfsio/1.4.1
+module load sfcio/1.4.1
+module load sigio/2.3.2
+module load landsfcutil/2.4.1
+module load nemsiogfs/2.5.3
+module load wgrib2/2.0.8
 
+module use /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/modulefiles
+module load esmf/8.1.0bs27
+
+
+## load cmake
 export CMAKE_C_COMPILER=cc
 export CMAKE_CXX_COMPILER=CC
 export CMAKE_Fortran_COMPILER=ftn
 export CMAKE_Platform=wcoss_cray
+

--- a/docs/README_wcoss_cray_intel.txt
+++ b/docs/README_wcoss_cray_intel.txt
@@ -8,7 +8,7 @@ module rm NetCDF-intel-sandybridge/4.2
 module load intel/19.0.5.281
 module load xt-lsfhpc/9.1.3
 module load craype-sandybridge
-module load python/2.7.14
+module load python/3.6.3
 module load cmake/3.16.2
 module load git/2.18.0
 

--- a/docs/README_wcoss_cray_intel.txt
+++ b/docs/README_wcoss_cray_intel.txt
@@ -1,0 +1,26 @@
+#Setup instructions for WCOSS-Cray using Intel-19.0.5.281 (bash shell)
+
+. /opt/modules/3.2.10.3/init/sh
+module purge
+module load PrgEnv-intel/5.2.82
+module rm intel
+module rm NetCDF-intel-sandybridge/4.2
+module load intel/19.0.5.281
+module load xt-lsfhpc/9.1.3
+module load craype-sandybridge
+module load python/2.7.14
+module load cmake/3.16.2
+module load git/2.18.0
+
+module use /usrx/local/nceplibs/NCEPLIBS/NCEPLIBS-ufs-v2.0.0/intel-19.0.5.281/impi-2019/modules
+module load NCEPLIBS/2.0.0
+module load esmf jasper libpng libjpeg netcdf
+
+export CC=cc
+export FC=ftn
+export CXX=CC
+
+export CMAKE_C_COMPILER=cc
+export CMAKE_CXX_COMPILER=CC
+export CMAKE_Fortran_COMPILER=ftn
+export CMAKE_Platform=wcoss_cray

--- a/docs/README_wcoss_dell_p3_intel.txt
+++ b/docs/README_wcoss_dell_p3_intel.txt
@@ -1,0 +1,19 @@
+#Setup instructions for NOAA WCOSS Dell using Intel-18.0.1.163 (bash shell)
+
+. /usrx/local/prod/lmod/lmod/init/sh
+
+module purge
+module load EnvVars/1.0.3
+module load ips/18.0.1.163
+module load impi/18.0.1
+module load lsf/10.1
+module load cmake/3.16.2
+module load python/2.7.14
+
+module use /usrx/local/nceplibs/dev/NCEPLIBS/cmake/install/NCEPLIBS-ufs-v2.0.0/ips-18.0.1.163/impi-18.0.1/modules
+module load NCEPLIBS/2.0.0
+
+export CMAKE_C_COMPILER=mpiicc
+export CMAKE_CXX_COMPILER=mpiicpc
+export CMAKE_Fortran_COMPILER=mpiifort
+export CMAKE_Platform=wcoss_dell_p3

--- a/docs/README_wcoss_dell_p3_intel.txt
+++ b/docs/README_wcoss_dell_p3_intel.txt
@@ -8,7 +8,7 @@ module load ips/18.0.1.163
 module load impi/18.0.1
 module load lsf/10.1
 module load cmake/3.16.2
-module load python/2.7.14
+module load python/3.6.3
 
 module use /usrx/local/nceplibs/dev/NCEPLIBS/cmake/install/NCEPLIBS-ufs-v2.0.0/ips-18.0.1.163/impi-18.0.1/modules
 module load NCEPLIBS/2.0.0


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Added the build-environment files ('README_xxx.txt') for WCOSS Dell and Cray to the 'docs/' directory.

## TESTS CONDUCTED: 
SRW App ('release/public-v1' branch) was built without any issues on WCOSS Dell and Cray.

## ISSUE:
Fixes issue mentioned in #79.
Related to https://github.com/NOAA-EMC/regional_workflow/pull/385.

## CONTRIBUTORS: 
@BenjaminBlake-NOAA 
