### PR TITLE
Fix module loads on Hera

### DIFF
--- a/env/build_hera_intel.env
+++ b/env/build_hera_intel.env
@@ -26,7 +26,8 @@ module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load sp/2.3.3
-module load w3emc/2.7.3
+module load w3emc/2.9.1
+module load sigio/2.3.2
 module load w3nco/2.4.1
 module load upp/10.0.6
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Module load changes on Hera now require the sigio module and updated w3emc (2.9.1) module to be loaded in order to build the SRW App.

## TESTS CONDUCTED: 
Built the SRW App successfully and successfully ran a 6-hr forecast with the RRFS_CONUS_25km domain on Hera.

