### PR TITLE
fix for regional_workflow pointer

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,6 +1,6 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-EPIC/regional_workflow
+repo_url = https://github.com/ufs-community/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = develop
 hash = ef63cc0


### PR DESCRIPTION
Fixes pointer to regional_workflow which was mistakenly set to NOAA-EPIC.