### PR TITLE
Update UPP hash to current develop

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = a49af05
+hash = 4a16052
 local_path = src/UPP
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR is for updating to a more recent UPP hash.

In order to update to a new hash, changes are made to the regional_workflow/scripts/exregional_run_post.sh script to account for recent changes for UPP to use a fortran namelist (still called itag)

## TESTS CONDUCTED: 
Tests were conducted on Cheyenne and Hera for the Intel compiler. 6-hr long tests were successful on both.

## DEPENDENCIES:
PR [#677](https://github.com/ufs-community/regional_workflow/pull/677)

## DOCUMENTATION:
There are no documentation changes needed for SRW. Documentation related to this enhancement was updated internally in the UPP Users Guide.

## ISSUE (optional): 
This PR resolves issue #207 

## CONTRIBUTORS (optional): 

