### PR TITLE
Replace deprecated app.add_stylesheet with app.add_css_file.

### DIFF
--- a/docs/UsersGuide/source/conf.py
+++ b/docs/UsersGuide/source/conf.py
@@ -110,7 +110,7 @@ html_context = {
      }
 
 def setup(app):
-    app.add_stylesheet('custom.css')  # may also be an URL
+    app.add_css_file('custom.css')  # may also be an URL
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Replace app.add_stylesheet with app.add_csss_file for ReadTheDocs build for the develop branch. This is needed to fix:
Running Sphinx v4.1.1
loading translations [en]... done
making output directory... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/ufs-srweather-app/envs/latest/lib/python3.7/site-packages/sphinx/cmd/build.py", line 279, in build_main
    args.tags, args.verbosity, args.jobs, args.keep_going)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ufs-srweather-app/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 251, in __init__
    self.config.setup(self)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ufs-srweather-app/checkouts/latest/docs/UsersGuide/source/conf.py", line 113, in setup
    app.add_stylesheet('custom.css')  # may also be an URL
AttributeError: 'Sphinx' object has no attribute 'add_stylesheet'

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/ufs-srweather-app/checkouts/latest/docs/UsersGuide/source/conf.py", line 113, in setup
    app.add_stylesheet('custom.css')  # may also be an URL
AttributeError: 'Sphinx' object has no attribute 'add_stylesheet'
The full traceback has been saved in /tmp/sphinx-err-5n19bai9.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!

## TESTS CONDUCTED: 
HTML builds on MacOS

## DEPENDENCIES:
None

## DOCUMENTATION:
This fixes the documentation

