### PR TITLE
Release/public v2 - ufs-WM 

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,9 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/ufs-community/regional_workflow
+repo_url = https://github.com/NOAA-EPIC/regional_workflow
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = de82b63
+branch = feature/hera-fix
+#hash = de82b63
 local_path = regional_workflow
 required = True
 
@@ -20,8 +20,8 @@ required = True
 protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = 96dffa1
+branch = release/public-v3-SRW
+#hash = 96dffa1
 local_path = src/ufs-weather-model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -20,7 +20,7 @@ required = True
 protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
-branch = release/public-v3-SRW
+branch = release-public-v3-SRW
 #hash = 96dffa1
 local_path = src/ufs-weather-model
 required = True

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -10,7 +10,7 @@ OPTIONS
       show this help guide
   -p, --platform=PLATFORM
       name of machine you are building on
-      (e.g. cheyenne | hera | jet | orion | wcoss_dell_p3)
+      (e.g. cheyenne | hera | jet | orion | gaea | noaacloud | macos | linux )
   -c, --compiler=COMPILER
       compiler to use; default depends on platform
       (e.g. intel | gnu | cray | gccgfortran)
@@ -154,9 +154,8 @@ if [ -z "${COMPILER}" ] ; then
   case ${PLATFORM} in
     jet|hera|gaea) COMPILER=intel ;;
     orion|noaacloud) COMPILER=intel ;;
-    wcoss_dell_p3) COMPILER=intel ;;
-    cheyenne) COMPILER=intel ;;
-    macos,singularity) COMPILER=gnu ;;
+    cheyenne,linux) COMPILER=intel ;;
+    macos,linux,singularity) COMPILER=gnu ;;
     odin) COMPILER=intel ;;
     *)
       COMPILER=intel
@@ -243,7 +242,7 @@ if [ "${VERBOSE}" = true ]; then
 fi
 
 # Before we go on load modules, we first need to activate Lmod for some systems
-source ${SRC_DIR}/etc/lmod-setup.sh
+source ${SRC_DIR}/etc/lmod-setup.sh ${PLATFORM}
 
 # source the module file for this platform/compiler combination, then build the code
 printf "... Load MODULE_FILE and create BUILD directory ...\n"

--- a/modulefiles/build_cheyenne_gnu
+++ b/modulefiles/build_cheyenne_gnu
@@ -2,29 +2,28 @@
 
 proc ModulesHelp { } {
    puts stderr "This module loads libraries for building SRW on"
-   puts stderr "the CISL Cheyenne machine using GNU"
+   puts stderr "the CISL Cheyenne machine using GNU compilers"
 }
 
 module-whatis "Loads libraries needed for building SRW on Cheyenne"
 
+module purge
 module load cmake/3.22.0
-module load ncarenv/1.3
-module load gnu/10.1.0
-module load mpt/2.22
-module load ncarcompilers/0.5.0
+module load gnu/11.2.0
+module load mpt/2.25
 module load python/3.7.9
-module unload netcdf
 
-module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.2.0/modulefiles/stack
+module use /glade/scratch/nperlin/HPC-stack/gnu11.2/install-1.2.0/modulefiles/stack
 module load hpc/1.2.0
-module load hpc-gnu/10.1.0
-module load hpc-mpt/2.22
+module load hpc-gnu/11.2.0
+module load hpc-mpt/2.25
 
 module load srw_common
 module load g2/3.4.3
-module load esmf/8_2_0
 module load netcdf/4.7.4
-module load png/1.6.35
+module load esmf/8.3.0b09
+module load mapl/2.11.0-esmf-8.3.0b09
+module load libpng/1.6.35
 module load pio/2.5.2
 
 setenv CMAKE_C_COMPILER mpicc

--- a/modulefiles/build_cheyenne_intel
+++ b/modulefiles/build_cheyenne_intel
@@ -11,7 +11,6 @@ module purge
 module load cmake/3.22.0
 module load intel/2022.1
 module load mpt/2.25
-module load python/3.7.9
 
 module use /glade/scratch/nperlin/HPC-stack/intel2022.1/install-1.2.0/modulefiles/stack
 module load hpc/1.2.0

--- a/modulefiles/build_cheyenne_intel
+++ b/modulefiles/build_cheyenne_intel
@@ -13,18 +13,18 @@ module load intel/2022.1
 module load mpt/2.25
 module load python/3.7.9
 
-module use /glade/work/epicufsrt/GMTB/tools/intel/2022.1/hpc-stack-v1.2.0_6eb6/modulefiles/stack
+module use /glade/scratch/nperlin/HPC-stack/intel2022.1/install-1.2.0/modulefiles/stack
 module load hpc/1.2.0
 module load hpc-intel/2022.1
 module load hpc-mpt/2.25
 
 module load srw_common
-module load g2/3.4.5
+module load g2/3.4.3
 module load esmf/8.3.0b09
 module load mapl/2.11.0-esmf-8.3.0b09
 module load netcdf/4.7.4
-module load libpng/1.6.37
-module load pio/2.5.3
+module load libpng/1.6.35
+module load pio/2.5.2
 
 setenv CMAKE_C_COMPILER mpicc
 setenv CMAKE_CXX_COMPILER mpixx

--- a/modulefiles/build_cheyenne_intel
+++ b/modulefiles/build_cheyenne_intel
@@ -2,33 +2,32 @@
 
 proc ModulesHelp { } {
    puts stderr "This module loads libraries for building SRW on"
-   puts stderr "the CISL Cheyenne machine using Intel-19.1.1"
+   puts stderr "the CISL Cheyenne machine using Intel-2022.1"
 }
 
 module-whatis "Loads libraries needed for building SRW on Cheyenne"
 
+module purge
 module load cmake/3.22.0
-module load ncarenv/1.3
-module load intel/2021.2
-module load mpt/2.22
-module load ncarcompilers/0.5.0
+module load intel/2022.1
+module load mpt/2.25
 module load python/3.7.9
-module unload netcdf
 
-module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.2.0/modulefiles/stack
+module use /glade/work/epicufsrt/GMTB/tools/intel/2022.1/hpc-stack-v1.2.0_6eb6/modulefiles/stack
 module load hpc/1.2.0
-module load hpc-intel/2021.2
-module load hpc-mpt/2.22
+module load hpc-intel/2022.1
+module load hpc-mpt/2.25
 
 module load srw_common
-module load g2/3.4.3
-module load esmf/8_2_0
+module load g2/3.4.5
+module load esmf/8.3.0b09
+module load mapl/2.11.0-esmf-8.3.0b09
 module load netcdf/4.7.4
-module load png/1.6.35
-module load pio/2.5.2
+module load libpng/1.6.37
+module load pio/2.5.3
 
 setenv CMAKE_C_COMPILER mpicc
-setenv CMAKE_CXX_COMPILER mpicxx
+setenv CMAKE_CXX_COMPILER mpixx
 setenv CMAKE_Fortran_COMPILER mpif90
 setenv CMAKE_Platform cheyenne.intel
 

--- a/modulefiles/srw_common
+++ b/modulefiles/srw_common
@@ -8,8 +8,8 @@ module load hdf5/1.10.6
 module load-any netcdf/4.7.4 netcdf-c/4.7.4
 module load-any netcdf/4.7.4 netcdf-fortran/4.5.4
 module load-any pio/2.5.2 parallelio/2.5.2
-module load-any esmf/8_2_0 esmf/8.2.0
-module load fms/2021.03
+module load esmf/8.3.0b09 
+module load fms/2021.04
 
 module load bacio/2.4.1
 module load crtm/2.3.0

--- a/modulefiles/wflow_cheyenne
+++ b/modulefiles/wflow_cheyenne
@@ -7,12 +7,12 @@ proc ModulesHelp { } {
 
 module-whatis "Loads libraries needed for running SRW on Cheyenne"
 
-module load ncarenv
 module use -a /glade/p/ral/jntp/UFS_SRW_app/modules/
 module load rocoto
+module load miniconda3/4.12.0
 
 if { [module-info mode load] } {
-  puts stderr "Please do the following to activate ncar_pylib:
-       > ncar_pylib /glade/p/ral/jntp/UFS_SRW_app/ncar_pylib/regional_workflow"
+  puts stderr "Please do the following to activate regional_workflow:
+       > conda activate regional_workflow"
 }
 


### PR DESCRIPTION
(may not need merging in its present form, uses local builds of the hpc-stack on cheyenne)
## DESCRIPTION OF CHANGES: 

1. Use repositories  branch/hash :
-  ufs-community/ufs-weather-model   branch=release-public-v3-SRW
-  NOAA-EPIC/regional_workflow  branch=feature/hera-fix
 - ufs-community/UFS_UTILS   hash = 31271f7
 - NOAA-EMC/UPP  hash = 1dbcb0c4  

2. Fixes for Cheyenne compilers and SRW builds

3. Temporary directory for the HPC-stack built to match the package versions required for the _ufs-weather-model_, as well as sync with other platforms

## TESTS CONDUCTED: 

HPC-stack built on Cheyenne for intel/2022:

    /glade/scratch/nperlin/HPC-stack/intel2022.1/install-1.2.0/
   
HPC-stack on Cheyenne- GNU11.2 build:
/glade/scratch/nperlin/HPC-stack/gnu11.2/install-1.2.0/

SRW app built successfully with both Intel/2022.1 and GNU11.2.

## ISSUE (optional): 
- This PR is resolving module dependence issues for cheyenne for intel/2022 and packages needed for SRW release/public-v2; 
Updates with the compilers and modules on Cheyenne are related to the PR#250

- ufs-weather-model branch release-public-v2-SRW is checked out during the SRW build 

## CONTRIBUTORS (optional): 
@mark-a-potts 
