### PR TITLE
Port SRW App to WCOSS2

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -12,7 +12,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/UFS_UTILS
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 31271f7
+hash = b6efa86
 local_path = src/UFS_UTILS
 required = True
 
@@ -30,7 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 394917e
+hash = fbd41a5
 local_path = src/UPP
 required = True
 

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -10,7 +10,7 @@ OPTIONS
       show this help guide
   -p, --platform=PLATFORM
       name of machine you are building on
-      (e.g. cheyenne | hera | jet | orion | wcoss_dell_p3)
+      (e.g. cheyenne | hera | jet | orion | wcoss_dell_p3 | wcoss2)
   -c, --compiler=COMPILER
       compiler to use; default depends on platform
       (e.g. intel | gnu | cray | gccgfortran)
@@ -155,6 +155,7 @@ if [ -z "${COMPILER}" ] ; then
     jet|hera|gaea) COMPILER=intel ;;
     orion) COMPILER=intel ;;
     wcoss_dell_p3) COMPILER=intel ;;
+    wcoss2) COMPILER=intel ;;
     cheyenne) COMPILER=intel ;;
     macos,singularity) COMPILER=gnu ;;
     odin) COMPILER=intel ;;

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -136,6 +136,12 @@ while :; do
   shift
 done
 
+# Ensure platform name from variance ======================================
+if [[ "${PLATFORM}" == "wcoss2" || "${PLATFORM}" == "cactus" ||
+      "${PLATFORM}" == "dogwood" ]]; then
+  PLATFORM="wcoss2"
+fi
+
 # check if PLATFORM is set
 if [ -z $PLATFORM ] ; then
   printf "\nERROR: Please set PLATFORM.\n\n"

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -136,12 +136,6 @@ while :; do
   shift
 done
 
-# Ensure platform name from variance ======================================
-if [[ "${PLATFORM}" == "wcoss2" || "${PLATFORM}" == "cactus" ||
-      "${PLATFORM}" == "dogwood" ]]; then
-  PLATFORM="wcoss2"
-fi
-
 # check if PLATFORM is set
 if [ -z $PLATFORM ] ; then
   printf "\nERROR: Please set PLATFORM.\n\n"

--- a/etc/lmod-setup.csh
+++ b/etc/lmod-setup.csh
@@ -35,8 +35,7 @@ else if ( "$L_MACHINE" == odin ) then
    setenv MODULEPATH "/oldscratch/ywang/external/hpc-stack/modulefiles/mpi/intel/2020/cray-mpich/7.7.16:/oldscratch/ywang/external/hpc-stack/modulefiles/compiler/intel/2020:/oldscratch/ywang/external/hpc-stack/modulefiles/core:/oldscratch/ywang/external/hpc-stack/modulefiles/stack:/opt/cray/pe/perftools/21.02.0/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/craype-targets/default/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles"
 
 else if ( "$L_MACHINE" == wcoss2 ) then
-   module purge
-   module load envvar/1.0
+   module reset
 
 else
    module purge

--- a/etc/lmod-setup.csh
+++ b/etc/lmod-setup.csh
@@ -34,6 +34,10 @@ else if ( "$L_MACHINE" == odin ) then
    module --initial_load --no_redirect restore
    setenv MODULEPATH "/oldscratch/ywang/external/hpc-stack/modulefiles/mpi/intel/2020/cray-mpich/7.7.16:/oldscratch/ywang/external/hpc-stack/modulefiles/compiler/intel/2020:/oldscratch/ywang/external/hpc-stack/modulefiles/core:/oldscratch/ywang/external/hpc-stack/modulefiles/stack:/opt/cray/pe/perftools/21.02.0/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/craype-targets/default/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles"
 
+else if ( "$L_MACHINE" == wcoss2 ) then
+   module purge
+   module load envvar/1.0
+
 else
    module purge
 endif

--- a/etc/lmod-setup.csh
+++ b/etc/lmod-setup.csh
@@ -34,9 +34,6 @@ else if ( "$L_MACHINE" == odin ) then
    module --initial_load --no_redirect restore
    setenv MODULEPATH "/oldscratch/ywang/external/hpc-stack/modulefiles/mpi/intel/2020/cray-mpich/7.7.16:/oldscratch/ywang/external/hpc-stack/modulefiles/compiler/intel/2020:/oldscratch/ywang/external/hpc-stack/modulefiles/core:/oldscratch/ywang/external/hpc-stack/modulefiles/stack:/opt/cray/pe/perftools/21.02.0/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/craype-targets/default/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles"
 
-else if ( "$L_MACHINE" == wcoss2 ) then
-   module reset
-
 else
    module purge
 endif

--- a/etc/lmod-setup.sh
+++ b/etc/lmod-setup.sh
@@ -36,10 +36,8 @@ elif [ "$L_MACHINE" = odin ]; then
    export MODULEPATH="/oldscratch/ywang/external/hpc-stack/modulefiles/mpi/intel/2020/cray-mpich/7.7.16:/oldscratch/ywang/external/hpc-stack/modulefiles/compiler/intel/2020:/oldscratch/ywang/external/hpc-stack/modulefiles/core:/oldscratch/ywang/external/hpc-stack/modulefiles/stack:/opt/cray/pe/perftools/21.02.0/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/craype-targets/default/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles"
 
 elif [ "$L_MACHINE" = wcoss2 ]; then
-   module purge
-   module load envvar/1.0
+   module reset
 
 else
    module purge
 fi
-

--- a/etc/lmod-setup.sh
+++ b/etc/lmod-setup.sh
@@ -35,9 +35,6 @@ elif [ "$L_MACHINE" = odin ]; then
    module --initial_load --no_redirect restore
    export MODULEPATH="/oldscratch/ywang/external/hpc-stack/modulefiles/mpi/intel/2020/cray-mpich/7.7.16:/oldscratch/ywang/external/hpc-stack/modulefiles/compiler/intel/2020:/oldscratch/ywang/external/hpc-stack/modulefiles/core:/oldscratch/ywang/external/hpc-stack/modulefiles/stack:/opt/cray/pe/perftools/21.02.0/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/craype-targets/default/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles"
 
-elif [ "$L_MACHINE" = wcoss2 ]; then
-   module reset
-
 else
    module purge
 fi

--- a/etc/lmod-setup.sh
+++ b/etc/lmod-setup.sh
@@ -35,6 +35,10 @@ elif [ "$L_MACHINE" = odin ]; then
    module --initial_load --no_redirect restore
    export MODULEPATH="/oldscratch/ywang/external/hpc-stack/modulefiles/mpi/intel/2020/cray-mpich/7.7.16:/oldscratch/ywang/external/hpc-stack/modulefiles/compiler/intel/2020:/oldscratch/ywang/external/hpc-stack/modulefiles/core:/oldscratch/ywang/external/hpc-stack/modulefiles/stack:/opt/cray/pe/perftools/21.02.0/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/craype-targets/default/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles"
 
+elif [ "$L_MACHINE" = wcoss2 ]; then
+   module purge
+   module load envvar/1.0
+
 else
    module purge
 fi

--- a/modulefiles/build_wcoss2_intel
+++ b/modulefiles/build_wcoss2_intel
@@ -35,7 +35,7 @@ module load sp/2.3.3
 module load w3nco/2.4.1
 
 module load libjpeg/9c
-module load cray_pals/1.0.12
+module load cray-pals/1.1.3
 
 module load w3emc/2.9.2
 module load nemsio/2.5.2

--- a/modulefiles/build_wcoss2_intel
+++ b/modulefiles/build_wcoss2_intel
@@ -1,0 +1,49 @@
+#%Module
+
+proc ModulesHelp { } {
+   puts stderr "This module loads libraries for building SRW on"
+   puts stderr "the NOAA WCOSS2 machine using Intel-19.1.3.304"
+}
+
+module-whatis "Loads libraries needed for building SRW on WCOSS2 (Cactus/Dogwood)"
+
+module load PrgEnv-intel/8.1.0
+module load intel/19.1.3.304
+module load craype/2.7.13
+module load cray-mpich/8.1.7
+
+module load cmake/3.20.2
+
+setenv HPC_OPT /apps/ops/para/libs
+module use /apps/ops/para/libs/modulefiles/compiler/intel/19.1.3.304
+module use /apps/ops/para/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.7
+
+module load jasper/2.0.25
+module load zlib/1.2.11
+module load libpng/1.6.37
+module load hdf5/1.10.6
+module load netcdf/4.7.4
+module load pio/2.5.2
+module load esmf/8.3.0b09
+module load fms/2022.01
+module load bacio/2.4.1
+module load crtm/2.3.0
+module load g2/3.4.5
+module load g2tmpl/1.10.0
+module load ip/3.3.3
+module load sp/2.3.3
+module load w3nco/2.4.1
+
+module load libjpeg/9c
+module load cray_pals/1.0.12
+
+module load w3emc/2.9.2
+module load nemsio/2.5.2
+module load sigio/2.3.2
+module load sfcio/1.4.1
+module load wrf_io/1.2.0
+
+setenv CMAKE_C_COMPILER cc
+setenv CMAKE_CXX_COMPILER CC
+setenv CMAKE_Fortran_COMPILER ftn
+setenv CMAKE_Platform wcoss2

--- a/modulefiles/build_wcoss2_intel
+++ b/modulefiles/build_wcoss2_intel
@@ -7,6 +7,8 @@ proc ModulesHelp { } {
 
 module-whatis "Loads libraries needed for building SRW on WCOSS2 (Cactus/Dogwood)"
 
+module load envvar/1.0
+
 module load PrgEnv-intel/8.1.0
 module load intel/19.1.3.304
 module load craype/2.7.13


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Port UFS SRW App to WCOSS2
- Since HPC-stack is not available on WCOSS2 yet, this is a temporary module file.
- work with the latest hashes of UFS_UTILS and UPP (shown in PR #266)

## TESTS CONDUCTED: 
- Tested hashes:
UFS_UTILS: b6efa86
ufs weather model: 96dffa1
UPP: fbd41a5

- Build steps:
1. git clone -b feature/wcoss2 https://github.com/chan-hoo/ufs-srweather-app
2. cd ufs-srweather-app
3. ./manage_externals/checkout_externals
4. ./devbuild.sh --platform=wcoss2

## ISSUE: 
Fixes issue mentioned in #249

## CONTRIBUTORS: 
@BenjaminBlake-NOAA 
