### PR TITLE
Feature/add build test

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,39 @@
+# Build test for the UFS Short-Range Weather App
+
+## Description
+
+This script builds the executables for the UFS Short-Range Weather Application (SRW App)
+for the current code in the users ufs-srweather-app directory.  It consists of the following steps:
+
+* Build all of the executables for the supported compilers on the given machine
+
+* Check for the existence of all executables
+
+* Print out a PASS/FAIL message
+
+Currently, the following configurations are supported:
+
+Machine     | Cheyenne       | Hera           | Jet            |
+------------| ---------------|----------------|----------------|
+Compiler(s) | Intel, GNU     | Intel          | Intel          |
+
+The CMake build is done in the ``build_${compiler}`` directory.
+The executables for each build are installed under the ``bin_${compiler}`` directory.
+
+NOTE:  To run the regional workflow using these executables, the ``EXECDIR`` variable in the
+``${SR_WX_APP_TOP_DIR}/regional_workflow/ush/setup.sh`` file must be set to the
+appropiate directory, for example:  ``EXECDIR="${SR_WX_APP_TOP_DIR}/bin_intel/bin"``,
+where ``${SR_WX_APP_TOP_DIR}`` is the top-level directory of the cloned ufs-srweather-app repository.
+
+## Usage
+
+To run the tests, specify the machine name on the command line, for example:
+
+On cheyenne:
+
+```
+cd test
+./build.sh cheyenne >& build.out &
+```
+
+Check the ``${SR_WX_APP_TOP_DIR}/test/build_test$PID.out`` file for PASS/FAIL.

--- a/test/build.sh
+++ b/test/build.sh
@@ -1,0 +1,146 @@
+#!/bin/bash -l
+#=======================================================================
+# Description:  This script runs a build test for the
+#               UFS Short-Range Weather App. The executables
+#               built are listed below in $executables_created.
+#               A pass/fail message is printed at the end of the output.
+#
+# Necessary input parameters: machine name (jet hera or cheyenne)
+#
+# Usage:  see function usage below
+#
+# Examples: ./build.sh $machine >& test.out &
+#
+set -eux    # Uncomment for debugging
+#=======================================================================
+
+fail() { echo -e "\n$1\n" >> ${TEST_OUTPUT} && exit 1; }
+
+function usage() {
+  echo
+  echo "Usage: $0 machine | -h"
+  echo
+  echo "       machine       [required] is one of: ${machines[@]}"
+  echo "       -h            display this help"
+  echo
+  exit 1
+}
+
+machines=( hera jet cheyenne )
+
+[[ $# -eq 0 ]] && usage
+if [ "$1" = "-h" ] ; then usage ; fi
+
+export machine=${1}
+machine=`echo "${machine}" | tr '[A-Z]' '[a-z]'`  # scripts in sorc need lower case machine name
+
+#-----------------------------------------------------------------------
+# Check that machine is valid
+#-----------------------------------------------------------------------
+if [[ "${machines[@]}" =~ "$machine" ]]; then
+  echo "machine ${machine} is valid"
+else
+  echo "ERROR: machine ${machine} is NOT valid"
+  exit 1
+fi
+
+#-----------------------------------------------------------------------
+# Set compilers to be tested depending on machine
+#-----------------------------------------------------------------------
+if [ "${machine}" == "cheyenne" ] ; then
+  compilers=( intel gnu )
+else
+  compilers=( intel )
+fi
+
+#-----------------------------------------------------------------------
+# Set some directories
+#-----------------------------------------------------------------------
+PID=$$
+TEST_DIR=$( pwd )                   # Directory with this script
+TOP_DIR=${TEST_DIR}/..              # Top level (umbrella repo) directory
+TEST_OUTPUT=${TEST_DIR}/build_test${PID}.out
+
+build_it=0        # Set to 1 to skip build (for testing pass/fail criteria)
+#-----------------------------------------------------------------------
+# Create the output file if it doesn't exist
+#-----------------------------------------------------------------------
+if [ ! -f "$TEST_OUTPUT" ]; then
+   touch ${TEST_OUTPUT}
+fi
+
+cd ${TOP_DIR}
+
+ENV_DIR=${TOP_DIR}/env
+#-----------------------------------------------------------------------
+# Arrray of all executables built
+#-----------------------------------------------------------------------
+declare -a executables_created=( chgres_cube \
+                                 emcsfc_ice_blend \
+                                 emcsfc_snow2mdl \
+                                 filter_topo \
+                                 fregrid \
+                                 fvcom_to_FV3 \
+                                 global_cycle \
+                                 global_equiv_resol \
+                                 make_hgrid \
+                                 make_solo_mosaic \
+                                 ncep_post \
+                                 orog \
+                                 orog_gsl \
+                                 regional_esg_grid \
+                                 sfc_climo_gen \
+                                 shave \
+                                 ufs_model \
+                                 vcoord_gen )
+
+#-----------------------------------------------------------------------
+# Set up the build environment and run the build script.
+#-----------------------------------------------------------------------
+  for compiler in "${compilers[@]}"; do
+    BUILD_DIR=${TOP_DIR}/build_${compiler}
+    BUILD_OUTPUT=${BUILD_DIR}/build.out
+    BIN_DIR=${TOP_DIR}/bin_${compiler}
+    EXEC_DIR=${BIN_DIR}/bin
+    if [ $build_it -eq 0 ] ; then
+      . ${ENV_DIR}/build_${machine}_${compiler}.env
+#-----------------------------------------------------------------------
+# Remove old and bin directories if they exist
+#-----------------------------------------------------------------------
+      if [ -d "${BUILD_DIR}" ] ; then rm -rf ${BUILD_DIR} ; fi
+      if [ -d "${BIN_DIR}" ] ; then rm -rf ${BIN_DIR} ; fi
+      mkdir ${BUILD_DIR}
+      cd ${BUILD_DIR}
+      cmake .. -DCMAKE_INSTALL_PREFIX=../bin_${compiler}
+      make -j 4 >& ${BUILD_OUTPUT} || fail "Build ${machine} ${compiler} FAILED"
+    fi    # End of skip build for testing
+
+  #-----------------------------------------------------------------------
+  # check for existence of executables.
+  #-----------------------------------------------------------------------
+  n_fail=0
+  for file in "${executables_created[@]}" ; do
+    exec_file=${EXEC_DIR}/${file}
+    if [ -f ${exec_file} ]; then
+      echo "SUCCEED: ${compiler} executable file ${exec_file} exists" >> ${TEST_OUTPUT}
+    else
+      echo "FAIL: ${compiler} executable file ${exec_file} does NOT exist" >> ${TEST_OUTPUT}
+      let "n_fail=n_fail+1"
+    fi
+  done
+  #-----------------------------------------------------------------------
+  # Rename build and bin dirs for next build
+  #-----------------------------------------------------------------------
+done   # End compiler loop
+#-----------------------------------------------------------------------
+# Set message for output
+#-----------------------------------------------------------------------
+msg="????"
+if [[ $n_fail -gt 0 ]] ; then
+  echo "BUILD(S) FAILED" >> ${TEST_OUTPUT}
+  msg="FAIL"
+else
+  echo "ALL BUILDS SUCCEEDED" >> ${TEST_OUTPUT}
+  msg="PASS"
+fi
+echo "$msg" >> ${TEST_OUTPUT}

--- a/test/build.sh
+++ b/test/build.sh
@@ -73,7 +73,7 @@ cd ${TOP_DIR}
 
 ENV_DIR=${TOP_DIR}/env
 #-----------------------------------------------------------------------
-# Arrray of all executables built
+# Array of all executables built
 #-----------------------------------------------------------------------
 declare -a executables_created=( chgres_cube \
                                  emcsfc_ice_blend \
@@ -119,9 +119,6 @@ declare -a executables_created=( chgres_cube \
       let "n_fail=n_fail+1"
     fi
   done
-  #-----------------------------------------------------------------------
-  # Rename build and bin dirs for next build
-  #-----------------------------------------------------------------------
 done   # End compiler loop
 #-----------------------------------------------------------------------
 # Set message for output

--- a/test/build.sh
+++ b/test/build.sh
@@ -99,20 +99,11 @@ declare -a executables_created=( chgres_cube \
 #-----------------------------------------------------------------------
   for compiler in "${compilers[@]}"; do
     BUILD_DIR=${TOP_DIR}/build_${compiler}
-    BUILD_OUTPUT=${BUILD_DIR}/build.out
     BIN_DIR=${TOP_DIR}/bin_${compiler}
     EXEC_DIR=${BIN_DIR}/bin
     if [ $build_it -eq 0 ] ; then
-      . ${ENV_DIR}/build_${machine}_${compiler}.env
-#-----------------------------------------------------------------------
-# Remove old and bin directories if they exist
-#-----------------------------------------------------------------------
-      if [ -d "${BUILD_DIR}" ] ; then rm -rf ${BUILD_DIR} ; fi
-      if [ -d "${BIN_DIR}" ] ; then rm -rf ${BIN_DIR} ; fi
-      mkdir ${BUILD_DIR}
-      cd ${BUILD_DIR}
-      cmake .. -DCMAKE_INSTALL_PREFIX=${BIN_DIR}
-      make -j 4 >& ${BUILD_OUTPUT} || fail "Build ${machine} ${compiler} FAILED"
+      ./devbuild.sh ${machine} --compiler=${compiler} --build-dir=${BUILD_DIR} --install-dir=${BIN_DIR} \
+        --clean || fail "Build ${machine} ${compiler} FAILED"
     fi    # End of skip build for testing
 
   #-----------------------------------------------------------------------

--- a/test/build.sh
+++ b/test/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -l
+#!/bin/bash
 #=======================================================================
 # Description:  This script runs a build test for the
 #               UFS Short-Range Weather App. The executables
@@ -32,7 +32,7 @@ machines=( hera jet cheyenne )
 if [ "$1" = "-h" ] ; then usage ; fi
 
 export machine=${1}
-machine=`echo "${machine}" | tr '[A-Z]' '[a-z]'`  # scripts in sorc need lower case machine name
+machine=$(echo "${machine}" | tr '[A-Z]' '[a-z]')  # scripts in sorc need lower case machine name
 
 #-----------------------------------------------------------------------
 # Check that machine is valid
@@ -111,7 +111,7 @@ declare -a executables_created=( chgres_cube \
       if [ -d "${BIN_DIR}" ] ; then rm -rf ${BIN_DIR} ; fi
       mkdir ${BUILD_DIR}
       cd ${BUILD_DIR}
-      cmake .. -DCMAKE_INSTALL_PREFIX=../bin_${compiler}
+      cmake .. -DCMAKE_INSTALL_PREFIX=${BIN_DIR}
       make -j 4 >& ${BUILD_OUTPUT} || fail "Build ${machine} ${compiler} FAILED"
     fi    # End of skip build for testing
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Add ``build.sh`` to test directory to provide the build step for automated testing.  A ``README.md`` file is included with information on how to run the build.sh script.

## TESTS CONDUCTED: 
build.sh script tested on Cheyenne (Intel and GNU), Hera (Intel) and Jet (Intel).  All builds succeeded.

## DEPENDENCIES:
None

## DOCUMENTATION:
Provided in the README.md file.  Will be included in the User's Guide when testing is added.

