### PR TITLE
Remove redundant hdf5 module that causes problems with Cheyenne build

### DIFF
--- a/modulefiles/srw_common
+++ b/modulefiles/srw_common
@@ -4,7 +4,6 @@ module load jasper/2.0.25
 module load zlib/1.2.11
 module load-any png/1.6.35 libpng/1.6.37
 
-module load hdf5/1.10.6
 module load-any netcdf/4.7.4 netcdf-c/4.7.4
 module load-any netcdf/4.7.4 netcdf-fortran/4.5.4
 module load-any pio/2.5.3 parallelio/2.5.2


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Currently, due to either a flaw in the hpc-stack install or lmod install on Cheyenne (or both!), there is unexpected behavior when attempting to load the ncio module required for building SRW on Cheyenne, which causes the modulefile to fail to load:

```
module load build_cheyenne_intel
Lmod has detected the following error:  Cannot load module "netcdf/4.8.1" because these module(s) are loaded:
   hdf5

While processing the following module(s):
    Module fullname       Module Filename
    ---------------       ---------------
    netcdf/4.8.1          /glade/u/apps/ch/modulefiles/default/intel/2022.1/netcdf/4.8.1.lua
    ncio/1.1.2            /glade/work/epicufsrt/GMTB/tools/intel/2022.1/hpc-stack-v1.2.0_6eb6/modulefiles/mpi/intel/2022.1/mpt/2.25/ncio/1.1.2.lua
    srw_common            modulefiles/srw_common
    build_cheyenne_intel  modulefiles/build_cheyenne_intel
```

As it turns out, the offending module causing the conflict, hdf5, seems to be unnecessary. So by removing this module, we can solve the problem.

## TESTS CONDUCTED: 
Ran fundamental set of WE2E tests (as described in comments of #277) on Cheyenne (intel), Hera, Orion, and Jet.. All passed.

## DEPENDENCIES:
None

## ISSUE (optional): 
Fixes issue mentioned in #325 

## CONTRIBUTORS:
Thanks to @christopherwharrop-noaa and @panll for their help and consultation on this issue