### PR TITLE
added noaacloud to devbuild options [ci skip]

### DIFF
--- a/devbuild.sh
+++ b/devbuild.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
-set -x
+
 # usage instructions
 usage () {
 cat << EOF_USAGE

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-
+#!/bin/bash 
+set -x
 # usage instructions
 usage () {
 cat << EOF_USAGE
@@ -8,10 +8,10 @@ Usage: $0 --platform=PLATFORM [OPTIONS]...
 OPTIONS
   -h, --help
       show this help guide
-  --platform=PLATFORM
+  -p, --platform=PLATFORM
       name of machine you are building on
       (e.g. cheyenne | hera | jet | orion | wcoss_dell_p3)
-  --compiler=COMPILER
+  -c, --compiler=COMPILER
       compiler to use; default depends on platform
       (e.g. intel | gnu | cray | gccgfortran)
   --app=APPLICATION
@@ -104,10 +104,10 @@ fi
 while :; do
   case $1 in
     --help|-h) usage; exit 0 ;;
-    --platform=?*) PLATFORM=${1#*=} ;;
-    --platform|--platform=) usage_error "$1 requires argument." ;;
-    --compiler=?*) COMPILER=${1#*=} ;;
-    --compiler|--compiler=) usage_error "$1 requires argument." ;;
+    --platform=?*|-p=?*) PLATFORM=${1#*=} ;;
+    --platform|--platform=|-p|-p=) usage_error "$1 requires argument." ;;
+    --compiler=?*|-c=?*) COMPILER=${1#*=} ;;
+    --compiler|--compiler=|-c|-c=) usage_error "$1 requires argument." ;;
     --app=?*) APPLICATION=${1#*=} ;;
     --app|--app=) usage_error "$1 requires argument." ;;
     --ccpp=?*) CCPP=${1#*=} ;;
@@ -153,7 +153,7 @@ set -eu
 if [ -z "${COMPILER}" ] ; then
   case ${PLATFORM} in
     jet|hera|gaea) COMPILER=intel ;;
-    orion) COMPILER=intel ;;
+    orion|noaacloud) COMPILER=intel ;;
     wcoss_dell_p3) COMPILER=intel ;;
     cheyenne) COMPILER=intel ;;
     macos,singularity) COMPILER=gnu ;;

--- a/etc/lmod-setup.csh
+++ b/etc/lmod-setup.csh
@@ -19,8 +19,14 @@ else if ( "$L_MACHINE" == singularity ) then
 
    module purge
 
+else if ( "$L_MACHINE" == noaacloud ) then
+   set ENV="/usr/share/lmod/lmod/init/csh"
+   source $ENV
+
+   module purge
+
 else if ( "$L_MACHINE" == gaea ) then
-   set ENV="/lustre/f2/pdata/esrl/gsd/contrib/lua-5.1.4.9/init/init_lmod.csh"
+   set ENV="/lustre/f2/pdata/esrl/gsd/contrib/lua-5.1.4.9/lmod/lmod/init/csh"
    source $ENV
 
 else if ( "$L_MACHINE" == odin ) then

--- a/etc/lmod-setup.sh
+++ b/etc/lmod-setup.sh
@@ -13,6 +13,11 @@ if [ "$L_MACHINE" = macos ]; then
 
    module purge
 
+elif [ "$L_MACHINE" = noaacloud ]; then
+   export BASH_ENV="/usr/share/lmod/lmod/init/bash"
+   source $BASH_ENV
+
+   module purge
 elif [ "$L_MACHINE" = singularity ]; then
    export BASH_ENV="/usr/share/lmod/lmod/init/bash"
    source $BASH_ENV
@@ -20,8 +25,9 @@ elif [ "$L_MACHINE" = singularity ]; then
    module purge
 
 elif [ "$L_MACHINE" = gaea ]; then
-   export BASH_ENV="/lustre/f2/pdata/esrl/gsd/contrib/lua-5.1.4.9/init/init_lmod.sh"
+   export BASH_ENV="/lustre/f2/pdata/esrl/gsd/contrib/lua-5.1.4.9/lmod/lmod/init/bash"
    source $BASH_ENV
+   module purge
 
 elif [ "$L_MACHINE" = odin ]; then
    module unload modules


### PR DESCRIPTION
This fix adds "noaacloud" as a supported platform for the devbuild.sh script. It also adds "noaacloud" specifically as a platform to the etc/setup_lmod.* scripts.

Builds complete successfully under both bash and csh shells.