### PR TITLE
release/public-v1: Update hash ufs-weather-model 2021/02/19

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -20,7 +20,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = release/public-v2
-hash = 58cf07a
+hash = 6d48720
 local_path = src/ufs_weather_model
 required = True
 


### PR DESCRIPTION
Update hash for the ufs-weather-model in `Externals.cfg` following the merge of https://github.com/ufs-community/ufs-weather-model/pull/423 and PRs listed in there.

No testing required, the code changes in ccpp-physics are for the CCPP Single Column Model only, the files modified are not used by the ufs-weather-model.