### PR TITLE
Fix --ccpp option in devbuild.sh

### DIFF
--- a/devbuild.sh
+++ b/devbuild.sh
@@ -14,11 +14,11 @@ OPTIONS
   -c, --compiler=COMPILER
       compiler to use; default depends on platform
       (e.g. intel | gnu | cray | gccgfortran)
-  --app=APPLICATION
+  -a, --app=APPLICATION
       weather model application to build
       (e.g. ATM | ATMW | S2S | S2SW)
   --ccpp="CCPP_SUITE1,CCPP_SUITE2..."
-      CCCP suites to include in build; delimited with ','
+      CCPP suites (CCPP_SUITES) to include in build; delimited with ','
   --enable-options="OPTION1,OPTION2,..."
       enable ufs-weather-model options; delimited with ','
       (e.g. 32BIT | INLINE_POST | UFS_GOCART | MOM6 | CICE6 | WW3 | CMEPS)
@@ -52,13 +52,13 @@ settings () {
 cat << EOF_SETTINGS
 Settings:
 
-  SRC_DIR=${SRC_DIR}
+  SRW_DIR=${SRW_DIR}
   BUILD_DIR=${BUILD_DIR}
   INSTALL_DIR=${INSTALL_DIR}
   PLATFORM=${PLATFORM}
   COMPILER=${COMPILER}
   APP=${APPLICATION}
-  CCPP=${CCPP}
+  CCPP=${CCPP_SUITES}
   ENABLE_OPTIONS=${ENABLE_OPTIONS}
   DISABLE_OPTIONS=${DISABLE_OPTIONS}
   CLEAN=${CLEAN}
@@ -79,13 +79,13 @@ usage_error () {
 
 # default settings
 LCL_PID=$$
-SRC_DIR=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
-MACHINE_SETUP=${SRC_DIR}/src/UFS_UTILS/sorc/machine-setup.sh
-BUILD_DIR=${SRC_DIR}/build
-INSTALL_DIR=${SRC_DIR}
+SRW_DIR=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
+MACHINE_SETUP=${SRW_DIR}/src/UFS_UTILS/sorc/machine-setup.sh
+BUILD_DIR="${SRW_DIR}/build"
+INSTALL_DIR=${SRW_DIR}
 COMPILER=""
 APPLICATION=""
-CCPP=""
+CCPP_SUITES=""
 ENABLE_OPTIONS=""
 DISABLE_OPTIONS=""
 BUILD_TYPE="RELEASE"
@@ -108,9 +108,9 @@ while :; do
     --platform|--platform=|-p|-p=) usage_error "$1 requires argument." ;;
     --compiler=?*|-c=?*) COMPILER=${1#*=} ;;
     --compiler|--compiler=|-c|-c=) usage_error "$1 requires argument." ;;
-    --app=?*) APPLICATION=${1#*=} ;;
-    --app|--app=) usage_error "$1 requires argument." ;;
-    --ccpp=?*) CCPP=${1#*=} ;;
+    --app=?*|-a=?*) APPLICATION=${1#*=} ;;
+    --app|--app=|-a|-a=) usage_error "$1 requires argument." ;;
+    --ccpp=?*) CCPP_SUITES=${1#*=} ;;
     --ccpp|--ccpp=) usage_error "$1 requires argument." ;;
     --enable-options=?*) ENABLE_OPTIONS=${1#*=} ;;
     --enable-options|--enable-options=) usage_error "$1 requires argument." ;;
@@ -135,6 +135,17 @@ while :; do
   esac
   shift
 done
+
+# Ensure uppercase / lowercase ============================================
+APPLICATION="${APPLICATION^^}"
+PLATFORM="${PLATFORM,,}"
+COMPILER="${COMPILER,,}"
+
+# Ensure platform name from variance ======================================
+if [[ "${PLATFORM}" == "wcoss2" || "${PLATFORM}" == "cactus" ||
+      "${PLATFORM}" == "dogwood" ]]; then
+  PLATFORM="wcoss2"
+fi
 
 # check if PLATFORM is set
 if [ -z $PLATFORM ] ; then
@@ -174,7 +185,7 @@ fi
 
 # set MODULE_FILE for this platform/compiler combination
 MODULE_FILE="build_${PLATFORM}_${COMPILER}"
-if [ ! -f "${SRC_DIR}/modulefiles/${MODULE_FILE}" ]; then
+if [ ! -f "${SRW_DIR}/modulefiles/${MODULE_FILE}" ]; then
   printf "ERROR: module file does not exist for platform/compiler\n" >&2
   printf "  MODULE_FILE=${MODULE_FILE}\n" >&2
   printf "  PLATFORM=${PLATFORM}\n" >&2
@@ -226,8 +237,8 @@ CMAKE_SETTINGS="${CMAKE_SETTINGS} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}"
 if [ ! -z "${APPLICATION}" ]; then
   CMAKE_SETTINGS="${CMAKE_SETTINGS} -DAPP=${APPLICATION}"
 fi
-if [ ! -z "${CCPP}" ]; then
-  CMAKE_SETTINGS="${CMAKE_SETTINGS} -DCCPP=${CCPP}"
+if [ ! -z "${CCPP_SUITES}" ]; then
+  CMAKE_SETTINGS="${CMAKE_SETTINGS} -DCCPP_SUITES=${CCPP_SUITES}"
 fi
 if [ ! -z "${ENABLE_OPTIONS}" ]; then
   CMAKE_SETTINGS="${CMAKE_SETTINGS} -DENABLE_OPTIONS=${ENABLE_OPTIONS}"
@@ -243,17 +254,17 @@ if [ "${VERBOSE}" = true ]; then
 fi
 
 # Before we go on load modules, we first need to activate Lmod for some systems
-source ${SRC_DIR}/etc/lmod-setup.sh
+source ${SRW_DIR}/etc/lmod-setup.sh
 
 # source the module file for this platform/compiler combination, then build the code
 printf "... Load MODULE_FILE and create BUILD directory ...\n"
-module use ${SRC_DIR}/modulefiles
+module use ${SRW_DIR}/modulefiles
 module load ${MODULE_FILE}
 module list
 mkdir -p ${BUILD_DIR}
 cd ${BUILD_DIR}
 printf "... Generate CMAKE configuration ...\n"
-cmake ${SRC_DIR} ${CMAKE_SETTINGS} 2>&1 | tee log.cmake
+cmake ${SRW_DIR} ${CMAKE_SETTINGS} 2>&1 | tee log.cmake
 printf "... Compile executables ...\n"
 make ${MAKE_SETTINGS} 2>&1 | tee log.make
 

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -141,12 +141,6 @@ APPLICATION="${APPLICATION^^}"
 PLATFORM="${PLATFORM,,}"
 COMPILER="${COMPILER,,}"
 
-# Ensure platform name from variance ======================================
-if [[ "${PLATFORM}" == "wcoss2" || "${PLATFORM}" == "cactus" ||
-      "${PLATFORM}" == "dogwood" ]]; then
-  PLATFORM="wcoss2"
-fi
-
 # check if PLATFORM is set
 if [ -z $PLATFORM ] ; then
   printf "\nERROR: Please set PLATFORM.\n\n"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Fix the issue on the `--ccpp` option in `devbuild.sh`.

## TESTS CONDUCTED: 
- build test:

./devbuild.sh -p=hera --ccpp="FV3_GFS_v16"
=> `Calling CCPP code generator (ccpp_prebuild.py) for suites --suites=FV3_GFS_v16 ...`

./devbuild.sh -p=hera
=> `Calling CCPP code generator (ccpp_prebuild.py) for suites --suites=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha,FV3_GFS_v15_thompson_mynn_lam3km ...`

- WE2E test:
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16

## ISSUE: 
Fixes issue mentioned in #279 

