### PR TITLE
Add the FV3_HRRR suite to build; update regional_workflow hash

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = b490a36
+hash = 42fd627
 local_path = regional_workflow
 required = True
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_RRFS_v1beta")
+  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_RRFS_v1beta,FV3_HRRR")
 endif()
 
 ExternalProject_Add(ufs_weather_model


### PR DESCRIPTION
## NOTE:
This PR should be merged right after PR #[382](https://github.com/NOAA-EMC/regional_workflow/pull/382) into regional_workflow (and using in Externals.cfg the hash of regional_workflow that the merge of PR #[382](https://github.com/NOAA-EMC/regional_workflow/pull/382) generates).

## DESCRIPTION OF CHANGES:
* Add the FV3_HRRR suite to the list of suites to build.
* Update hashes of regional_workflow and ufs-weather-model to work with PR #[382](https://github.com/NOAA-EMC/regional_workflow/pull/382) into regional_workflow.

## TESTS CONDUCTED:
See PR #[382](https://github.com/NOAA-EMC/regional_workflow/pull/382) in regional_workflow.
