### PR TITLE
Print usage if machine name is not passed to `lmod-setup.sh/csh`.

### DIFF
--- a/devbuild.sh
+++ b/devbuild.sh
@@ -163,7 +163,7 @@ if [ -z "${COMPILER}" ] ; then
     wcoss2) COMPILER=intel ;;
     cheyenne) COMPILER=intel ;;
     macos,singularity) COMPILER=gnu ;;
-    odin) COMPILER=intel ;;
+    odin,noaacloud) COMPILER=intel ;;
     *)
       COMPILER=intel
       printf "WARNING: Setting default COMPILER=intel for new platform ${PLATFORM}\n" >&2;
@@ -249,7 +249,7 @@ if [ "${VERBOSE}" = true ]; then
 fi
 
 # Before we go on load modules, we first need to activate Lmod for some systems
-source ${SRW_DIR}/etc/lmod-setup.sh
+source ${SRW_DIR}/etc/lmod-setup.sh $MACHINE
 
 # source the module file for this platform/compiler combination, then build the code
 printf "... Load MODULE_FILE and create BUILD directory ...\n"

--- a/docs/INSTALL
+++ b/docs/INSTALL
@@ -42,7 +42,7 @@ source etc/lmod-setup.sh PLATFORM
 # From here on, we can assume Lmod is loaded and ready to go. Then we load the specific
 # module for a given PLATFORM and COMPILER as follows
 
-module use modulefiles
+module use $PWD/modulefiles   #full path to modulefiles directory
 module load build_[PLATFORM]_[COMPILER]
 
 # Supported CMake flags:

--- a/etc/lmod-setup.csh
+++ b/etc/lmod-setup.csh
@@ -1,7 +1,14 @@
 #!/bin/csh
 
 if ( $# == 0 ) then
-   set L_MACHINE=${MACHINE}
+   cat << EOF_USAGE
+Usage: source etc/lmod-setup.csh PLATFORM
+
+OPTIONS:
+   PLATFORM - name of machine you are building on
+      (e.g. cheyenne | hera | jet | orion | wcoss_dell_p3)
+EOF_USAGE
+   exit 1
 else
    set L_MACHINE=$1
 endif

--- a/etc/lmod-setup.sh
+++ b/etc/lmod-setup.sh
@@ -2,6 +2,14 @@
 
 if [ $# = 0 ]; then
    L_MACHINE=${MACHINE}
+   cat << EOF_USAGE
+Usage: source etc/lmod-setup.sh PLATFORM
+
+OPTIONS:
+   PLATFORM - name of machine you are building on
+      (e.g. cheyenne | hera | jet | orion | wcoss_dell_p3)
+EOF_USAGE
+   exit 1
 else
    L_MACHINE=$1
 fi

--- a/modulefiles/build_macos_gnu
+++ b/modulefiles/build_macos_gnu
@@ -8,7 +8,7 @@ proc ModulesHelp { } {
 module-whatis "Loads libraries needed for building SRW on Hera"
 
 if { [module-info mode load] } {
-   system "ulimit -S -s unlimited;"
+   puts "ulimit -S -s unlimited;"
 }
 
 # This path should point to your HPCstack installation directory
@@ -79,5 +79,15 @@ setenv CMAKE_Fortran_COMPILER $env(MPI_FC)
 setenv CMAKE_Platform macos.gnu
 
 setenv CMAKE_Fortran_COMPILER_ID "GNU"
-setenv LDFLAGS "-L$env(MPI_ROOT)/lib"
 setenv FFLAGS "-DNO_QUAD_PRECISION -fallow-argument-mismatch "
+
+#leave setting LDFLAGS to user because MPI_ROOT does not have
+#valid value before this modulefile is fully loaded.
+set shell [module-info shelltype]
+if {$shell == "sh"} {
+   puts stderr {Please execute this command:
+        > export LDFLAGS=-L$MPI_ROOT/lib}
+} else {
+   puts stderr {Please execute this command:
+        > setenv LDFLAGS -L$MPI_ROOT/lib}
+}

--- a/modulefiles/wflow_macos
+++ b/modulefiles/wflow_macos
@@ -14,7 +14,10 @@ setenv CMAKE_Platform macos
 # 
 setenv VENV "/Users/username/venv/regional_workflow"
 if { [module-info mode load] } {
-   system "source $env(VENV)/bin/activate;"
+   puts "source $env(VENV)/bin/activate;"
+}
+if { [module-info mode remove] } {
+   puts "deactivate;"
 }
 
 # Uncomment if Rocoto workflow manager is used

--- a/test/build.sh
+++ b/test/build.sh
@@ -21,7 +21,7 @@ function usage() {
   exit 1
 }
 
-machines=( hera jet cheyenne orion wcoss_cray wcoss_dell_p3 gaea odin singularity )
+machines=( hera jet cheyenne orion wcoss2 wcoss_dell_p3 gaea odin singularity macos noaacloud )
 
 [[ $# -eq 2 ]] && usage
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

- Adds usage message to `etc/lmod-setup` to avoid confusion with passing machine name.
- Adds some missing platform names in `devbuild.sh` and `test/build.sh`
- Bug fixes for macos modulefiles

## TESTS CONDUCTED: 
Confirmed build works on Hera.

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE (optional): 
None

## CONTRIBUTORS (optional): 
@natalie-perlin 

