### PR TITLE
update build-env for wcoss cray

### DIFF
--- a/env/build_wcoss_cray_intel.env
+++ b/env/build_wcoss_cray_intel.env
@@ -15,7 +15,6 @@ module use /usrx/local/dev/modulefiles
 module load NetCDF-intel-sandybridge/4.7.4
 module load HDF5-parallel-intel-sandybridge/1.10.6
 
-## WCOSS cray for WW3
 module load jasper-gnu-sandybridge/1.900.1
 module load zlib-intel-sandybridge/1.2.7
 module load png-intel-sandybridge/1.2.49
@@ -40,7 +39,9 @@ module load sp/2.3.3
 module load upp/10.0.6
 module load w3emc/2.7.3
 module load w3nco/2.4.1
-module load wgrib2/2.0.8
+
+module use /gpfs/hps/nco/ops/nwprod/lib/modulefiles
+module load wgrib2-intel/2.0.8
 
 module swap pmi pmi/5.0.11
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Since wgrib2 is not found in the designated path on the wcoss cray, a different version of wgrib2 is set in the environment file.

## TESTS CONDUCTED: 
WE2E tests on the wcoss cray:
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2

## ISSUE: 
Fixes issue mentioned in #188 

