### PR TITLE
Update hashes of all components to latest versions

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 405553b
+hash = 3f83cde
 local_path = regional_workflow
 required = True
 
@@ -12,7 +12,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/UFS_UTILS
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = f30740e
+hash = 31271f7
 local_path = src/UFS_UTILS
 required = True
 
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = e593349
+hash = 96dffa1
 local_path = src/ufs-weather-model
 required = True
 
@@ -30,7 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 4a16052
+hash = 394917e
 local_path = src/UPP
 required = True
 

--- a/env/build_cheyenne_gnu.env
+++ b/env/build_cheyenne_gnu.env
@@ -1,8 +1,8 @@
-#Setup instructions for CISL Cheyenne using Intel-19.1.1 (bash shell)
+#Setup instructions for CISL Cheyenne using GNU-10.1.0 (bash shell)
 
 module purge
 
-module load cmake/3.18.2
+module load cmake/3.22.0
 module load ncarenv/1.3
 module load gnu/10.1.0
 module load mpt/2.22

--- a/env/build_cheyenne_gnu.env
+++ b/env/build_cheyenne_gnu.env
@@ -16,6 +16,7 @@ module load hpc-gnu/10.1.0
 module load hpc-mpt/2.22
 
 module load srw_common
+module load g2/3.4.3
 
 export CMAKE_C_COMPILER=mpicc
 export CMAKE_CXX_COMPILER=mpicxx

--- a/env/build_cheyenne_intel.env
+++ b/env/build_cheyenne_intel.env
@@ -1,4 +1,4 @@
-#Setup instructions for CISL Cheyenne using Intel-19.1.1 (bash shell)
+#Setup instructions for CISL Cheyenne using Intel-2021.2 (bash shell)
 
 module purge
 
@@ -16,6 +16,7 @@ module load hpc-intel/2021.2
 module load hpc-mpt/2.22
 
 module load srw_common
+module load g2/3.4.3
 
 export CMAKE_C_COMPILER=mpicc
 export CMAKE_CXX_COMPILER=mpicxx

--- a/env/build_cheyenne_intel.env
+++ b/env/build_cheyenne_intel.env
@@ -2,7 +2,7 @@
 
 module purge
 
-module load cmake/3.18.2
+module load cmake/3.22.0
 module load ncarenv/1.3
 module load intel/2021.2
 module load mpt/2.22

--- a/env/build_orion_intel.env
+++ b/env/build_orion_intel.env
@@ -4,7 +4,7 @@ module purge
 
 module load contrib noaatools
 
-module load cmake/3.18.1
+module load cmake/3.22.1
 module load python/3.9.2
 
 module use /apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack

--- a/env/srw_common
+++ b/env/srw_common
@@ -12,7 +12,7 @@ module load fms/2021.03
 
 module load bacio/2.4.1
 module load crtm/2.3.0
-module load g2/3.4.2
+module load g2/3.4.3
 module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load sp/2.3.3


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This is a badly needed update to the hashes of the UFS SRW components. Some of the current hashes are well out-of-date at this point, and missing several critical fixes that have been added to various components.

regional_workflow: 405553b (Mar 22) --> 3f83cde (Apr 4)
UFS_UTILS: f30740e (**Nov 5 2021!**) --> 31271f7 (Mar 25)
ufs-weather-model: e593349 (Feb 23) --> 96dffa1 (Apr 4)
UPP: 4a16052 (Feb 10) --> 394917e (Apr 4)

## TESTS CONDUCTED: 
Per comments on [regional_workflow issue #673](https://github.com/ufs-community/regional_workflow/issues/673), nearly all WE2E tests pass now on Hera (way more than the current set of hashes). I believe this is enough to be confident in updating the hashes.

## DEPENDENCIES:
None.

## DOCUMENTATION:
If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material.