### PR TITLE
Add rocoto to workflow env files for WCOSS

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 7da0c46
+hash = bf733c1
 local_path = regional_workflow
 required = True
 

--- a/env/wflow_wcoss_cray.env
+++ b/env/wflow_wcoss_cray.env
@@ -1,5 +1,9 @@
 # Python environment for workflow on WCOSS_cray
 
+module load xt-lsfhpc/9.1.3
+module use -a /usrx/local/emc_rocoto/modulefiles
+module load rocoto/1.3.0rc2
+
 module unload python/2.7.14
 module load python/3.6.3
 module use /usrx/local/nceplibs/modulefiles 

--- a/env/wflow_wcoss_dell_p3.env
+++ b/env/wflow_wcoss_dell_p3.env
@@ -1,5 +1,9 @@
 # Python environment for workflow on WCOSS_dell_p3
 
+module load lsf/10.1
+module use /gpfs/dell3/usrx/local/dev/emc_rocoto/modulefiles/
+module load ruby/2.5.1 rocoto/1.3.0rc2
+
 module load python/3.6.3
 module use /usrx/local/nceplibs/dev/modulefiles 
 module load srw-app-python/1.0.0


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
To remove the rocoto commands for the WCOSS dell and cray from the launch script of the regional workflow, the rocoto commands are added to the workflow environment files for the WCOSS dell and cray in the UFS SRW App.

## TESTS CONDUCTED: 
WE2E tests on the WCOSS dell and cray:
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- nco_grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- MET_ensemble_verification

## ISSUE: 
Fixes issue mentioned in #190 
