### PR TITLE
Add support for Rocoto with generic LINUX platform

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,9 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/christinaholtNOAA/regional_workflow
+repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
-branch = linux_target
-#hash = 9bac8563
+#branch = develop
+hash = 9bac8563
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,9 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/regional_workflow
+repo_url = https://github.com/christinaholtNOAA/regional_workflow
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = 9bac8563
+branch = linux_target
+#hash = 9bac8563
 local_path = regional_workflow
 required = True
 

--- a/env/wflow_jet.env
+++ b/env/wflow_jet.env
@@ -1,5 +1,7 @@
 # Python environment for workflow on Jet
 
+module load rocoto
+
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 conda activate regional_workflow

--- a/env/wflow_orion.env
+++ b/env/wflow_orion.env
@@ -1,6 +1,6 @@
 # Python environment for workflow on Orion
 
-module load rocoto
+module load contrib rocoto
 
 module use -a /apps/contrib/miniconda3-noaa-gsl/modulefiles
 module load miniconda3


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This is a minor change here that standardizes the workflow environment files. Jet and Orion were not loading rocoto, while Hera and Cheyenne were. This change allows these files to be sourced in `ush/launch_FV3LAM_wflow.sh` to avoid duplication of information, and to reduce the number of machine case statements needed in general.

## TESTS CONDUCTED: 
Ran with the corresponding linux_target branch in regional_workflow on Hera. Passed the grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GSD_SAR. 

## DEPENDENCIES:
NOAA-EMC/regional_workflow/pull/617

## ISSUE (optional): 
Corresponds to [regional_workflow Issue #610](https://github.com/NOAA-EMC/regional_workflow/issues/610)

## CONTRIBUTORS (optional): 
@christopherwharrop-noaa
