### PR TITLE
Update wflow_jet

### DIFF
--- a/modulefiles/wflow_jet
+++ b/modulefiles/wflow_jet
@@ -9,8 +9,8 @@ module-whatis "Loads libraries needed for running SRW on Jet"
 
 module load rocoto
 
-module use -a /contrib/miniconda3/modulefiles
-module load miniconda3
+module use /contrib/miniconda3/modulefiles
+module load miniconda3/4.5.12
 
 if { [module-info mode load] } {
   puts stderr "Please do the following to activate conda:


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:
Fixed the issue on running the SRW on Jet: load a specific version of `miniconda3/4.5.12` from /contrib/, which was used to create a conda environment "`regional_workflow`". This prevents loading the default miniconda3 module from the hpc-stack on Jet in /lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/core/miniconda3/ (default -> 4.6.14.lua)

TESTS CONDUCTED:
Tests conducted through Jenkins using the PR#286. 
Tests through Jenkins were successful:
[Jenkins-build-srw-jet-intel](https://jenkins-epic.woc.noaa.gov/job/ufs-srweather-app/job/srw-build-intel/124/consoleFull)

[Jenkins-srw-e2e-tests](https://jenkins-epic.woc.noaa.gov/job/ufs-srweather-app/job/srw-e2e-launch/135/consoleFull)

ISSUE (optional):
There were problems with running SRW tests on Jet after the recent HPC-stack update, with miniconda3 module becoming available in the hpc-stack build, as well as in /contrib/miniconda3/modulefiles.

## CONTRIBUTORS (optional): 
@mark-a-potts @BruceKropp-Raytheon