### PR TITLE
Emergency bugfix following #108: correct hash for ufs-weather-model

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -20,7 +20,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = release/public-v2
-hash = 6d48720
+hash = 041267c
 local_path = src/ufs_weather_model
 required = True
 


### PR DESCRIPTION
I made a mistake with the hash in PR #108, this PR fixes it. Tested and works. Will merge immediately. Sorry for the hiccup, and thanks @chan-hoo for reporting.