### PR TITLE
Change references from NOAA-EMC/UFS_UTILS to ufs-community/UFS_UTILS

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -19,7 +19,7 @@ Explicitly state what tests were run on these changes, or if any are still pendi
 ## DEPENDENCIES:
 Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
 - NOAA-EMC/regional_workflow/pull/<pr_number>
-- NOAA-EMC/UFS_UTILS/pull/<pr_number>
+- ufs-community/UFS_UTILS/pull/<pr_number>
 - ufs-community/ufs-weather-model/pull/<pr_number>
 
 ## DOCUMENTATION:

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,7 +9,7 @@ required = True
 
 [ufs_utils]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/UFS_UTILS
+repo_url = https://github.com/ufs-community/UFS_UTILS
 # Specify either a branch name or a hash but not both.
 #branch = develop
 hash = ea821358

--- a/docs/UsersGuide/source/CodeReposAndDirs.rst
+++ b/docs/UsersGuide/source/CodeReposAndDirs.rst
@@ -33,7 +33,7 @@ repositories associated with this umbrella repo (see :numref:`Table %s <top_leve
    | Repository for the regional     | https://github.com/NOAA-EMC/regional_workflow           |
    | workflow                        |                                                         |
    +---------------------------------+---------------------------------------------------------+
-   | Repository for UFS utilities,   | https://github.com/NOAA-EMC/UFS_UTILS                   |
+   | Repository for UFS utilities,   | https://github.com/ufs-community/UFS_UTILS              |
    | including pre-processing,       |                                                         |
    | chgres_cube, and more           |                                                         |
    +---------------------------------+---------------------------------------------------------+


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update Externals.cfg and other documentation to reference ufs-community/UFS_UTILS instead of NOAA-EMC/UFS-UTILS.

## TESTS CONDUCTED: 
Manage_externals tested and correctly checks out ufs-community/UFS_UTILS on Hera.

## DOCUMENTATION:
Changed to represent move from NOAA-EMC/UFS_UTILS to ufs-community/UFS_UTILS.

