### PR TITLE
[release/public-v2] Updating WM to ufs-community umbrella

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -19,11 +19,9 @@ required = True
 
 [ufs-weather-model]
 protocol = git
-#repo_url = https://github.com/ufs-community/ufs-weather-model
-repo_url = https://github.com/NOAA-EPIC/ufs-weather-model-1
+repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
-#branch = develop
-branch = release-public-v3-SRW
+branch = release/public-v3.0
 local_path = src/ufs-weather-model
 required = True
 


### PR DESCRIPTION
This PR updates the pointer to the ufs-weather-model to the newly created release/public-v3.0 of the ufs-community umbrella.  The new branch is identical to the branch that was tested under NOAA-EPIC.