### PR TITLE
Replace deprecated app.add_stylesheet with app.add_css_file.

### DIFF
--- a/docs/UsersGuide/source/conf.py
+++ b/docs/UsersGuide/source/conf.py
@@ -110,7 +110,7 @@ html_context = {
      }
 
 def setup(app):
-    app.add_stylesheet('custom.css')  # may also be an URL
+    app.add_css_file('custom.css')  # may also be an URL
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
app.add_css file is needed for the automated ReadTheDocs build.

## TESTS CONDUCTED: 
None required.

## DEPENDENCIES:
None.
## DOCUMENTATION:
None needed.
