### PR TITLE
Fix artifact creation for branches with / in name

### DIFF
--- a/.cicd/Jenkinsfile
+++ b/.cicd/Jenkinsfile
@@ -98,7 +98,8 @@ pipeline {
                 }
 
                 environment {
-                    BUILD_VERSION = "${env.SRW_PLATFORM}-${env.SRW_COMPILER}-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
+                    BRANCH_NAME_ESCAPED = env.BRANCH_NAME.replace('/', '_')
+                    BUILD_VERSION = "${env.SRW_PLATFORM}-${env.SRW_COMPILER}-${env.BRANCH_NAME_ESCAPED}-${env.BUILD_NUMBER}"
                     BUILD_NAME = "ufs-srweather-app_${env.BUILD_VERSION}"
                 }
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

The slash in branch names such as release/.* and feature/.* is
interpreted as a directory separator. This change replaces the "/"
character with a "_".

## TESTS CONDUCTED: 
A successful Jenkins pipeline run.