### PR TITLE
[release/public-v2] Cleaning up modules and separating hpc-stack and spack-stack for srw_common

### DIFF
--- a/modulefiles/build_cheyenne_gnu
+++ b/modulefiles/build_cheyenne_gnu
@@ -8,11 +8,11 @@ proc ModulesHelp { } {
 module-whatis "Loads libraries needed for building SRW on Cheyenne"
 
 module load cmake/3.22.0
+module load python/3.7.9
 module load ncarenv/1.3
 module load gnu/11.2.0
 module load mpt/2.25
 module load ncarcompilers/0.5.0
-module load python/3.7.9
 module unload netcdf
 
 module use /glade/work/epicufsrt/GMTB/tools/gnu/11.2.0/hpc-stack-v1.2.0/modulefiles/stack

--- a/modulefiles/build_cheyenne_gnu
+++ b/modulefiles/build_cheyenne_gnu
@@ -26,6 +26,7 @@ module load w3emc/2.9.2
 module load esmf/8.3.0b09 
 module load mapl/2.11.0-esmf-8.3.0b09
 module load netcdf/4.7.4
+module load libpng/1.6.35
 module load pio/2.5.2
 
 setenv CMAKE_C_COMPILER mpicc

--- a/modulefiles/build_cheyenne_intel
+++ b/modulefiles/build_cheyenne_intel
@@ -7,11 +7,13 @@ proc ModulesHelp { } {
 
 module-whatis "Loads libraries needed for building SRW on Cheyenne"
 
-module purge
 module load cmake/3.22.0
+module load python/3.7.9
+module load ncarenv/1.3
 module load intel/2022.1
 module load mpt/2.25
-module load python/3.7.9
+module load ncarcompilers/0.5.0
+module unload netcdf
 
 module use /glade/work/epicufsrt/GMTB/tools/intel/2022.1/hpc-stack-v1.2.0_6eb6/modulefiles/stack
 module load hpc/1.2.0
@@ -19,15 +21,16 @@ module load hpc-intel/2022.1
 module load hpc-mpt/2.25
 
 module load srw_common
+
 module load g2/3.4.5
 module load esmf/8.3.0b09
 module load mapl/2.11.0-esmf-8.3.0b09
 module load netcdf/4.7.4
 module load libpng/1.6.37
 module load pio/2.5.3
+module load fms/2022.01
 
 setenv CMAKE_C_COMPILER mpicc
-setenv CMAKE_CXX_COMPILER mpixx
+setenv CMAKE_CXX_COMPILER mpicxx
 setenv CMAKE_Fortran_COMPILER mpif90
 setenv CMAKE_Platform cheyenne.intel
-

--- a/modulefiles/build_cheyenne_intel
+++ b/modulefiles/build_cheyenne_intel
@@ -22,6 +22,8 @@ module load hpc-mpt/2.25
 
 module load srw_common
 
+module unload w3emc/2.7.3
+module load w3emc/2.9.1
 module load g2/3.4.5
 module load esmf/8.3.0b09
 module load mapl/2.11.0-esmf-8.3.0b09

--- a/modulefiles/build_noaacloud_intel
+++ b/modulefiles/build_noaacloud_intel
@@ -14,8 +14,7 @@ module load cmake/3.22.1
 module use /apps/modules/modulefiles 
 module load rocoto
 
-module load srw_common
-module load esmf/8.2.0
+module load srw_common.spack
 
 module use /contrib/GST/miniconda3/modulefiles
 module load miniconda3/4.10.3

--- a/modulefiles/srw_common
+++ b/modulefiles/srw_common
@@ -2,15 +2,12 @@
 
 module load jasper/2.0.25
 module load zlib/1.2.11
-module try-load png/1.6.35 
-module try-load libpng/1.6.35
 
 module load hdf5/1.10.6
-module load-any netcdf/4.7.4 netcdf-c/4.7.4
-module load-any netcdf/4.7.4 netcdf-fortran/4.5.4
-module load-any pio/2.5.2 parallelio/2.5.2
-module load-any esmf/8.3.0b09 
-module load fms
+module load netcdf/4.7.4 
+module load pio/2.5.2 
+module load esmf/8.3.0b09    
+module load fms/2022.01
 
 module load bacio/2.4.1
 module load crtm/2.3.0
@@ -21,9 +18,9 @@ module load sp/2.3.3
 module load w3nco/2.4.1
 module load upp/10.0.10
 
-module load-any gftl-shared/v1.3.3 gftl-shared/1.3.3
-module load-any yafyaml/v0.5.1 yafyaml/0.5.1
-module load-any mapl/2.11.0-esmf-8.3.0b09
+module load gftl-shared/v1.3.3 
+module load yafyaml/v0.5.1     
+module load mapl/2.11.0-esmf-8.3.0b09
 
 module load gfsio/1.4.1
 module load landsfcutil/2.4.1
@@ -31,5 +28,6 @@ module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
 module load sfcio/1.4.1
 module load sigio/2.3.2
-module try-load w3emc/2.7.3
+module load w3emc/2.7.3
 module load wgrib2/2.0.8
+

--- a/modulefiles/srw_common.spack
+++ b/modulefiles/srw_common.spack
@@ -1,0 +1,33 @@
+#%Module
+
+module load jasper/2.0.25
+module load zlib/1.2.11
+
+module load hdf5/1.10.6
+module load netcdf-c/4.7.4
+module load netcdf-fortran/4.5.4
+module load parallelio/2.5.2 
+module load esmf/8.3.0b09
+module load fms/2021.03
+
+module load bacio/2.4.1
+module load crtm/2.3.0
+module load g2/3.4.3
+module load g2tmpl/1.10.0
+module load ip/3.3.3
+module load sp/2.3.3
+module load w3nco/2.4.1
+module load upp/10.0.10
+
+module load gftl-shared/1.3.3 
+module load yafyaml/0.5.1 
+
+module load gfsio/1.4.1
+module load landsfcutil/2.4.1
+module load nemsio/2.5.2
+module load nemsiogfs/2.5.3
+module load sfcio/1.4.1
+module load sigio/2.3.2
+module load w3emc/2.7.3
+module load wgrib2/2.0.8
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha,FV3_GFS_v15_thompson_mynn_lam3km")
+  set(CCPP_SUITES "FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_RRFS_v1alpha,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0")
 endif()
 
 if(NOT APP)


### PR DESCRIPTION
This PR cleans up the modules and returns them to straight "module load" commands after issues were uncovered using "module load-any" on Cheyenne and Azure. 

This also adds in the FV3_WoFS_v0 suite to the src/CMakeLists.txt where it was missing.