### PR TITLE
Add `module purge` to beginning of orion build module, update regional_workflow hash

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,9 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/mkavulich/regional_workflow
+repo_url = https://github.com/ufs-community/regional_workflow
 # Specify either a branch name or a hash but not both.
-branch = feature/fix_cheyenne_run
-#hash = bb54e59
+#branch = develop
+hash = f5f8158
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,9 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/regional_workflow
+repo_url = https://github.com/mkavulich/regional_workflow
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = 20a149d
+branch = fix_cheyenne_run
+#hash = bb54e59
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 protocol = git
 repo_url = https://github.com/mkavulich/regional_workflow
 # Specify either a branch name or a hash but not both.
-branch = fix_cheyenne_run
+branch = feature/fix_cheyenne_run
 #hash = bb54e59
 local_path = regional_workflow
 required = True

--- a/env/build_orion_intel.env
+++ b/env/build_orion_intel.env
@@ -1,5 +1,7 @@
 #Setup instructions for MSU Orion using Intel-18.0.5 (bash shell)
 
+module purge
+
 module load contrib noaatools
 
 module load cmake/3.18.1


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
With changes in regional_workflow necessary for fixing of some problems on the Cheyenne platform, the ufs-srweather-app hash needs to be updated, and a `module purge` command needs to be added to the beginning of the Orion platform's build module. This ensures a clean and consistent build environment and avoids tricky-to-solve environment-specific build errors.

## TESTS CONDUCTED: 
Testing complete on Cheyenne, Orion, Hera, and Jet. All tests pass aside from those with pre-existing issues; see [regional_workflow PR](https://github.com/ufs-community/regional_workflow/pull/672) for more details

## DEPENDENCIES:
- Regional workflow PR must be merged first, then this PR can be updated to reference the new hash: https://github.com/ufs-community/regional_workflow/pull/672

## ISSUE (optional): 
Related to issue https://github.com/ufs-community/regional_workflow/issues/663