### PR TITLE
Update hashes for ufs-weather-model, UFS_UTILS and regional_workflow (remove setting PS1 from regional_workflow/modulefiles/tasks/gaea/*.local)

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = release/public-v2
-hash = 82f0553c
+hash = 58cf07a
 local_path = src/ufs_weather_model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,11 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/regional_workflow
-# Specify either a branch name or a hash but not both.
-#branch = release/public-v1
-hash = bc08607
+# repo_url = https://github.com/NOAA-EMC/regional_workflow
+# # Specify either a branch name or a hash but not both.
+# #branch = release/public-v1
+# hash = bc08607
+repo_url = https://github.com/climbfuji/regional_workflow
+branch = remove_ps1_gaea_modulefiles
 local_path = regional_workflow
 required = True
 
@@ -11,7 +13,7 @@ required = True
 protocol = git
 repo_url = https://github.com/NOAA-EMC/UFS_UTILS
 #branch = release/public-v2
-hash = 2e6782d
+hash = 38c60a1
 local_path = src/UFS_UTILS
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = release/public-v2
-hash = b66fbae
+hash = 82f0553c
 local_path = src/ufs_weather_model
 required = True
 


### PR DESCRIPTION
## Description
This PR
- updates the hash of UFS_UTILS to point to the head of release/public-v2. Without this update, generating ICs crashes on gaea. The differences for UFS_UTILS can be viewed by checking out the current and new hash: there are large differences in `surface.F90` and a one-liner change in `build_all.sh`
- updates the hash of ufs-weather-model for the recent merge that fixes the b4b mismatches when changing the MPI decomposition for regional runs
- updates the hash of regional_workflow for the changes described in https://github.com/NOAA-EMC/regional_workflow/pull/429

## Testing
- workflow (GST) runs end to end on gaea; note: do *not* use cron to automatically resubmit jobs
- no other systems tested yet

## Dependencies
- waiting on https://github.com/NOAA-EMC/regional_workflow/pull/429

