### PR TITLE
Update regional_workflow hash for MacOS/stand-alone Linux update

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,18 +1,18 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/regional_workflow
+repo_url = https://github.com/mkavulich/regional_workflow
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = 9bac8563
+branch = update_develop_for_macos_linux
+#hash = 5bbbc53
 local_path = regional_workflow
 required = True
 
 [ufs_utils]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/UFS_UTILS
+repo_url = https://github.com/mkavulich/UFS_UTILS
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = ea821358
+branch = fix_orog_segfault
+#hash = ea821358
 local_path = src/UFS_UTILS
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,10 +9,10 @@ required = True
 
 [ufs_utils]
 protocol = git
-repo_url = https://github.com/mkavulich/UFS_UTILS
+repo_url = https://github.com/NOAA-EMC/UFS_UTILS
 # Specify either a branch name or a hash but not both.
-branch = fix_orog_segfault
-#hash = ea821358
+#branch = fix_orog_segfault
+hash = e67789f
 local_path = src/UFS_UTILS
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This commit will include the UFS_UTILS and regional_workflow hashes for using the ufs-srweather-app on MACOS and non-rocoto Linux platforms. Also includes a QOL feature from the release branch: using the "BUILD_ALL" flags in CMakeLists.txt means that making changes to the source code and re-running `make` will incorporate those changes correctly.

See DEPENDENCIES for PRs that must be merged before this one can be complete.

## TESTS CONDUCTED: 
Tests have been completed successfully on a MacOS machine and Hera. More details will be provided once the necessary PRs in regional_workflow and UFS_UTILS are merged.

## DEPENDENCIES:
- https://github.com/NOAA-EMC/regional_workflow/pull/539
- https://github.com/NOAA-EMC/UFS_UTILS/pull/545

## DOCUMENTATION:
Will update this PR with the proper documentation before opening for review.

## ISSUE: 
Will fully resolve https://github.com/NOAA-EMC/regional_workflow/issues/369
