### PR TITLE
Fix for miniconda3 load on Hera

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -3,7 +3,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = ef63cc0
+hash = de82b63
 local_path = regional_workflow
 required = True
 

--- a/modulefiles/wflow_hera
+++ b/modulefiles/wflow_hera
@@ -9,8 +9,6 @@ module-whatis "Loads libraries needed for running SRW on Hera"
 
 module load rocoto
 
-module unload miniconda3
-
 module use /contrib/miniconda3/modulefiles
 module load miniconda3/4.5.12
 

--- a/modulefiles/wflow_hera
+++ b/modulefiles/wflow_hera
@@ -9,8 +9,10 @@ module-whatis "Loads libraries needed for running SRW on Hera"
 
 module load rocoto
 
-module use -a /contrib/miniconda3/modulefiles
-module load miniconda3
+module unload miniconda3
+
+module use /contrib/miniconda3/modulefiles
+module load miniconda3/4.5.12
 
 if { [module-info mode load] } {
   puts stderr "Please do the following to activate conda:


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Pin down the version of miniconda3 on Hera, and do not append to the module path. Addresses Issue #256.

## TESTS CONDUCTED: 
Command line tests for loading these modules were conducted.

## ISSUE: 
Addresses Issue #256.

## CONTRIBUTORS: 
@JeffBeck-NOAA @danielabdi-noaa 
