### PR TITLE
Update NOAA-EMC/regional_workflow references to ufs-community/regional_workflow.  Change EMC_post references to UPP.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -18,7 +18,7 @@ Explicitly state what tests were run on these changes, or if any are still pendi
 
 ## DEPENDENCIES:
 Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
-- NOAA-EMC/regional_workflow/pull/<pr_number>
+- ufs-community/regional_workflow/pull/<pr_number>
 - ufs-community/UFS_UTILS/pull/<pr_number>
 - ufs-community/ufs-weather-model/pull/<pr_number>
 
@@ -26,7 +26,7 @@ Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For examp
 If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material.
 
 ## ISSUE (optional): 
-If this PR is resolving or referencing one or more issues, in this repository or elewhere, list them here. For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/NOAA-EMC/other_repository/pull/63"
+If this PR is resolving or referencing one or more issues, in this repository or elewhere, list them here. For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/ufs-community/other_repository/pull/63"
 
 ## CONTRIBUTORS (optional): 
 If others have contributed to this work aside from the PR author, list them here

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,6 +1,6 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/regional_workflow
+repo_url = https://github.com/ufs-community/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
 hash = 20a149d

--- a/docs/UsersGuide/source/CodeReposAndDirs.rst
+++ b/docs/UsersGuide/source/CodeReposAndDirs.rst
@@ -30,14 +30,14 @@ repositories associated with this umbrella repo (see :numref:`Table %s <top_leve
    | Repository for                  | https://github.com/ufs-community/ufs-weather-model      |
    | the UFS Weather Model           |                                                         |
    +---------------------------------+---------------------------------------------------------+
-   | Repository for the regional     | https://github.com/NOAA-EMC/regional_workflow           |
+   | Repository for the regional     | https://github.com/ufs-community/regional_workflow      |
    | workflow                        |                                                         |
    +---------------------------------+---------------------------------------------------------+
    | Repository for UFS utilities,   | https://github.com/ufs-community/UFS_UTILS              |
    | including pre-processing,       |                                                         |
    | chgres_cube, and more           |                                                         |
    +---------------------------------+---------------------------------------------------------+
-   | Repository for the Unified Post | https://github.com/NOAA-EMC/EMC_post                    |
+   | Repository for the Unified Post | https://github.com/NOAA-EMC/UPP                         |
    | Processor (UPP)                 |                                                         |
    +---------------------------------+---------------------------------------------------------+
 
@@ -92,7 +92,7 @@ scripts are presented in parentheses.  Some directories have been removed for br
    │          └── wrappers
    ├── (share)
    └── src
-        ├── EMC_post
+        ├── UPP
         │     ├── parm
         │     └── sorc
         │          └── ncep_post.fd

--- a/docs/UsersGuide/source/ConfigNewPlatform.rst
+++ b/docs/UsersGuide/source/ConfigNewPlatform.rst
@@ -275,7 +275,7 @@ The ``README.md`` file will contain instructions on the order that each script s
    +--------------------+----------------------------+------------+-----------+
    | ufs-weather-model  | ./run_fcst.sh              | 6          | 1h 40 m   |
    +--------------------+----------------------------+------------+-----------+
-   | EMC_post           | ./run_post.sh              | 1          | 7 m       |
+   | UPP                | ./run_post.sh              | 1          | 7 m       |
    +--------------------+----------------------------+------------+-----------+
 
 Running on a New Platform with Rocoto Workflow Manager

--- a/docs/UsersGuide/source/ConfigParameters.inc
+++ b/docs/UsersGuide/source/ConfigParameters.inc
@@ -310,7 +310,7 @@ Maximum number of attempts.
 Customized Post Configuration Parameters
 ========================================
 ``USE_CUSTOM_POST_CONFIG_FILE``: (Default: “FALSE”)
-   Flag that determines whether a user-provided custom configuration file should be used for post-processing the model data. If this is set to "TRUE", then the workflow will use the custom post-processing (UPP) configuration file specified in ``CUSTOM_POST_CONFIG_FP``. Otherwise, a default configuration file provided in the EMC_post repository will be used.
+   Flag that determines whether a user-provided custom configuration file should be used for post-processing the model data. If this is set to "TRUE", then the workflow will use the custom post-processing (UPP) configuration file specified in ``CUSTOM_POST_CONFIG_FP``. Otherwise, a default configuration file provided in the UPP repository will be used.
 
 ``CUSTOM_POST_CONFIG_FP``: (Default: “”)
    The full path to the custom post flat file, including filename, to be used for post-processing. This is only used if ``CUSTOM_POST_CONFIG_FILE`` is set to "TRUE".

--- a/docs/UsersGuide/source/InputOutputFiles.rst
+++ b/docs/UsersGuide/source/InputOutputFiles.rst
@@ -200,7 +200,7 @@ the user in the ``config.sh`` settings.
 If you wish to modify the fields or levels that are output from the UPP, you will need to make
 modifications to file ``fv3lam.xml``, which resides in the UPP repository distributed with the UFS SRW
 Application. Specifically, if the code was cloned in the directory ``ufs-srweather-app``, the file will be
-located in ``ufs-srweather-app/src/EMC_post/parm``.
+located in ``ufs-srweather-app/src/UPP/parm``.
 
 .. note::
    This process requires advanced knowledge of which fields can be output for the UFS Weather Model.

--- a/docs/UsersGuide/source/Introduction.rst
+++ b/docs/UsersGuide/source/Introduction.rst
@@ -105,7 +105,7 @@ as an example for users familiar with Python, and may be used to do a visual che
 that the application is producing reasonable results. 
 
 The scripts are available in the `regional_workflow repository
-<https://github.com/NOAA-EMC/regional_workflow/tree/release/public-v1/ush/Python>`_
+<https://github.com/ufs-community/regional_workflow/tree/release/public-v1/ush/Python>`_
 under ush/Python. Usage information and instructions are described in  
 :numref:`Chapter %s <Graphics>` and are also included at the top of the script. 
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update NOAA-EMC/regional_workflow references to ufs-community/regional_workflow.  Change EMC_post references to UPP.

## DOCUMENTATION:
Documentation updated to reflect changes to the regional_workflow and UPP repositories.
