### PR TITLE
Follow-up to "Update hashes for ufs-weather-model, UFS_UTILS and regional_workflow"

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,11 +1,9 @@
 [regional_workflow]
 protocol = git
-# repo_url = https://github.com/NOAA-EMC/regional_workflow
-# # Specify either a branch name or a hash but not both.
-# #branch = release/public-v1
-# hash = bc08607
-repo_url = https://github.com/climbfuji/regional_workflow
-branch = remove_ps1_gaea_modulefiles
+repo_url = https://github.com/NOAA-EMC/regional_workflow
+# Specify either a branch name or a hash but not both.
+#branch = release/public-v1
+hash = 517c1a93
 local_path = regional_workflow
 required = True
 


### PR DESCRIPTION
PR #101 was merged before the regional_workflow hash could be updated in `Externals.cfg`. This PR fixes it and points to the head of release/public-v1 of the regional workflow.