### PR TITLE
Remove FV3_CPT_v0 from the list of suites to build with; update hash of regional_workflow

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 03a0eed
+hash = 2718b62
 local_path = regional_workflow
 required = True
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha,FV3_GFS_v15_thompson_mynn_lam3km")
+  set(CCPP_SUITES "FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha,FV3_GFS_v15_thompson_mynn_lam3km")
 endif()
 
 if(NOT APP)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "FV3_CPT_v0,FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha,FV3_GFS_v15_thompson_mynn_lam3km")
+  set(CCPP_SUITES "FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GSD_SAR,FV3_GSD_v0,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha,FV3_GFS_v15_thompson_mynn_lam3km")
 endif()
 
 if(NOT APP)


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This removes the old/unused physics suite `FV3_CPT_v0` from the list of suites to build.  It also updates the hash of `regional_workflow` to include PR #[697](https://github.com/ufs-community/regional_workflow/pull/697).

## TESTS CONDUCTED: 
Builds successfully on Hera.  See PR #[697](https://github.com/ufs-community/regional_workflow/pull/697) in the `regional_workflow` repo for WE2E tests conducted.

## DEPENDENCIES:
This must be merged after PR #[697](https://github.com/ufs-community/regional_workflow/pull/697) is merged in the `regional_workflow` repo.
