### PR TITLE
Make the name of the forecast model the same as its repository

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,7 +22,7 @@ repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
 hash = 2f1c8e1
-local_path = src/ufs_weather_model
+local_path = src/ufs-weather-model
 required = True
 
 [EMC_post]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -16,7 +16,7 @@ hash = ea821358
 local_path = src/UFS_UTILS
 required = True
 
-[ufs_weather_model]
+[ufs-weather-model]
 protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,9 @@ if(NOT CCPP_SUITES)
   set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha")
 endif()
 
-ExternalProject_Add(ufs_weather_model
-  PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ufs_weather_model
-  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ufs_weather_model
+ExternalProject_Add(ufs-weather-model
+  PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ufs-weather-model
   INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
   CMAKE_ARGS   "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
                "-DCCPP_SUITES=${CCPP_SUITES}"
@@ -23,7 +23,7 @@ ExternalProject_Add(ufs_weather_model
                "-DNETCDF_DIR=$ENV{NETCDF}"
                "-D32BIT=ON"
                "-DAPP=ATM"
-  INSTALL_COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/bin && cp ${CMAKE_CURRENT_BINARY_DIR}/ufs_weather_model/src/ufs_weather_model-build/ufs_model ${CMAKE_INSTALL_PREFIX}/bin/
+  INSTALL_COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/bin && cp ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model/src/ufs-weather-model-build/ufs_model ${CMAKE_INSTALL_PREFIX}/bin/
   )
 
 ExternalProject_Add(EMC_post


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Change the underscores in the name of the external component for the ufs weather model (ufs_weather_model) to dashes (ufs-weather-model) in some configuration scrpts.

## TESTS CONDUCTED: 
- GST test on the WCOSS dell

## ISSUE: 
- Fixes issue mentioned in #145   
- Related to https://github.com/NOAA-EMC/regional_workflow/issues/505
