### PR TITLE
RRFS_baseline: Change branch to RRFS_baseline for regional_workflow

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,8 +2,8 @@
 protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = 40cfeff
+branch = RRFS_baseline
+#hash = 40cfeff
 local_path = regional_workflow
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Comment out the hash of regional_workflow and point to the RRFS_baseline branch.

