### PR TITLE
Fix GNU build and run on Cheyenne

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -12,7 +12,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UFS_UTILS
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 005f9a0a
+hash = ea821358
 local_path = src/UFS_UTILS
 required = True
 

--- a/docs/UsersGuide/source/Quickstart.rst
+++ b/docs/UsersGuide/source/Quickstart.rst
@@ -42,6 +42,8 @@ and will clone the regional workflow, pre-processing utilities, UFS Weather Mode
 into the appropriate directories under your ``regional_workflow`` and ``src`` directories.
 
 
+.. _SetUpBuild:
+
 Set up the Build Environment
 ============================
 Instructions for loading the proper modules and/or setting the correct environment variables can be
@@ -53,9 +55,10 @@ or use ``setenv`` rather than ``export`` depending on your environment:
 .. code-block:: console
 
    $ ls -l env/
-      -rw-rw-r-- 1 user ral 466 Jan  21 10:09 build_cheyenne_intel.env
-      -rw-rw-r-- 1 user ral 461 Jan  21 10:09 build_hera_intel.env
-      -rw-rw-r-- 1 user ral 543 Jan  21 10:09 build_jet_intel.env
+      -rw-rw-r-- 1 user ral 1062 Apr  27 10:09 build_cheyenne_gnu.env
+      -rw-rw-r-- 1 user ral 1061 Apr  27 10:09 build_cheyenne_intel.env
+      -rw-rw-r-- 1 user ral 1023 Apr  27 10:09 build_hera_intel.env
+      -rw-rw-r-- 1 user ral 1017 Apr  27 10:09 build_jet_intel.env
 
 Build the Executables
 =====================
@@ -115,6 +118,11 @@ machine you are running on, those changes should be sufficient; however, if that
 on Cheyenne), or if you have pre-staged the initialization data you would like to use, you will also want to set 
 ``USE_USER_STAGED_EXTRN_FILES="TRUE"`` and set the paths to the data for ``EXTRN_MDL_SOURCE_BASEDIR_ICS`` and 
 ``EXTRN_MDL_SOURCE_BASEDIR_LBCS``. 
+
+.. note::
+
+   If you set up the build environment with the GNU compiler in :numref:`Section %s <SetUpBuild>`, you will
+   have to add the line ``COMPILER="gnu"`` to the ``config.sh`` file.
  
 At a minimum, the following parameters should be set for the machine you are using:
 

--- a/env/build_cheyenne_gnu.env
+++ b/env/build_cheyenne_gnu.env
@@ -6,10 +6,10 @@ module load gnu/9.1.0
 module load mpt/2.22
 module load ncarcompilers/0.5.0
 module load cmake/3.16.4
+module unload netcdf
 
-
-module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-nco-20201113/modulefiles/stack
-module load hpc/1.0.0-beta1
+module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
+module load hpc/1.1.0
 module load hpc-gnu/9.1.0
 module load hpc-mpt/2.22
 module load jasper/2.0.22
@@ -17,7 +17,7 @@ module load zlib/1.2.11
 module load png/1.6.35
 module load hdf5/1.10.6
 module load netcdf/4.7.4
-module load pio/2.5.1
+module load pio/2.5.2
 module load esmf/8_1_0_beta_snapshot_27
 module load bacio/2.4.1
 module load crtm/2.3.0


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
- Update build_cheyenne_gnu.env to use latest hpc stack
- Update Externals.cfg to point to hash of UFS_UTILS with bug fix
- Update Quickstart documentation accordingly

## TESTS CONDUCTED: 
Out-of-the-box case builds and workflow runs to completion on Cheyenne with GNU build.
Intel tests run on Cheyenne and Hera, all with: Workflow status:  SUCCESS

grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2 
grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
GST_release_public_v1

## DOCUMENTATION:
Documentation has been updated

## ISSUE (optional): 

## CONTRIBUTORS (optional): 

