### PR TITLE
Update the name of EMC Post exec in build test.

### DIFF
--- a/test/build.sh
+++ b/test/build.sh
@@ -85,7 +85,7 @@ declare -a executables_created=( chgres_cube \
                                  global_equiv_resol \
                                  make_hgrid \
                                  make_solo_mosaic \
-                                 ncep_post \
+                                 upp.x \
                                  orog \
                                  orog_gsl \
                                  regional_esg_grid \


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The recent update to the build of EMC changed the name of the expected executable. The build test fails. This change updates the test to ensure consistency with produced executables.

## TESTS CONDUCTED: 
Ran test/build.sh on Hera with successful completion.

## CONTRIBUTORS (optional): 
@mkavulich 
