### PR TITLE
Update hash of regional_workflow in Externals.cfg to use the latest tested version (corresponding to PR #404 into regional_workflow)

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = release/public-v1
-hash = 46e9631
+hash = bed5c87
 local_path = regional_workflow
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update hash of regional_workflow in Externals.cfg to use the latest tested version corresponding to PR #[404](https://github.com/NOAA-EMC/regional_workflow/pull/404) into regional_workflow.

## TESTS CONDUCTED: 
See PR #[404](https://github.com/NOAA-EMC/regional_workflow/pull/404) into regional_workflow.

