### PR TITLE
Update regional_workflow hash, add shortcuts for common devbuild.sh options

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 6800643
+hash = ef63cc0
 local_path = regional_workflow
 required = True
 

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -8,10 +8,10 @@ Usage: $0 --platform=PLATFORM [OPTIONS]...
 OPTIONS
   -h, --help
       show this help guide
-  --platform=PLATFORM
+  -p, --platform=PLATFORM
       name of machine you are building on
       (e.g. cheyenne | hera | jet | orion | wcoss_dell_p3)
-  --compiler=COMPILER
+  -c, --compiler=COMPILER
       compiler to use; default depends on platform
       (e.g. intel | gnu | cray | gccgfortran)
   --app=APPLICATION
@@ -104,10 +104,10 @@ fi
 while :; do
   case $1 in
     --help|-h) usage; exit 0 ;;
-    --platform=?*) PLATFORM=${1#*=} ;;
-    --platform|--platform=) usage_error "$1 requires argument." ;;
-    --compiler=?*) COMPILER=${1#*=} ;;
-    --compiler|--compiler=) usage_error "$1 requires argument." ;;
+    --platform=?*|-p=?*) PLATFORM=${1#*=} ;;
+    --platform|--platform=|-p|-p=) usage_error "$1 requires argument." ;;
+    --compiler=?*|-c=?*) COMPILER=${1#*=} ;;
+    --compiler|--compiler=|-c|-c=) usage_error "$1 requires argument." ;;
     --app=?*) APPLICATION=${1#*=} ;;
     --app|--app=) usage_error "$1 requires argument." ;;
     --ccpp=?*) CCPP=${1#*=} ;;


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Incorporate changes from regional_workflow PR #744 (ef63cc0) and #745 (bd13e16). Also, add shortcuts for the --platform (-p) and --compiler (-c) options to the devbuild.sh script.

## TESTS CONDUCTED: 
Ran build on Hera (intel) and Cheyenne (gnu) using old and new devbuild options, got expected results. Ran WE2E tests on each as well, no unexpected failures.

## DEPENDENCIES:
None

## DOCUMENTATION:
Updated help stanza for devbuild.sh

## ISSUE (optional): 
This will resolve #231 
