### PR TITLE
Update cmake on the wcoss dell and cray

### DIFF
--- a/env/build_wcoss_cray_intel.env
+++ b/env/build_wcoss_cray_intel.env
@@ -44,8 +44,8 @@ module load wgrib2/2.0.8
 
 module swap pmi pmi/5.0.11
 
-## load cmake
-module load cmake/3.20.1
+module load cmake/3.20.2
+
 export CMAKE_C_COMPILER=cc
 export CMAKE_CXX_COMPILER=CC
 export CMAKE_Fortran_COMPILER=ftn

--- a/env/build_wcoss_dell_p3_intel.env
+++ b/env/build_wcoss_dell_p3_intel.env
@@ -2,11 +2,6 @@
 
 module purge
 
-module load cmake/3.20.0
-module load HPSS/5.0.2.5
-module load lsf/10.1
-module load python/3.6.3
-
 ### hpc-stack ###
 module use /usrx/local/nceplibs/dev/hpc-stack/libs/hpc-stack/modulefiles/stack
 module load hpc/1.1.0
@@ -37,6 +32,10 @@ module load w3nco/2.4.1
 module load wgrib2/2.0.8
 module load zlib/1.2.11
 
+module load cmake/3.20.0
+module load HPSS/5.0.2.5
+module load lsf/10.1
+module load python/3.6.3
 
 export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Since the latest version of cmake (3.20.1) is not loaded correctly on both the WCOSS dell and cray, 
1) WCOSS dell: move the load command after hpc-stack commands
2) WCOSS cray: its version is changed to 3.20.2

## TESTS CONDUCTED: 
WE2E tests on the wcoss dell and cray:
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_NA_3km_ics_FV3GFS_lbcs_FV3GFS_suite_RRFS_v1alpha

## ISSUE: 
Fixes issue mentioned in #158 

