### PR TITLE
Orion test with intel2022 esmf-8.3.0

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,8 +2,8 @@
 protocol = git
 repo_url = https://github.com/ufs-community/regional_workflow
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = de82b63
+branch = release/public-v2
+#hash = de82b63
 local_path = regional_workflow
 required = True
 
@@ -11,8 +11,8 @@ required = True
 protocol = git
 repo_url = https://github.com/ufs-community/UFS_UTILS
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = 31271f7
+branch = develop
+#hash = 31271f7
 local_path = src/UFS_UTILS
 required = True
 
@@ -20,8 +20,8 @@ required = True
 protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = 96dffa1
+branch = develop
+#hash = 96dffa1
 local_path = src/ufs-weather-model
 required = True
 
@@ -29,8 +29,8 @@ required = True
 protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = 394917e
+branch = develop
+#hash = 394917e
 local_path = src/UPP
 required = True
 

--- a/modulefiles/build_hera_intel
+++ b/modulefiles/build_hera_intel
@@ -8,23 +8,27 @@ proc ModulesHelp { } {
 module-whatis "Loads libraries needed for building SRW on Hera"
 
 module use /scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles
-module load miniconda3/3.7.3
 
 module use /contrib/sutils/modulefiles
 module load sutils
 
+module load intel/2022.1.2
+module load impi/2022.1.2
 module load cmake/3.20.1
 
-module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack
+module use /scratch1/NCEPDEV/stmp2/Natalie.Perlin/HPC-stack/install-1.2.0_intel2022/modulefiles/stack
 
-module load hpc/1.1.0
-module load hpc-intel/18.0.5.274
-module load hpc-impi/2018.0.4
 
+module load hpc/1.2.0
+module load hpc-intel/2022.1.2
+module load hpc-impi/2022.1.2
+#module load intelpython/2022.1.2
+
+module use /scratch1/NCEPDEV/stmp2/Natalie.Perlin/SRW/ufs-srweather-app/modulefiles
 module load srw_common
 
-module unload fms
-module load fms/2021.03-avx
+#module unload fms
+#module load fms/2021.03-avx
 
 setenv CMAKE_C_COMPILER mpiicc
 setenv CMAKE_CXX_COMPILER mpiicpc

--- a/modulefiles/build_orion_intel
+++ b/modulefiles/build_orion_intel
@@ -11,14 +11,25 @@ module load contrib noaatools
 
 module load cmake/3.22.1
 module load python/3.9.2
+module load intel/2022.1.2
+module load impi/2022.1.2
 
-module use /apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack
+module use /work/noaa/epic-ps/nperlin/HPC-stack/install-1.2.0_intel2022/modulefiles/stack
 
-module load hpc/1.1.0
-module load hpc-intel/2018.4
-module load hpc-impi/2018.4
+module load hpc/1.2.0
+module load hpc-intel/2022.1.2
+module load hpc-impi/2022.1.2
 
+module use /work/noaa/epic-ps/nperlin/SRW/ufs-srweather-app/modulefiles
 module load srw_common
+
+setenv CC mpiicc
+setenv CXX mpiicpc
+setenv FC mpiifort
+
+setenv MPI_CC mpiicc
+setenv MPI_CXX mpiicpc
+setenv MPI_FC mpiifort
 
 setenv CMAKE_C_COMPILER mpiicc
 setenv CMAKE_CXX_COMPILER mpiicpc

--- a/modulefiles/srw_common
+++ b/modulefiles/srw_common
@@ -19,7 +19,7 @@ module load sp/2.3.3
 module load w3nco/2.4.1
 module load upp/10.0.10
 
-module load shared/1.3.3
+module load gftl-shared/1.3.3
 module load yafyaml/0.5.1
 module load mapl/2.11.0-esmf-8.3.0
 

--- a/modulefiles/srw_common
+++ b/modulefiles/srw_common
@@ -2,33 +2,32 @@
 
 module load jasper/2.0.25
 module load zlib/1.2.11
-module load-any png/1.6.35 libpng/1.6.35
+module load png/1.6.35 
 
 module load hdf5/1.10.6
-module load-any netcdf/4.7.4 netcdf-c/4.7.4
-module load-any netcdf/4.7.4 netcdf-fortran/4.5.4
-module load-any pio/2.5.2 parallelio/2.5.2
-module load-any esmf/8_2_0 esmf/8.2.0
-module load fms/2021.03
+module load netcdf/4.7.4 
+module load pio/2.5.3 
+module load esmf/8.3.0
+module load fms/2022.01
 
 module load bacio/2.4.1
 module load crtm/2.3.0
-module load g2/3.4.3
+module load g2/3.4.5
 module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load sp/2.3.3
 module load w3nco/2.4.1
 module load upp/10.0.10
 
-module load-any gftl-shared/v1.3.3 gftl-shared/1.3.3
-module load-any yafyaml/v0.5.1 yafyaml/0.5.1
-module load-any mapl/2.11.0-esmf-8_2_0 mapl/2.11.0-esmf-8.2.0
+module load shared/1.3.3
+module load yafyaml/0.5.1
+module load mapl/2.11.0-esmf-8.3.0
 
 module load gfsio/1.4.1
 module load landsfcutil/2.4.1
-module load nemsio/2.5.2
+module load nemsio/2.5.4
 module load nemsiogfs/2.5.3
 module load sfcio/1.4.1
 module load sigio/2.3.2
-module load w3emc/2.7.3
+module load w3emc/2.9.2
 module load wgrib2/2.0.8


### PR DESCRIPTION
DO NOT MERGE - FOR TESTING PURPOSES ONLY!

## DESCRIPTION OF CHANGES: 
Build configured for Orion with intel/2022.1.2 and impi/2022.1.2 and a temporary hpc-stack build with esmf-8.3.0, mapl/2.11.0, w3emc/2.9.2, using these compilers. PR is made to enable automatic testing using Jenkins.

## TESTS CONDUCTED: 
HPC-stack build on Hera and Orion in a temporary location, for basic testing of SRW functionality with intel/2022 build and esmf-8.3.0.
Location of the build as of June 8, 2022:
/work/noaa/epic-ps/nperlin/HPC-stack/install-1.2.0_intel2022


## ISSUE (optional): 
ufs-community/ufs-weather-model needs an ESMF version higher than 8.2.0, which is a module listed in srw_common for the SRW develop branch


