### PR TITLE
Attempt to fix RTD build issue on release v1 branch

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ formats: []
 # Optionally set the version of Python and requirements required to build your
 # docs
 python:
-   version: 3.7
+   version: "3.7"
    install:
    - requirements: docs/UsersGuide/requirements.txt
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,31 +5,20 @@
 # Required
 version: 2
 
-# Set the version of Python and other tools you might need
-build:
-  os: ubuntu-20.04
-  tools:
-    python: "3.9"
-    # You can also specify other tool versions:
-    # nodejs: "16"
-    # rust: "1.55"
-    # golang: "1.17"
+# Build all formats (htmlzip, pdf, epub)
+#formats: all
+formats: []
 
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-   configuration: docs/UsersGuide/source/conf.py
-
-# If using Sphinx, optionally build your docs in additional formats such as PDF
-# formats:
-#    - pdf
-
-# Optionally declare the Python requirements required to build your docs
+# Optionally set the version of Python and requirements required to build your
+# docs
 python:
+   version: 3.7
    install:
    - requirements: docs/UsersGuide/requirements.txt
 
-submodules:
-   include:
-   - hpc-stack-mod
-   recursive: true
+# Configuration for Sphinx documentation (this is the default documentation
+# type)
+sphinx:
+  builder: html
+  configuration: docs/UsersGuide/source/conf.py
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,22 +2,34 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required 
+# Required
 version: 2
 
-# Build all formats (htmlzip, pdf, epub)
-#formats: all
-formats: []
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
 
-# Optionally set the version of Python and requirements required to build your
-# docs
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/UsersGuide/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
 python:
-   version: 3.7
    install:
    - requirements: docs/UsersGuide/requirements.txt
 
-# Configuration for Sphinx documentation (this is the default documentation
-# type)
-sphinx:
-  builder: html
-  configuration: docs/UsersGuide/source/conf.py
+submodules:
+   include:
+   - hpc-stack-mod
+   recursive: true
+

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,20 +5,27 @@
 # Required
 version: 2
 
-# Build all formats (htmlzip, pdf, epub)
-#formats: all
-formats: []
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
 
-# Optionally set the version of Python and requirements required to build your
-# docs
+# Build documentation in the docs/UsersGuide directory with Sphinx
+sphinx:
+   builder: html
+   configuration: docs/UsersGuide/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
 python:
-   version: "3.7"
    install:
    - requirements: docs/UsersGuide/requirements.txt
-
-# Configuration for Sphinx documentation (this is the default documentation
-# type)
-sphinx:
-  builder: html
-  configuration: docs/UsersGuide/source/conf.py
 

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,2 +1,6 @@
+
+Jinja2<3.1
+#docutils==0.16
+#sphinx==2.4.4
 sphinxcontrib-bibtex
 sphinx_rtd_theme

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,6 +1,7 @@
 
-Jinja2<3.0
-docutils==0.16
-sphinx==2.4.4
+jinja2<3.1
+#docutils==0.16
+#sphinx==2.4.4
 sphinxcontrib-bibtex
-sphinx-rtd-theme==0.4.3
+#sphinx-rtd-theme==0.4.3
+sphinx_rtd_theme

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,6 +1,6 @@
 
-Jinja2<3.1
-#docutils==0.16
-#sphinx==2.4.4
+Jinja2<3.0
+docutils==0.16
+sphinx==2.4.4
 sphinxcontrib-bibtex
-sphinx_rtd_theme
+sphinx-rtd-theme==0.4.3

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,4 +1,2 @@
-docutils==0.16
-sphinx==2.4.4
 sphinxcontrib-bibtex
-sphinx-rtd-theme==0.4.3
+sphinx_rtd_theme

--- a/docs/UsersGuide/source/conf.py
+++ b/docs/UsersGuide/source/conf.py
@@ -102,15 +102,12 @@ html_theme_options = {"body_max_width": "none"}
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+html_context = {}
 
 def setup(app):
     app.add_css_file('custom.css')  # may also be an URL
+    app.add_css_file('theme_overrides.css')  # may also be a URL
+
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/UsersGuide/source/conf.py
+++ b/docs/UsersGuide/source/conf.py
@@ -102,15 +102,12 @@ html_theme_options = {"body_max_width": "none"}
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+html_context = {}
 
 def setup(app):
     app.add_css_file('custom.css')  # may also be an URL
-    
+    app.add_css_file('theme_overrides.css')  # may also be a URL
+
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/UsersGuide/source/conf.py
+++ b/docs/UsersGuide/source/conf.py
@@ -102,12 +102,15 @@ html_theme_options = {"body_max_width": "none"}
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-html_context = {}
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in RTD theme
+        ],
+     }
 
 def setup(app):
     app.add_css_file('custom.css')  # may also be an URL
-    app.add_css_file('theme_overrides.css')  # may also be a URL
-
+    
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Added "jinja2<3.1" to requirements.txt to (hopefully) prevent build issue on v1.0.1 release branch.

## TESTS CONDUCTED: 
Built the docs on my RTD account. 

## DEPENDENCIES:
None. 

## DOCUMENTATION:
N/A

## ISSUE (optional): 
The release/public-v1 branch started showing a "Build failed" message once Jamie and I were added to the RTD account. My updates from PR #234 did not fix the problem (docs built successfully on my repo but not when merged). No issue was filed since the RTD docs still show the last successful build. However, any future doc changes (limited though they'll be), will not show without fixing this issue.


