### PR TITLE
Update build environments for wcoss dell and cray

### DIFF
--- a/env/build_wcoss_cray_intel.env
+++ b/env/build_wcoss_cray_intel.env
@@ -9,7 +9,6 @@ module rm NetCDF-intel-sandybridge/4.2
 module load xt-lsfhpc/9.1.3
 module load craype-haswell
 module load python/3.6.3
-module load cmake/3.16.2
 module load gcc/5.3.0
 #
 module use /usrx/local/dev/modulefiles
@@ -26,26 +25,27 @@ export PNG_ROOT="/usrx/local/prod//png/1.2.49/intel/sandybridge"
 module use /usrx/local/nceplibs/NCEPLIBS/cmake/install/NCEPLIBS-v1.3.0/modules
 module load bacio/2.4.1
 module load crtm/2.3.0
+module load esmf/811
+module load fms/2020.04.03
 module load gfsio/1.4.1
 module load g2/3.4.1
 module load g2tmpl/1.9.1
 module load ip/3.3.3
+module load landsfcutil/2.4.1
 module load nemsio/2.5.2
+module load nemsiogfs/2.5.3
 module load sfcio/1.4.1
 module load sigio/2.3.2
 module load sp/2.3.3
-module load upp/10.0.4
+module load upp/10.0.6
 module load w3emc/2.7.3
 module load w3nco/2.4.1
-module load landsfcutil/2.4.1
-module load nemsiogfs/2.5.3
 module load wgrib2/2.0.8
 
-module use /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/modulefiles
-module load esmf/8.1.0bs27
 module swap pmi pmi/5.0.11
 
 ## load cmake
+module load cmake/3.16.2
 export CMAKE_C_COMPILER=cc
 export CMAKE_CXX_COMPILER=CC
 export CMAKE_Fortran_COMPILER=ftn

--- a/env/build_wcoss_dell_p3_intel.env
+++ b/env/build_wcoss_dell_p3_intel.env
@@ -4,8 +4,6 @@ module purge
 
 module load cmake/3.16.2
 module load HPSS/5.0.2.5
-module load ips/18.0.1.163
-module load impi/18.0.1
 module load lsf/10.1
 module load python/3.6.3
 
@@ -17,28 +15,26 @@ module load hpc-impi/18.0.1
 
 module load bacio/2.4.1
 module load crtm/2.3.0
+module load esmf/8_1_1
 module load gfsio/1.4.1
-module load g2/3.4.1
+module load g2/3.4.2
 module load g2tmpl/1.10.0
+module load hdf5/1.10.6
 module load ip/3.3.3
 module load jasper/2.0.22
-module load png/1.6.35
-module load sfcio/1.4.1
-module load sigio/2.3.2
-module load sp/2.3.3
-module load w3nco/2.4.1
-module load zlib/1.2.11
-
-# Additional modules
-module load esmf/8_1_0_beta_snapshot_27
-module load hdf5/1.10.6
 module load landsfcutil/2.4.1
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
 module load netcdf/4.7.4
-module load upp/10.0.4
-module load wgrib2/2.0.8
+module load png/1.6.35
+module load sfcio/1.4.1
+module load sigio/2.3.2
+module load sp/2.3.3
+module load upp/10.0.6
 module load w3emc/2.7.3
+module load w3nco/2.4.1
+module load wgrib2/2.0.8
+module load zlib/1.2.11
 
 
 export CMAKE_C_COMPILER=mpiicc


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The build environment files for the WCOSS dell and cray are updated for the latest ufs weather model.

## TESTS CONDUCTED: 
WE2E tests on the dell and cray:
- grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- nco_grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2

## ISSUE: 
Fixes issue mentioned in #143

