### PR TITLE
Update Spack Stack Location for NOAA Cloud

### DIFF
--- a/modulefiles/build_noaacloud_intel
+++ b/modulefiles/build_noaacloud_intel
@@ -6,7 +6,7 @@ proc ModulesHelp { } {
 }
 
 module purge
-module use /contrib/spack-stack/apps/srw-app-test/modulefiles/Core
+module use /contrib/spack/apps/ufs-srw-public-v2/modulefiles/Core
 module load stack-intel
 module load stack-intel-oneapi-mpi
 module load cmake/3.22.1 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update Spack Stack location in the NOAA Cloud build file.

## TESTS CONDUCTED: 
Ran the comprehensive suite of tests on AWS through Jenkins successfully. More work is needed to setup Azure and GCP with Jenkins. As a result, I ran a single E2E test on Azure and GCP manually. Both of these tests were successful.

## DEPENDENCIES:
None.

## DOCUMENTATION:
No updates.

## ISSUE (optional): 

## CONTRIBUTORS (optional): 
@kgerheiser who updated the Spack HPC-Stack on NOAA Cloud.

