### PR TITLE
[develop] Update build environments for latest version of weather model (hash 2f1c8e1)

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = dfabe21
+hash = 2f1c8e1
 local_path = src/ufs_weather_model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = b8ed338
+hash = dfabe21
 local_path = src/ufs_weather_model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 37f0da7
+hash = b8ed338
 local_path = src/ufs_weather_model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,9 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/regional_workflow
+repo_url = https://github.com/mkavulich/regional_workflow
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = 3586e11
+branch = update_GFS_v16_suite
+#hash = 3586e11
 local_path = regional_workflow
 required = True
 
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = ea8a7aa
+hash = 13053c1
 local_path = src/ufs_weather_model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 13053c1
+hash = 37f0da7
 local_path = src/ufs_weather_model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,9 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/mkavulich/regional_workflow
+repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
-branch = update_GFS_v16_suite
-#hash = 3586e11
+#branch = develop
+hash = 40cfeff
 local_path = regional_workflow
 required = True
 

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -70,7 +70,7 @@ fi
 
 mkdir -p ${BUILD_DIR}
 cd ${BUILD_DIR}
-cmake .. -DCMAKE_INSTALL_PREFIX=..
-make -j ${BUILD_JOBS:-4}
+cmake .. -DCMAKE_INSTALL_PREFIX=.. 2>&1 | tee log.cmake
+make -j ${BUILD_JOBS:-4} 2>&1 | tee log.make
 
 exit 0

--- a/env/build_cheyenne_gnu.env
+++ b/env/build_cheyenne_gnu.env
@@ -18,7 +18,7 @@ module load png/1.6.35
 module load hdf5/1.10.6
 module load netcdf/4.7.4
 module load pio/2.5.2
-module load esmf/8_1_0_beta_snapshot_27
+module load esmf/8_1_1
 module load bacio/2.4.1
 module load crtm/2.3.0
 module load g2/3.4.1
@@ -28,7 +28,7 @@ module load nemsio/2.5.2
 module load sp/2.3.3
 module load w3emc/2.7.3
 module load w3nco/2.4.1
-module load upp/10.0.0
+module load upp/10.0.6
 
 module load gfsio/1.4.1
 module load sfcio/1.4.1

--- a/env/build_cheyenne_intel.env
+++ b/env/build_cheyenne_intel.env
@@ -7,17 +7,19 @@ module load mpt/2.22
 module load ncarcompilers/0.5.0
 module load cmake/3.16.4
 
-module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-nco-20201113/modulefiles/stack
-module load hpc/1.0.0-beta1
+module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
+module load hpc/1.1.0
 module load hpc-intel/19.1.1
 module load hpc-mpt/2.22
+
 module load jasper/2.0.22
 module load zlib/1.2.11
 module load png/1.6.35
 module load hdf5/1.10.6
 module load netcdf/4.7.4
-module load pio/2.5.1
-module load esmf/8_1_0_beta_snapshot_27
+module load pio/2.5.2
+module load esmf/8_1_1
+
 module load bacio/2.4.1
 module load crtm/2.3.0
 module load g2/3.4.1
@@ -27,7 +29,7 @@ module load nemsio/2.5.2
 module load sp/2.3.3
 module load w3emc/2.7.3
 module load w3nco/2.4.1
-module load upp/10.0.0
+module load upp/10.0.6
 
 module load gfsio/1.4.1
 module load sfcio/1.4.1

--- a/env/build_hera_intel.env
+++ b/env/build_hera_intel.env
@@ -16,8 +16,8 @@ module load zlib/1.2.11
 module load png/1.6.35
 module load hdf5/1.10.6
 module load netcdf/4.7.4
-module load pio/2.5.1
-module load esmf/8_1_0_beta_snapshot_47
+module load pio/2.5.2
+module load esmf/8_1_1
 module load bacio/2.4.1
 module load crtm/2.3.0
 module load g2/3.4.1
@@ -27,7 +27,7 @@ module load nemsio/2.5.2
 module load sp/2.3.3
 module load w3emc/2.7.3
 module load w3nco/2.4.1
-module load upp/10.0.4
+module load upp/10.0.6
 
 module load gfsio/1.4.1
 module load sfcio/1.4.1

--- a/env/build_hera_intel.env
+++ b/env/build_hera_intel.env
@@ -6,9 +6,9 @@ module use /contrib/sutils/modulefiles
 module load sutils
 module load cmake/3.16.1
 
-module use /scratch2/NCEPDEV/nwprod/hpc-stack/test/modulefiles/stack
+module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack
 
-module load hpc/1.0.0-beta1
+module load hpc/1.1.0
 module load hpc-intel/18.0.5.274
 module load hpc-impi/2018.0.4
 module load jasper/2.0.22
@@ -17,7 +17,7 @@ module load png/1.6.35
 module load hdf5/1.10.6
 module load netcdf/4.7.4
 module load pio/2.5.1
-module load esmf/8_1_0_beta_snapshot_27
+module load esmf/8_1_0_beta_snapshot_47
 module load bacio/2.4.1
 module load crtm/2.3.0
 module load g2/3.4.1
@@ -27,7 +27,7 @@ module load nemsio/2.5.2
 module load sp/2.3.3
 module load w3emc/2.7.3
 module load w3nco/2.4.1
-module load upp/10.0.0
+module load upp/10.0.4
 
 module load gfsio/1.4.1
 module load sfcio/1.4.1

--- a/env/build_jet_intel.env
+++ b/env/build_jet_intel.env
@@ -6,17 +6,17 @@ module load sutils
 module load cmake/3.16.1
 
 module use /lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack
+
 module load hpc/1.1.0
 module load hpc-intel/18.0.5.274
 module load hpc-impi/2018.4.274
-
 module load jasper/2.0.22
 module load zlib/1.2.11
 module load png/1.6.35
 module load hdf5/1.10.6
 module load netcdf/4.7.4
-module load pio/2.5.1
-module load esmf/8_1_0_beta_snapshot_27
+module load pio/2.5.2
+module load esmf/8_1_1
 module load bacio/2.4.1
 module load crtm/2.3.0
 module load g2/3.4.1
@@ -26,7 +26,7 @@ module load nemsio/2.5.2
 module load sp/2.3.3
 module load w3emc/2.7.3
 module load w3nco/2.4.1
-module load upp/10.0.0
+module load upp/10.0.6
 
 module load gfsio/1.4.1
 module load sfcio/1.4.1

--- a/env/build_orion_intel.env
+++ b/env/build_orion_intel.env
@@ -3,10 +3,11 @@
 module load contrib noaatools
 
 module load cmake/3.17.3
+module load python/3.7.5
 
-module use /apps/contrib/NCEP/test/hpc-stack-nco/modulefiles/stack
+module use /apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack
 
-module load hpc/1.0.0-beta1
+module load hpc/1.1.0
 module load hpc-intel/2018.4
 module load hpc-impi/2018.4
 
@@ -15,8 +16,8 @@ module load zlib/1.2.11
 module load png/1.6.35
 module load hdf5/1.10.6
 module load netcdf/4.7.4
-module load pio/2.5.1
-module load esmf/8_1_0_beta_snapshot_27
+module load pio/2.5.2
+module load esmf/8_1_1
 module load bacio/2.4.1
 module load crtm/2.3.0
 module load g2/3.4.1
@@ -26,7 +27,7 @@ module load nemsio/2.5.2
 module load sp/2.3.3
 module load w3emc/2.7.3
 module load w3nco/2.4.1
-module load upp/10.0.0
+module load upp/10.0.6
 
 module load gfsio/1.4.1
 module load sfcio/1.4.1

--- a/env/wflow_orion.env
+++ b/env/wflow_orion.env
@@ -1,5 +1,7 @@
 # Python environment for workflow on Orion
 
+module load rocoto
+
 module use -a /apps/contrib/miniconda3-noaa-gsl/modulefiles
 module load miniconda3
 conda activate regional_workflow

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_RRFS_v1beta,FV3_HRRR")
+  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR")
 endif()
 
 ExternalProject_Add(ufs_weather_model

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,8 @@ ExternalProject_Add(ufs_weather_model
                "-DCMAKE_CXX_COMPILER=${MPI_CXX_COMPILER}"
                "-DCMAKE_Fortran_COMPILER=${MPI_Fortran_COMPILER}"
                "-DNETCDF_DIR=$ENV{NETCDF}"
-               "-32BIT=ON"
+               "-D32BIT=ON"
+               "-DAPP=ATM"
   INSTALL_COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/bin && cp ${CMAKE_CURRENT_BINARY_DIR}/ufs_weather_model/src/ufs_weather_model-build/ufs_model ${CMAKE_INSTALL_PREFIX}/bin/
   )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR")
+  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha")
 endif()
 
 ExternalProject_Add(ufs_weather_model

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ ExternalProject_Add(ufs_weather_model
                "-DCMAKE_CXX_COMPILER=${MPI_CXX_COMPILER}"
                "-DCMAKE_Fortran_COMPILER=${MPI_Fortran_COMPILER}"
                "-DNETCDF_DIR=$ENV{NETCDF}"
+               "-32BIT=ON"
   INSTALL_COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/bin && cp ${CMAKE_CURRENT_BINARY_DIR}/ufs_weather_model/src/ufs_weather_model-build/ufs_model ${CMAKE_INSTALL_PREFIX}/bin/
   )
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR (along with https://github.com/NOAA-EMC/regional_workflow/pull/492) update the UFS SRW App to work with a more up-to-date hash of the ufs-weather-model (https://github.com/ufs-community/ufs-weather-model/commit/2f1c8e1883370b30828dea87d4250e10c35499f4)

## TESTS CONDUCTED: 
Ran full suite of tests on Hera (aside from nco tests) with updated environment files (/scratch2/BMC/det/kavulich/workdir/update_app_master/step-by-step/expt_dirs/). The following failures were noted:

 - grid_RRFS_AK_13km_RAP_RAP (pre-existing failure, "AVOST IN VILKA")
 - grid_RRFS_AK_3km_RAP_RAP (pre-existing failure, "AVOST IN VILKA")
 - grid_RRFS_CONUS_25km_ics_NAM_lbcs_NAM_suite_GSD_SAR (**New failure in make_ics and make_lbcs**)
 - grid_RRFS_CONUS_25km_ics_NAM_lbcs_NAM_suite_HRRR (**New failure in make_ics and make_lbcs**)
 - grid_RRFS_CONUS_25km_ics_NAM_lbcs_NAM_suite_RRFS_v1beta (**New failure in make_ics and make_lbcs**)
 - GST_release_public_v1 (wallclock time violation; see https://github.com/NOAA-EMC/regional_workflow/issues/490)
 - suite_FV3_CPT_v0 (pre-existing failure; `invalid reference to variable in NAMELIST input`)
 - suite_FV3_GFS_v16 (pre-existing failure; segmentation fault)

The new failures are only for older versions of NAM input; this is due to a change in the weather model, and may need to be handled in a separate PR.

Ran several end-to-end tests on Cheyenne (Intel 19.1.1) and Jet. Also ran the Graduate Student Test case on Orion. No failures outside of those outlined above.

**Tests have not been run on WCOSS platforms; these will likely fail without being updated to the latest ESMF modules but I do not have access to update and test**

## ISSUE: 
Fixes issue #134 