### PR TITLE
Update weather model hash, upgrade Cheyenne GNU build environment to version 10.1

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -20,7 +20,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = release/public-v2
-hash = 0ad7487
+hash = d31b799
 local_path = src/ufs_weather_model
 required = True
 

--- a/docs/UsersGuide/source/Quickstart.rst
+++ b/docs/UsersGuide/source/Quickstart.rst
@@ -169,7 +169,7 @@ On Cheyenne:
 .. code-block:: console
 
    module load ncarenv
-   ncar_pylib /glade/p/ral/jntp/UFS_CAM/ncar_pylib_20200427
+   ncar_pylib /glade/p/ral/jntp/UFS_SRW_app/ncar_pylib/regional_workflow
    module use -a /glade/p/ral/jntp/UFS_SRW_app/modules
    module load rocoto 
 

--- a/docs/UsersGuide/source/SRWAppOverview.rst
+++ b/docs/UsersGuide/source/SRWAppOverview.rst
@@ -411,7 +411,7 @@ On Cheyenne:
 .. code-block:: console
 
    module load ncarenv
-   ncar_pylib /glade/p/ral/jntp/UFS_CAM/ncar_pylib_20200427
+   ncar_pylib /glade/p/ral/jntp/UFS_SRW_app/ncar_pylib/regional_workflow
 
 Load the rocoto module:
 

--- a/env/build_cheyenne_gnu.env
+++ b/env/build_cheyenne_gnu.env
@@ -1,13 +1,13 @@
-#Setup instructions for CISL Cheyenne using Intel-19.1.1 (bash shell)
+#Setup instructions for CISL Cheyenne using GNU-10.1.0 (bash shell)
 
 module purge
 module load ncarenv/1.3
-module load gnu/9.1.0
+module load gnu/10.1.0
 module load mpt/2.19
 module load ncarcompilers/0.5.0
 module load cmake/3.16.4
 
-module use /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v2.0.0/gnu-9.1.0/mpt-2.19/modules
+module use /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v2.0.0/gnu-10.1.0/mpt-2.19/modules/
 module load NCEPLIBS/2.0.0
 
 export CMAKE_C_COMPILER=mpicc


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updating Cheyenne build environment to use GNU 10.1. This requires updating the weather model hash to include a fix for GNU 10 compilers.

Also took the opportunity to update the documentation to include the new location of the Cheyenne python environment.

## TESTS CONDUCTED: 
Ran suite of release branch tests (minus the 3km versions) in [regional_workflow/tests/testlist.release_public_v1.txt](https://github.com/NOAA-EMC/regional_workflow/blob/develop/tests/testlist.release_public_v1.txt) with new GNU compilers. All passed. Also ran same tests on Hera as a sanity check (especially since the weather model hash was updated); all passed.

## ISSUE: 
Resolves #81
