### PR TITLE
Add python module to cheyenne build environments

### DIFF
--- a/env/build_cheyenne_gnu.env
+++ b/env/build_cheyenne_gnu.env
@@ -7,6 +7,7 @@ module load ncarenv/1.3
 module load gnu/10.1.0
 module load mpt/2.22
 module load ncarcompilers/0.5.0
+module load python/3.7.9
 module unload netcdf
 
 module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.2.0/modulefiles/stack

--- a/env/build_cheyenne_intel.env
+++ b/env/build_cheyenne_intel.env
@@ -7,6 +7,7 @@ module load ncarenv/1.3
 module load intel/2021.2
 module load mpt/2.22
 module load ncarcompilers/0.5.0
+module load python/3.7.9
 module unload netcdf
 
 module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.2.0/modulefiles/stack


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Build fails on Cheyenne if no python environment is loaded, so loading a python module to fix it.

## TESTS CONDUCTED: 
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2 passed on intel
- build now succeeds on gnu

