### PR TITLE
Add SPP to the SRW App

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,8 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/ufs-community/regional_workflow
+repo_url = https://github.com/JeffBeck-NOAA/regional_workflow
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = e5d5c38
+branch = feature/spp
 local_path = regional_workflow
 required = True
 
@@ -21,7 +20,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 805421d
+hash = e593349
 local_path = src/ufs-weather-model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,8 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = c4a5007
-#hash = 4a16052
+hash = 4a16052
 local_path = src/UPP
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,8 +1,9 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/JeffBeck-NOAA/regional_workflow
+repo_url = https://github.com/ufs-community/regional_workflow
 # Specify either a branch name or a hash but not both.
-branch = feature/spp
+#branch = develop
+hash = 03a0eed
 local_path = regional_workflow
 required = True
 
@@ -29,7 +30,8 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 4a16052
+hash = c4a5007
+#hash = 4a16052
 local_path = src/UPP
 required = True
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha,FV3_GFS_v15_thompson_mynn_lam3km")
+  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_GFS_v15_thompson_mynn_lam3km")
 endif()
 
 if(NOT APP)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_GFS_v15_thompson_mynn_lam3km")
+  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha,FV3_GFS_v15_thompson_mynn_lam3km")
 endif()
 
 if(NOT APP)


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR updates the hash of ufs-weather-model to near the HEAD to support SPP in the SRW App.  In addition, two SDFs previously supported by the SRW App (FV3_GSD_SAR and FV3_GSD_v0) were removed from the list of suites to build with the App, since they've been removed from the authoritative repository.  Note that the forked regional_workflow repo and branch listed in the Externals.cfg file will be updated to point to the authoritative regional_workflow and specific hash once the companion [PR #685](https://github.com/ufs-community/regional_workflow/pull/685) is merged, but before this PR is merged. 

## TESTS CONDUCTED: 
Build tested successfully on Hera.

WE2E testing:

grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_2017_gfdlmp - FAILED; also failed with previous hash of ufs-weather-model
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_2017_gfdlmp_regional - FAILED; also failed with previous hash of ufs-weather-model
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2 - SUCCEEDED
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16 - SUCCEEDED
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_RAP_suite_HRRR - SUCCEEDED
grid_RRFS_CONUS_25km_ics_GSMGFS_lbcs_GSMGFS_suite_CPT_v0 - FAILED; also failed with previous hash of ufs-weather-model
grid_RRFS_CONUS_25km_ics_GSMGFS_lbcs_GSMGFS_suite_GFS_2017_gfdlmp - FAILED; also failed with previous hash of ufs-weather-model
grid_RRFS_CONUS_25km_ics_GSMGFS_lbcs_GSMGFS_suite_GFS_v15p2 - SUCCEEDED
grid_RRFS_CONUS_25km_ics_GSMGFS_lbcs_GSMGFS_suite_GFS_v16 - FAILED; also failed with previous hash of ufs-weather-model
grid_RRFS_CONUS_25km_ics_HRRR_lbcs_HRRR_suite_HRRR - SUCCEEDED
grid_RRFS_CONUS_25km_ics_HRRR_lbcs_HRRR_suite_RRFS_v1beta - SUCCEEDED
grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_HRRR - SUCCEEDED
grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_RRFS_v1alpha - SUCCEEDED
grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta - SUCCEEDED
grid_RRFS_CONUS_25km_ics_NAM_lbcs_NAM_suite_HRRR - FAILED; also failed with previous hash of ufs-weather-model; NAM data likely too old for chgres_cube
grid_RRFS_CONUS_25km_ics_NAM_lbcs_NAM_suite_RRFS_v1beta - FAILED; also failed with previous hash of ufs-weather-model; NAM data likely too old for chgres_cube
grid_RRFS_CONUS_3km_ics_HRRR_lbcs_RAP_suite_HRRR_all_stoch - SUCCEEDED

## DEPENDENCIES:
Must merge regional_workflow [PR #685](https://github.com/ufs-community/regional_workflow/pull/685) before merging this PR.

