### PR TITLE
Add file for GNU build on Hera

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = de1220b
+hash = 59e09bc
 local_path = regional_workflow
 required = True
 

--- a/docs/UsersGuide/source/conf.py
+++ b/docs/UsersGuide/source/conf.py
@@ -110,7 +110,7 @@ html_context = {
      }
 
 def setup(app):
-    app.add_stylesheet('custom.css')  # may also be an URL
+    app.add_css_file('custom.css')  # may also be an URL
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/env/build_hera_gnu.env
+++ b/env/build_hera_gnu.env
@@ -4,7 +4,7 @@ module purge
 
 module use /contrib/sutils/modulefiles
 module load sutils
-module load cmake/3.16.1
+module load cmake/3.20.1
 
 module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack
 
@@ -19,10 +19,11 @@ module load hdf5/1.10.6
 module load netcdf/4.7.4
 module load pio/2.5.2
 module load esmf/8_1_1
+module load fms/2020.04.03
 module load bacio/2.4.1
 module load crtm/2.3.0
-module load g2/3.4.1
-module load g2tmpl/1.9.1
+module load g2/3.4.3
+module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load sp/2.3.3
@@ -37,14 +38,14 @@ module load nemsiogfs/2.5.3
 module load wgrib2/2.0.8
 
 
-# For run in bash
-export CMAKE_C_COMPILER=mpicc
-export CMAKE_CXX_COMPILER=mpicxx
-export CMAKE_Fortran_COMPILER=mpif90
-export CMAKE_Platform=hera.gnu
-
 # For build in csh
 #setenv CMAKE_C_COMPILER mpicc
 #setenv CMAKE_CXX_COMPILER mpicxx
 #setenv CMAKE_Fortran_COMPILER mpif90
 #setenv CMAKE_Platform hera.gnu
+
+# For build and/or run in bash
+export CMAKE_C_COMPILER=mpicc
+export CMAKE_CXX_COMPILER=mpicxx
+export CMAKE_Fortran_COMPILER=mpif90
+export CMAKE_Platform=hera.gnu

--- a/env/build_hera_gnu.env
+++ b/env/build_hera_gnu.env
@@ -1,0 +1,50 @@
+#Setup instructions for NOAA RDHPC Hera using GNU-9.2.0 (bash shell)
+
+module purge
+
+module use /contrib/sutils/modulefiles
+module load sutils
+module load cmake/3.16.1
+
+module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack
+
+module load hpc/1.1.0
+module load hpc-gnu/9.2.0
+module load hpc-mpich/3.3.2
+module load mpich/3.3.2
+module load jasper/2.0.22
+module load zlib/1.2.11
+module load png/1.6.35
+module load hdf5/1.10.6
+module load netcdf/4.7.4
+module load pio/2.5.2
+module load esmf/8_1_1
+module load bacio/2.4.1
+module load crtm/2.3.0
+module load g2/3.4.1
+module load g2tmpl/1.9.1
+module load ip/3.3.3
+module load nemsio/2.5.2
+module load sp/2.3.3
+module load w3emc/2.7.3
+module load w3nco/2.4.1
+module load upp/10.0.6
+
+module load gfsio/1.4.1
+module load sfcio/1.4.1
+module load landsfcutil/2.4.1
+module load nemsiogfs/2.5.3
+module load wgrib2/2.0.8
+
+
+# For run in bash
+export CMAKE_C_COMPILER=mpicc
+export CMAKE_CXX_COMPILER=mpicxx
+export CMAKE_Fortran_COMPILER=mpif90
+export CMAKE_Platform=hera.gnu
+
+# For build in csh
+#setenv CMAKE_C_COMPILER mpicc
+#setenv CMAKE_CXX_COMPILER mpicxx
+#setenv CMAKE_Fortran_COMPILER mpif90
+#setenv CMAKE_Platform hera.gnu

--- a/env/build_hera_intel.env
+++ b/env/build_hera_intel.env
@@ -37,6 +37,13 @@ module load nemsiogfs/2.5.3
 module load wgrib2/2.0.8
 
 
+# For build in csh
+#setenv CMAKE_C_COMPILER mpiicc
+#setenv CMAKE_CXX_COMPILER mpiicpc
+#setenv CMAKE_Fortran_COMPILER mpiifort
+#setenv CMAKE_Platform hera.intel
+
+# For build and/or run in bash
 export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Add file env/build_hera_gnu.env
- Replace deprecated add_stylesheet with add_css_file for documentation build on ReadTheDocs

## TESTS CONDUCTED: 
GNU build on Hera successful.  Modifications needed for regional workflow to run to completion.

|  GST                |  Hera         | Cheyenne      |
|---------------| ---------- | ------------- |
| Intel Build        | Pass          | Pass              |
| Intel Run          | Pass          | Pass              |
| GNU Build       | Pass          | Pass              |
| GNU Run         | Pass          | Pass              |


## DEPENDENCIES:
- See [PR#526](https://github.com/NOAA-EMC/regional_workflow/pull/526)

## DOCUMENTATION:
Modified documentation to build.  This will include information on setting COMPILER="gnu" in the config.sh file.

## ISSUE (optional): 
Fixes issue mentioned in #98 



