### PR TITLE
Update of gaea environment to not use lua modules

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,11 +1,9 @@
 [regional_workflow]
 protocol = git
-# repo_url = https://github.com/NOAA-EMC/regional_workflow
-# # Specify either a branch name or a hash but not both.
-# #branch = release/public-v1
-# hash = 517c1a93
-repo_url = https://github.com/climbfuji/regional_workflow
-branch = gaea_no_lua
+repo_url = https://github.com/NOAA-EMC/regional_workflow
+# Specify either a branch name or a hash but not both.
+#branch = release/public-v1
+hash = c656131f
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,11 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/regional_workflow
-# Specify either a branch name or a hash but not both.
-#branch = release/public-v1
-hash = 517c1a93
+# repo_url = https://github.com/NOAA-EMC/regional_workflow
+# # Specify either a branch name or a hash but not both.
+# #branch = release/public-v1
+# hash = 517c1a93
+repo_url = https://github.com/climbfuji/regional_workflow
+branch = gaea_no_lua
 local_path = regional_workflow
 required = True
 

--- a/env/wflow_gaea.env
+++ b/env/wflow_gaea.env
@@ -1,10 +1,6 @@
-# Python environment for workflow on Gaea
-
-source /lustre/f2/pdata/esrl/gsd/contrib/lua-5.1.4.9/init/init_lmod.sh
+# Rocoto and Python environment for workflow on Gaea
 
 module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
 
 module load rocoto/1.3.3
-module load miniconda3/4.8.3
-
-conda activate regional_workflow
+module load miniconda3/4.8.3-regional-workflow


### PR DESCRIPTION
Update gaea workflow environment to avoid using the lua module environment.

Also update `Externals.cfg` temporarily for code review and testing. This change will need to be reverted and the `regional_workflow` hash updated after https://github.com/NOAA-EMC/regional_workflow/pull/440 is merged and before this PR gets merged.


Testing: I tested this successfully on gaea with and without cron:
```
git clone -b gaea_no_lua --recursive https://github.com/climbfuji/ufs-srweather-app
cd ufs-srweather-app
source env/build_gaea_intel.env
mkdir build && cd build
cmake .. -DCMAKE_INSTALL_PREFIX=.. 2>&1 | tee log.cmake
make -j4 2>&1 | tee log.make
cd ..
# Is the next step necessary?
source env/wflow_gaea.env
#
cd /regional_workflow/ush
./generate_FV3LAM_wflow.sh
# Add the crontab line to my crontab, which now looks like this (without the pound lines)
###############################################################
PATH=/lustre/f2/pdata/esrl/gsd/contrib/rocoto-1.3.3/bin:$PATH
MAILTO="dom.heinzeller@noaa.gov"
###
*/1 * * * * cd /lustre/f2/dev/esrl/Dom.Heinzeller/ufs-srweather-app/expt_dirs/GST_release_public_v1 && ./launch_FV3LAM_wflow.sh >> launch_FV3LAM_wflow.out 2>> launch_FV3LAM_wflow.err
###############################################################
```
I really, really recommend to instruct the user to either set `MAILTO=...` in their crontab (if that works on the particular system, not all systems allow to send out emails from cron) or to pipe the output from cron to the two files as shown above.