### PR TITLE
Make thompson_mynn_lam3km ccpp suite available

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,11 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/regional_workflow
+#repo_url = https://github.com/NOAA-EMC/regional_workflow
+repo_url = https://github.com/chan-hoo/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = a1bd5ca
+branch = feature/thompson_mynn
+#hash = a1bd5ca
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,11 +1,9 @@
 [regional_workflow]
 protocol = git
-#repo_url = https://github.com/NOAA-EMC/regional_workflow
-repo_url = https://github.com/chan-hoo/regional_workflow
+repo_url = https://github.com/NOAA-EMC/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-branch = feature/thompson_mynn
-#hash = a1bd5ca
+hash = a1bd5ca
 local_path = regional_workflow
 required = True
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha")
+  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha,FV3_GFS_v15_thompson_mynn_lam3km")
 endif()
 
 if(NOT APP)


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Add a new ccpp suite 'thompson_mynn_lam3km', which is used at EMC, to the list of CCPP suites in the UFS SRW App.

## TESTS CONDUCTED: 
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2

and a new WE2E test on WCOSS dell and cray, and Hera:
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15_thompson_mynn_lam3km



## DEPENDENCIES:
- NOAA-EMC/regional_workflow/pull/644

## ISSUE: 
Fixes issue mentioned in #196 


