### PR TITLE
Update hash of regional_workflow

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 7acfe74
+hash = 3586e11
 local_path = regional_workflow
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:
Update hash of regional_workflow to the latest PR (#[450](https://github.com/NOAA-EMC/regional_workflow/pull/450)) in the regional_workflow repo.

## TESTS CONDUCTED: 
See PR #[450](https://github.com/NOAA-EMC/regional_workflow/pull/450) into regional_workflow.