### PR TITLE
Update hash of ufs weather model for use of pressure tendency diagnostic

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,11 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/regional_workflow
+#repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 68694fc
+#hash = 68694fc
+repo_url = https://github.com/chan-hoo/regional_workflow
+branch = feature/new_uwm
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 68694fc
+hash = bf733c1
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = bf733c1
+hash = 68694fc
 local_path = regional_workflow
 required = True
 
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 3b8bb78
+hash = ddcd809
 local_path = src/ufs-weather-model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,11 +1,9 @@
 [regional_workflow]
 protocol = git
-#repo_url = https://github.com/NOAA-EMC/regional_workflow
+repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-#hash = 68694fc
-repo_url = https://github.com/chan-hoo/regional_workflow
-branch = feature/new_uwm
+hash = 68694fc
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = bf733c1
+hash = a1bd5ca
 local_path = regional_workflow
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Since the hash of the UFS Weather Model should be newer than e6ca294 (committed on 07/21/21) to use the pressure tendency diagnostic, it is updated with 'ddcd809' used for the real-time runs at EMC.

## TESTS CONDUCTED: 
WE2E tests on WCOSS dell and Hera:
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GSD_SAR
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16

## DEPENDENCIES:
- NOAA-EMC/regional_workflow/pull/642

## ISSUE: 
Fixes issue mentioned in #192 

## CONTRIBUTORS: 
@BenjaminBlake-NOAA, @MatthewPyle-NOAA