### PR TITLE
Add support on NSSL/Odin

### DIFF
--- a/env/build_odin_intel.env
+++ b/env/build_odin_intel.env
@@ -1,0 +1,58 @@
+#Setup instructions for NOAA RDHPC Jet using Intel-18.0.5.274 (bash shell)
+
+module unload modules
+unset -f module
+
+export BASH_ENV=/usr/local/lmod/8.3.1/init/bash
+source $BASH_ENV
+export LMOD_SYSTEM_DEFAULT_MODULES=PrgEnv-intel:cray-mpich:intel:craype
+module --initial_load --no_redirect restore
+#module use <$HOME>/<your-modulefiles-dir>
+export MODULEPATH=/oldscratch/ywang/external/hpc-stack/modulefiles/mpi/intel/2020/cray-mpich/7.7.16:/oldscratch/ywang/external/hpc-stack/modulefiles/compiler/intel/2020:/oldscratch/ywang/external/hpc-stack/modulefiles/core:/oldscratch/ywang/external/hpc-stack/modulefiles/stack:/opt/cray/pe/perftools/21.02.0/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/craype-targets/default/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles
+
+#module purge
+export CMAKE=/home/yunheng.wang/tools/cmake-3.23.0-rc2/bin/cmake
+export PATH=/home/yunheng.wang/tools/cmake-3.23.0-rc2/bin:${PATH}
+
+module load hpc/1.2.0
+module load hpc-intel
+module load hpc-cray-mpich
+
+#module load srw_common
+
+module load jasper
+module load zlib
+module load png
+
+#module load cray-hdf5
+#module load cray-netcdf
+module load esmf
+module load fms
+
+module load bacio
+module load crtm
+module load g2
+module load g2tmpl
+module load ip
+module load sp
+module load w3nco
+module load upp
+
+module load gftl-shared
+module load yafyaml
+module load mapl
+
+module load gfsio
+module load landsfcutil
+module load nemsio
+module load nemsiogfs
+module load sfcio
+module load sigio
+module load w3emc
+module load wgrib2
+
+export CMAKE_C_COMPILER=cc
+export CMAKE_CXX_COMPILER=CC
+export CMAKE_Fortran_COMPILER=ftn
+export CMAKE_Platform=odin.intel
+

--- a/env/detect_machine.sh
+++ b/env/detect_machine.sh
@@ -97,7 +97,8 @@ case $(hostname -f) in
   login01.expanse.sdsc.edu) MACHINE_ID=expanse ;; ### expanse1
   login02.expanse.sdsc.edu) MACHINE_ID=expanse ;; ### expanse2
 
-  nid0*) MACHINE_ID=odin ;; ### Odin at NSSL
+  nid00193) MACHINE_ID=odin ;; ### Odin1 at NSSL
+  nid00385) MACHINE_ID=odin ;; ### Odin2 at NSSL
 esac
 
 MACHINE="${MACHINE_ID}"

--- a/env/detect_machine.sh
+++ b/env/detect_machine.sh
@@ -97,7 +97,7 @@ case $(hostname -f) in
   login01.expanse.sdsc.edu) MACHINE_ID=expanse ;; ### expanse1
   login02.expanse.sdsc.edu) MACHINE_ID=expanse ;; ### expanse2
 
-  nid0*) MACHINE_ID=odin ;; ### expanse2
+  nid0*) MACHINE_ID=odin ;; ### Odin at NSSL
 esac
 
 MACHINE="${MACHINE_ID}"

--- a/env/detect_machine.sh
+++ b/env/detect_machine.sh
@@ -96,6 +96,8 @@ case $(hostname -f) in
 
   login01.expanse.sdsc.edu) MACHINE_ID=expanse ;; ### expanse1
   login02.expanse.sdsc.edu) MACHINE_ID=expanse ;; ### expanse2
+
+  nid0*) MACHINE_ID=odin ;; ### expanse2
 esac
 
 MACHINE="${MACHINE_ID}"

--- a/env/wflow_odin.env
+++ b/env/wflow_odin.env
@@ -1,0 +1,25 @@
+# >>> conda initialize >>>
+# !! Contents within this block are managed by 'conda init' !!
+__conda_setup="$('/scratch/software/Odin/python/anaconda2/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+if [ $? -eq 0 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "/scratch/software/Odin/python/anaconda2/etc/profile.d/conda.sh" ]; then
+        . "/scratch/software/Odin/python/anaconda2/etc/profile.d/conda.sh"
+    else
+        export PATH="/scratch/software/Odin/python/anaconda2/bin:$PATH"
+    fi
+fi
+unset __conda_setup
+# <<< conda initialize <<<
+
+# To make "regional_workflow" avaiable,
+# you should uncomment the following lines, which create file ".condarc"
+# or install the environment yourself.
+#cat > $HOME/.condarc <<EOF
+#envs_dirs:
+#  - /home/yunheng.wang/.conda/envs
+#EOF
+
+conda config --set changeps1 False
+conda activate regional_workflow


### PR DESCRIPTION


## DESCRIPTION OF CHANGES: 
Add support on Odin using Intel 2020 and HPC-stack modules.

## TESTS CONDUCTED: 
Tested on Odin at NSSL.

## DEPENDENCIES:
None

## DOCUMENTATION:
It follows the same standard as on Jet/hera etc. Just changed the platform name to "_odin_".

## NEW FILES:
Just one new file.
- _env/build_odin_intel.env_
