### PR TITLE
changes to prevent build fail on RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,22 +2,34 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required 
+# Required
 version: 2
 
-# Build all formats (htmlzip, pdf, epub)
-#formats: all
-formats: []
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
 
-# Optionally set the version of Python and requirements required to build your
-# docs
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/UsersGuide/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
 python:
-   version: 3.7
    install:
    - requirements: docs/UsersGuide/requirements.txt
 
-# Configuration for Sphinx documentation (this is the default documentation
-# type)
-sphinx:
-  builder: html
-  configuration: docs/UsersGuide/source/conf.py
+submodules:
+   include:
+   - hpc-stack-mod
+   recursive: true
+

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,4 +1,2 @@
-docutils==0.16
-sphinx==2.4.4
 sphinxcontrib-bibtex
-sphinx-rtd-theme==0.4.3
+sphinx_rtd_theme

--- a/docs/UsersGuide/source/conf.py
+++ b/docs/UsersGuide/source/conf.py
@@ -102,15 +102,12 @@ html_theme_options = {"body_max_width": "none"}
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+html_context = {}
 
 def setup(app):
     app.add_css_file('custom.css')  # may also be an URL
+    app.add_css_file('theme_overrides.css')  # may also be a URL
+
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Added a .readthedocs.yaml file and updated conf.py and requirements.txt so that the release/public-v1 branch documents can build on RTD. 

## TESTS CONDUCTED: 
None required. The RTD release/public-v1 branch builds on my RTD account now (before it was failing). 

## DEPENDENCIES:
N/A

## DOCUMENTATION:
N/A

## ISSUE: 
The release/public-v1 branch started showing a "Build failed" message once Jaime and I were added to the RTD account. My own (previous) updates to the develop branch required these same changes to get RTD to build. No issue was filed since the RTD docs still show the last successful build. However, any future doc changes (limited though they'll be), will not show without this update. 
