### PR TITLE
Release/public v1

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,7 +22,7 @@ required = True
 [EMC_post]
 protocol = git
 repo_url = https://github.com/NOAA-EMC/EMC_post
-tag = upp-v9.0.0
+tag = upp_v9.0.1
 local_path = src/EMC_post
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 [regional_workflow]
 protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
-tag = ufs-v1.0.0
+tag = ufs-v1.0.1
 local_path = regional_workflow
 required = True
 


### PR DESCRIPTION
Changing the tag from ufs-1.0.0 to ufs-1.0.1 in Externals.cfg for pointing to regional workflow release tag ufs-1.0.1
Passed the test on Hera.