### PR TITLE
Update build environment files for Hera, Orion, WCOSS with latest hpc-stack

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 3586e11
+hash = 6e98256
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 6e98256
+hash = 3586e11
 local_path = regional_workflow
 required = True
 

--- a/env/build_hera_intel.env
+++ b/env/build_hera_intel.env
@@ -33,11 +33,9 @@ module load zlib/1.2.11
 module load esmf/8_1_0_beta_snapshot_27
 module load hdf5/1.10.6
 module load landsfcutil/2.4.1
-module load nccmp/1.8.7.0
 module load nemsiogfs/2.5.3
 module load netcdf/4.7.4
 module load upp/10.0.0
-module load wrf_io/1.1.1
 module load w3emc/2.7.3
 
 

--- a/env/build_hera_intel.env
+++ b/env/build_hera_intel.env
@@ -2,40 +2,56 @@
 
 module purge
 
+# UFS_UTILS
+module load hpss
+module load cmake/3.16.1
+# + ufs-weather-model
 module use /contrib/sutils/modulefiles
 module load sutils
-module load cmake/3.16.1
 
-module use /scratch2/NCEPDEV/nwprod/hpc-stack/test/modulefiles/stack
 
-module load hpc/1.0.0-beta1
+### hpc-stack ###
+module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack
+module load hpc/1.1.0
 module load hpc-intel/18.0.5.274
 module load hpc-impi/2018.0.4
-module load jasper/2.0.22
-module load zlib/1.2.11
-module load png/1.6.35
-module load hdf5/1.10.6
-module load netcdf/4.7.4
-module load pio/2.5.1
-module load esmf/8_1_0_beta_snapshot_27
+# UFS_UTILS
 module load bacio/2.4.1
-module load crtm/2.3.0
 module load g2/3.4.1
-module load g2tmpl/1.9.1
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load sp/2.3.3
-module load w3emc/2.7.3
 module load w3nco/2.4.1
-module load upp/10.0.0
-
-module load gfsio/1.4.1
 module load sfcio/1.4.1
+module load sigio/2.3.2
+module load wgrib2/2.0.8
+module load jasper/2.0.22
+module load zlib/1.2.11
+module load png/1.6.35
+# + EMC_post
+module load crtm/2.3.0
+module load g2tmpl/1.10.0
+module load gfsio/1.4.1 
+
+
+# UFS_UTILS
+module load hdf5/1.10.6
+module load netcdf/4.7.4
+module load nccmp/1.8.7.0
+module load esmf/8_1_0_beta_snapshot_27
+# + EMC_post
+module load nemsio/2.5.2
+module load w3emc/2.7.3
+module load wrf_io/1.1.1
+
+
+### Extra ###
 module load landsfcutil/2.4.1
 module load nemsiogfs/2.5.3
-module load wgrib2/2.0.8
+module load upp/10.0.0
 
 
+# ufs-weather-model
 export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort

--- a/env/build_hera_intel.env
+++ b/env/build_hera_intel.env
@@ -40,7 +40,6 @@ module load netcdf/4.7.4
 module load nccmp/1.8.7.0
 module load esmf/8_1_0_beta_snapshot_27
 # + EMC_post
-module load nemsio/2.5.2
 module load w3emc/2.7.3
 module load wrf_io/1.1.1
 

--- a/env/build_hera_intel.env
+++ b/env/build_hera_intel.env
@@ -2,10 +2,8 @@
 
 module purge
 
-# UFS_UTILS
-module load hpss
 module load cmake/3.16.1
-# + ufs-weather-model
+module load hpss
 module use /contrib/sutils/modulefiles
 module load sutils
 
@@ -14,9 +12,12 @@ module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack
 module load hpc/1.1.0
 module load hpc-intel/18.0.5.274
 module load hpc-impi/2018.0.4
-# UFS_UTILS
+
 module load bacio/2.4.1
+module load crtm/2.3.0
+module load gfsio/1.4.1
 module load g2/3.4.1
+module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load jasper/2.0.22
 module load nemsio/2.5.2
@@ -27,28 +28,19 @@ module load sp/2.3.3
 module load wgrib2/2.0.8
 module load w3nco/2.4.1
 module load zlib/1.2.11
-# + EMC_post
-module load crtm/2.3.0
-module load gfsio/1.4.1 
-module load g2tmpl/1.10.0
 
 ### Additional modules ###
-# UFS_UTILS
 module load esmf/8_1_0_beta_snapshot_27
 module load hdf5/1.10.6
+module load landsfcutil/2.4.1
 module load nccmp/1.8.7.0
+module load nemsiogfs/2.5.3
 module load netcdf/4.7.4
-
-# + EMC_post
+module load upp/10.0.0
 module load wrf_io/1.1.1
 module load w3emc/2.7.3
 
-### Extra ###
-module load landsfcutil/2.4.1
-module load nemsiogfs/2.5.3
-module load upp/10.0.0
 
-# ufs-weather-model
 export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort

--- a/env/build_hera_intel.env
+++ b/env/build_hera_intel.env
@@ -9,7 +9,6 @@ module load cmake/3.16.1
 module use /contrib/sutils/modulefiles
 module load sutils
 
-
 ### hpc-stack ###
 module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack
 module load hpc/1.1.0
@@ -19,40 +18,38 @@ module load hpc-impi/2018.0.4
 module load bacio/2.4.1
 module load g2/3.4.1
 module load ip/3.3.3
+module load jasper/2.0.22
 module load nemsio/2.5.2
-module load sp/2.3.3
-module load w3nco/2.4.1
+module load png/1.6.35
 module load sfcio/1.4.1
 module load sigio/2.3.2
+module load sp/2.3.3
 module load wgrib2/2.0.8
-module load jasper/2.0.22
+module load w3nco/2.4.1
 module load zlib/1.2.11
-module load png/1.6.35
 # + EMC_post
 module load crtm/2.3.0
-module load g2tmpl/1.10.0
 module load gfsio/1.4.1 
+module load g2tmpl/1.10.0
 
-
+### Additional modules ###
 # UFS_UTILS
-module load hdf5/1.10.6
-module load netcdf/4.7.4
-module load nccmp/1.8.7.0
 module load esmf/8_1_0_beta_snapshot_27
-# + EMC_post
-module load w3emc/2.7.3
-module load wrf_io/1.1.1
+module load hdf5/1.10.6
+module load nccmp/1.8.7.0
+module load netcdf/4.7.4
 
+# + EMC_post
+module load wrf_io/1.1.1
+module load w3emc/2.7.3
 
 ### Extra ###
 module load landsfcutil/2.4.1
 module load nemsiogfs/2.5.3
 module load upp/10.0.0
 
-
 # ufs-weather-model
 export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort
 export CMAKE_Platform=hera.intel
-

--- a/env/build_orion_intel.env
+++ b/env/build_orion_intel.env
@@ -34,11 +34,9 @@ module load zlib/1.2.11
 module load esmf/8_1_0_beta_snapshot_27
 module load hdf5/1.10.6
 module load landsfcutil/2.4.1
-module load nccmp/1.8.7.0
 module load nemsiogfs/2.5.3
 module load netcdf/4.7.4
 module load upp/10.0.0
-module load wrf_io/1.1.1
 module load w3emc/2.7.3
 
 

--- a/env/build_orion_intel.env
+++ b/env/build_orion_intel.env
@@ -2,9 +2,7 @@
 
 module purge
 
-# UFS_UTILS
 module load cmake/3.17.3
-# + ufs-weather-model
 module load contrib noaatools
 module load python/3.7.5
 
@@ -13,9 +11,12 @@ module use /apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack
 module load hpc/1.1.0
 module load hpc-intel/2018.4
 module load hpc-impi/2018.4
-# UFS_UTILS
+
 module load bacio/2.4.1
+module load crtm/2.3.0
+module load gfsio/1.4.1
 module load g2/3.4.1
+module load g2tmpl/1.9.1
 module load ip/3.3.3
 module load jasper/2.0.22
 module load nemsio/2.5.2
@@ -24,31 +25,23 @@ module load sfcio/1.4.1
 module load sigio/2.3.2
 module load sp/2.3.3
 module load wgrib2/2.0.8
+module load wrf_io/1.1.1
+module load w3emc/2.7.3
 module load w3nco/2.4.1
 module load zlib/1.2.11
-# + EMC_post
-module load crtm/2.3.0
-module load gfsio/1.4.1
-module load g2tmpl/1.9.1
-module load wrf_io/1.1.1
-module load w3emc/2.7.3
 
 ### Additional modules ###
-# UFS_UTILS
 module load esmf/8_1_0_beta_snapshot_27
 module load hdf5/1.10.6
+module load landsfcutil/2.4.1
 module load nccmp/1.8.7.0
+module load nemsiogfs/2.5.3
 module load netcdf/4.7.4
-# + EMC_post
+module load upp/10.0.0
 module load wrf_io/1.1.1
 module load w3emc/2.7.3
 
-### Extra ###
-module load landsfcutil/2.4.1
-module load nemsiogfs/2.5.3
-module load upp/10.0.0
 
-# ufs-weather-model
 export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort

--- a/env/build_orion_intel.env
+++ b/env/build_orion_intel.env
@@ -1,40 +1,59 @@
 #Setup instructions for MSU Orion using Intel-18.0.5 (bash shell)
 
-module load contrib noaatools
+module purge
 
+# UFS_UTILS
 module load cmake/3.17.3
+# + ufs-weather-model
+module load contrib noaatools
+module load python/3.7.5
 
-module use /apps/contrib/NCEP/test/hpc-stack-nco/modulefiles/stack
 
-module load hpc/1.0.0-beta1
+### hpc-stack ###
+module use /apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack
+module load hpc/1.1.0
 module load hpc-intel/2018.4
 module load hpc-impi/2018.4
-
-module load jasper/2.0.22
-module load zlib/1.2.11
-module load png/1.6.35
-module load hdf5/1.10.6
-module load netcdf/4.7.4
-module load pio/2.5.1
-module load esmf/8_1_0_beta_snapshot_27
+# UFS_UTILS
 module load bacio/2.4.1
-module load crtm/2.3.0
 module load g2/3.4.1
-module load g2tmpl/1.9.1
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load sp/2.3.3
-module load w3emc/2.7.3
 module load w3nco/2.4.1
-module load upp/10.0.0
-
-module load gfsio/1.4.1
 module load sfcio/1.4.1
+module load sigio/2.3.2
+module load wgrib2/2.0.8
+module load jasper/2.0.22
+module load zlib/1.2.11
+module load png/1.6.35
+# + EMC_post
+module load crtm/2.3.0
+module load g2tmpl/1.9.1
+module load gfsio/1.4.1
+module load w3emc/2.7.3
+module load wrf_io/1.1.1
+
+
+# UFS_UTILS
+module load hdf5/1.10.6
+module load netcdf/4.7.4
+module load nccmp/1.8.7.0
+module load esmf/8_1_0_beta_snapshot_27
+# + EMC_post
+module load w3emc/2.7.3
+module load wrf_io/1.1.1
+
+
+### Extra ###
+module load upp/10.0.0
 module load landsfcutil/2.4.1
 module load nemsiogfs/2.5.3
-module load wgrib2/2.0.8
 
+
+# ufs-weather-model
 export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort
 export CMAKE_Platform=orion.intel
+

--- a/env/build_orion_intel.env
+++ b/env/build_orion_intel.env
@@ -8,7 +8,6 @@ module load cmake/3.17.3
 module load contrib noaatools
 module load python/3.7.5
 
-
 ### hpc-stack ###
 module use /apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack
 module load hpc/1.1.0
@@ -18,38 +17,36 @@ module load hpc-impi/2018.4
 module load bacio/2.4.1
 module load g2/3.4.1
 module load ip/3.3.3
+module load jasper/2.0.22
 module load nemsio/2.5.2
-module load sp/2.3.3
-module load w3nco/2.4.1
+module load png/1.6.35
 module load sfcio/1.4.1
 module load sigio/2.3.2
+module load sp/2.3.3
 module load wgrib2/2.0.8
-module load jasper/2.0.22
+module load w3nco/2.4.1
 module load zlib/1.2.11
-module load png/1.6.35
 # + EMC_post
 module load crtm/2.3.0
-module load g2tmpl/1.9.1
 module load gfsio/1.4.1
-module load w3emc/2.7.3
+module load g2tmpl/1.9.1
 module load wrf_io/1.1.1
+module load w3emc/2.7.3
 
-
+### Additional modules ###
 # UFS_UTILS
-module load hdf5/1.10.6
-module load netcdf/4.7.4
-module load nccmp/1.8.7.0
 module load esmf/8_1_0_beta_snapshot_27
+module load hdf5/1.10.6
+module load nccmp/1.8.7.0
+module load netcdf/4.7.4
 # + EMC_post
-module load w3emc/2.7.3
 module load wrf_io/1.1.1
-
+module load w3emc/2.7.3
 
 ### Extra ###
-module load upp/10.0.0
 module load landsfcutil/2.4.1
 module load nemsiogfs/2.5.3
-
+module load upp/10.0.0
 
 # ufs-weather-model
 export CMAKE_C_COMPILER=mpiicc

--- a/env/build_wcoss_cray_intel.env
+++ b/env/build_wcoss_cray_intel.env
@@ -33,7 +33,7 @@ module load nemsio/2.5.2
 module load sp/2.3.3
 module load w3emc/2.7.3
 module load w3nco/2.4.1
-module load upp/10.0.0
+module load upp/10.0.4
 module load gfsio/1.4.1
 module load sfcio/1.4.1
 module load sigio/2.3.2
@@ -43,6 +43,8 @@ module load wgrib2/2.0.8
 
 module use /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/modulefiles
 module load esmf/8.1.0bs27
+
+module swap pmi pmi/5.0.11
 
 
 ## load cmake

--- a/env/build_wcoss_cray_intel.env
+++ b/env/build_wcoss_cray_intel.env
@@ -26,31 +26,28 @@ export PNG_ROOT="/usrx/local/prod//png/1.2.49/intel/sandybridge"
 module use /usrx/local/nceplibs/NCEPLIBS/cmake/install/NCEPLIBS-v1.3.0/modules
 module load bacio/2.4.1
 module load crtm/2.3.0
+module load gfsio/1.4.1
 module load g2/3.4.1
 module load g2tmpl/1.9.1
 module load ip/3.3.3
 module load nemsio/2.5.2
-module load sp/2.3.3
-module load w3emc/2.7.3
-module load w3nco/2.4.1
-module load upp/10.0.4
-module load gfsio/1.4.1
 module load sfcio/1.4.1
 module load sigio/2.3.2
+module load sp/2.3.3
+module load upp/10.0.4
+module load w3emc/2.7.3
+module load w3nco/2.4.1
 module load landsfcutil/2.4.1
 module load nemsiogfs/2.5.3
 module load wgrib2/2.0.8
 
 module use /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/modulefiles
 module load esmf/8.1.0bs27
-
 module swap pmi pmi/5.0.11
-
 
 ## load cmake
 export CMAKE_C_COMPILER=cc
 export CMAKE_CXX_COMPILER=CC
 export CMAKE_Fortran_COMPILER=ftn
 export CMAKE_Platform=wcoss_cray
-
 

--- a/env/build_wcoss_dell_p3_intel.env
+++ b/env/build_wcoss_dell_p3_intel.env
@@ -30,7 +30,7 @@ module load zlib/1.2.11
 # + EMC_post
 module load crtm/2.3.0
 module load gfsio/1.4.1
-module load g2tmpl/1.9.1
+module load g2tmpl/1.10.0
 
 # Additional modules
 # UFS_UTILS

--- a/env/build_wcoss_dell_p3_intel.env
+++ b/env/build_wcoss_dell_p3_intel.env
@@ -33,7 +33,6 @@ module load bacio/2.4.1
 module load crtm/2.3.0
 module load g2tmpl/1.9.1
 module load gfsio/1.4.1
-module load ip/3.3.3
 
 
 # UFS_UTILS

--- a/env/build_wcoss_dell_p3_intel.env
+++ b/env/build_wcoss_dell_p3_intel.env
@@ -11,41 +11,38 @@ module load ips/18.0.1.163
 module load impi/18.0.1
 module load python/3.6.3
 
-
 ### hpc-stack ###
 module use /usrx/local/nceplibs/dev/hpc-stack/libs/hpc-stack/modulefiles/stack
 module load hpc/1.1.0
 module load hpc-ips/18.0.1.163
 module load hpc-impi/18.0.1
 # UFS_UTILS
-module load jasper/2.0.22
-module load zlib/1.2.11
-module load png/1.6.35
 module load bacio/2.4.1
 module load g2/3.4.1
 module load ip/3.3.3
-module load sp/2.3.3
-module load w3nco/2.4.1
+module load jasper/2.0.22
+module load png/1.6.35
 module load sfcio/1.4.1
 module load sigio/2.3.2
+module load sp/2.3.3
+module load w3nco/2.4.1
+module load zlib/1.2.11
 # + EMC_post
-module load bacio/2.4.1
 module load crtm/2.3.0
-module load g2tmpl/1.9.1
 module load gfsio/1.4.1
+module load g2tmpl/1.9.1
 
-
+# Additional modules
 # UFS_UTILS
-module load hdf5/1.10.6
-module load netcdf/4.7.4
-module load nccmp/1.8.7.0
 module load esmf/8_1_0_beta_snapshot_27
+module load hdf5/1.10.6
+module load nccmp/1.8.7.0
 module load nemsio/2.5.2
+module load netcdf/4.7.4
 module load wgrib2/2.0.8
 # + EMC_post
-module load w3emc/2.7.3
 module load wrf_io/1.1.1
-
+module load w3emc/2.7.3
 
 ### Extra ###
 module load landsfcutil/2.4.1

--- a/env/build_wcoss_dell_p3_intel.env
+++ b/env/build_wcoss_dell_p3_intel.env
@@ -2,13 +2,11 @@
 
 module purge
 
-# UFS_UTILS
-module load lsf/10.1
-module load HPSS/5.0.2.5
 module load cmake/3.16.2
-# + ufs-weather-model
+module load HPSS/5.0.2.5
 module load ips/18.0.1.163
 module load impi/18.0.1
+module load lsf/10.1
 module load python/3.6.3
 
 ### hpc-stack ###
@@ -16,9 +14,12 @@ module use /usrx/local/nceplibs/dev/hpc-stack/libs/hpc-stack/modulefiles/stack
 module load hpc/1.1.0
 module load hpc-ips/18.0.1.163
 module load hpc-impi/18.0.1
-# UFS_UTILS
+
 module load bacio/2.4.1
+module load crtm/2.3.0
+module load gfsio/1.4.1
 module load g2/3.4.1
+module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load jasper/2.0.22
 module load png/1.6.35
@@ -27,29 +28,21 @@ module load sigio/2.3.2
 module load sp/2.3.3
 module load w3nco/2.4.1
 module load zlib/1.2.11
-# + EMC_post
-module load crtm/2.3.0
-module load gfsio/1.4.1
-module load g2tmpl/1.10.0
 
 # Additional modules
-# UFS_UTILS
 module load esmf/8_1_0_beta_snapshot_27
 module load hdf5/1.10.6
+module load landsfcutil/2.4.1
 module load nccmp/1.8.7.0
 module load nemsio/2.5.2
+module load nemsiogfs/2.5.3
 module load netcdf/4.7.4
+module load upp/10.0.4
 module load wgrib2/2.0.8
-# + EMC_post
 module load wrf_io/1.1.1
 module load w3emc/2.7.3
 
-### Extra ###
-module load landsfcutil/2.4.1
-module load nemsiogfs/2.5.3
-module load upp/10.0.4
 
-# ufs-weather-model
 export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort

--- a/env/build_wcoss_dell_p3_intel.env
+++ b/env/build_wcoss_dell_p3_intel.env
@@ -47,6 +47,7 @@ module load w3emc/2.7.3
 ### Extra ###
 module load landsfcutil/2.4.1
 module load nemsiogfs/2.5.3
+module load upp/10.0.4
 
 # ufs-weather-model
 export CMAKE_C_COMPILER=mpiicc

--- a/env/build_wcoss_dell_p3_intel.env
+++ b/env/build_wcoss_dell_p3_intel.env
@@ -33,13 +33,11 @@ module load zlib/1.2.11
 module load esmf/8_1_0_beta_snapshot_27
 module load hdf5/1.10.6
 module load landsfcutil/2.4.1
-module load nccmp/1.8.7.0
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
 module load netcdf/4.7.4
 module load upp/10.0.4
 module load wgrib2/2.0.8
-module load wrf_io/1.1.1
 module load w3emc/2.7.3
 
 

--- a/env/build_wcoss_dell_p3_intel.env
+++ b/env/build_wcoss_dell_p3_intel.env
@@ -2,42 +2,57 @@
 
 module purge
 
+# UFS_UTILS
+module load lsf/10.1
+module load HPSS/5.0.2.5
+module load cmake/3.16.2
+# + ufs-weather-model
 module load ips/18.0.1.163
 module load impi/18.0.1
-module load lsf/10.1
 module load python/3.6.3
-module load cmake/3.16.2
 
-module use /usrx/local/nceplibs/dev/hpc-stack/test/hpc-stack/modulefiles/stack
 
-module load hpc/1.0.0-beta1
+### hpc-stack ###
+module use /usrx/local/nceplibs/dev/hpc-stack/libs/hpc-stack/modulefiles/stack
+module load hpc/1.1.0
 module load hpc-ips/18.0.1.163
 module load hpc-impi/18.0.1
+# UFS_UTILS
 module load jasper/2.0.22
 module load zlib/1.2.11
 module load png/1.6.35
-module load hdf5/1.10.6
-module load netcdf/4.7.4
-module load pio/2.5.1
-module load esmf/8_1_0_beta_snapshot_27
+module load bacio/2.4.1
+module load g2/3.4.1
+module load ip/3.3.3
+module load sp/2.3.3
+module load w3nco/2.4.1
+module load sfcio/1.4.1
+module load sigio/2.3.2
+# + EMC_post
 module load bacio/2.4.1
 module load crtm/2.3.0
-module load g2/3.4.1
 module load g2tmpl/1.9.1
-module load ip/3.3.3
-module load nemsio/2.5.2
-module load sp/2.3.3
-module load w3emc/2.7.3
-module load w3nco/2.4.1
-module load upp/10.0.0
-
 module load gfsio/1.4.1
-module load sfcio/1.4.1
+module load ip/3.3.3
+
+
+# UFS_UTILS
+module load hdf5/1.10.6
+module load netcdf/4.7.4
+module load nccmp/1.8.7.0
+module load esmf/8_1_0_beta_snapshot_27
+module load nemsio/2.5.2
+module load wgrib2/2.0.8
+# + EMC_post
+module load w3emc/2.7.3
+module load wrf_io/1.1.1
+
+
+### Extra ###
 module load landsfcutil/2.4.1
 module load nemsiogfs/2.5.3
-module load wgrib2/2.0.8
 
-
+# ufs-weather-model
 export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Updated the build environment files `env/build_[machine]_[compiler].env` for Hera, Orion, and WCOSS with the latest hpc-stack.
- Rearranged the module list in alphabetical order for easy maintenance.

## TESTS CONDUCTED: 
- Completed the GST test successfully on Hera, Orion, and WCOSS Dell and Cray.

## ISSUE: 
- Fixes issue mentioned in #137 


