### PR TITLE
Fix for manage_externals.

### DIFF
--- a/manage_externals/manic/externals_description.py
+++ b/manage_externals/manic/externals_description.py
@@ -253,7 +253,7 @@ def read_gitmodules_file(root_dir, file_name):
                                           ExternalsDescription.REPO_URL, url)
                 externals_description.set(sec_name,
                                           ExternalsDescription.REQUIRED, 'True')
-                git_hash = submods[sec_name]['hash']
+                git_hash = submods[path]['hash']
                 externals_description.set(sec_name,
                                           ExternalsDescription.HASH, git_hash)
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The existing snapshot of the manage_externals package builds a Python dictionary of the git submodules of each package where the keys are the relative paths where the submodules are checked out on disk. The code that checks status of these paths is looking for the key to be the same as the section name. That is a bad assumption for submodules like CMEPS. 

This is why we might often see the last line of the checkout_externals display `u"CMEPS"` and then the utility didn't actually do anything else. 

With this fix, the user should be able to clone, run checkout_externals successfully, switch branches and re-run checkout_externals and get the appropriate hashes throughout.

The code in [ESMCI/manage_externals](https://github.com/ESMCI/manage_externals/blob/master/manic/externals_description.py) has a slightly different fix implemented, however, it doesn't seem that the logic surrounding that fix is necessary given the way the dictionary is populated (use of output from `git submodule status`). Unnecessary logic is less efficient, especially for dictionaries that are already O(1) operations, and can slow the process down for projects with a large submodule tree.

## TESTS CONDUCTED: 
Sequence went like this before fix:
- Run manage_externals/checkout_externals once on fresh clone.
- Run manage_externals/checkout_externals -S to see status of current checkout. Stopped running with u'CMEPS' and did nothing. (Same behavior has been observed on prior occasions without the-S flag)

Sequence after fix:
- Run manage_externals/checkout_externals once on fresh clone.
- Run manage_externals/checkout_externals -S to see status of current checkout. Loops through all .gitmodules submodules and then shows clean status of all externals.
- Checkout different branch. Run manage_externals/checkout_externals and all submodules are updated to expected hashes for new branches. Note: submodules that may not be tracked in current branch (e.g., python_utilities), will still exist on disk, untracked.


