### PR TITLE
Fixes to make build and run work in new merged directory structure

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,12 +1,3 @@
-[regional_workflow]
-protocol = git
-repo_url = https://github.com/ufs-community/regional_workflow
-# Specify either a branch name or a hash but not both.
-#branch = develop
-hash = b17ac12
-local_path = regional_workflow
-required = True
-
 [ufs_utils]
 protocol = git
 repo_url = https://github.com/ufs-community/UFS_UTILS

--- a/tests/WE2E/get_expts_status.sh
+++ b/tests/WE2E/get_expts_status.sh
@@ -44,13 +44,13 @@ scrfunc_dir=$( dirname "${scrfunc_fp}" )
 #-----------------------------------------------------------------------
 #
 # The current script should be located in the "tests" subdirectory of the
-# workflow's top-level directory, which we denote by homerrfs.  Thus,
-# homerrfs is the directory one level above the directory in which the
-# current script is located.  Set homerrfs accordingly.
+# workflow's top-level directory, which we denote by SR_WX_APP_TOP_DIR.
+# SR_WX_APP_TOP_DIR is the directory two levels above the directory in
+# which the current script is located; Set SR_WX_APP_TOP_DIR accordingly.
 #
 #-----------------------------------------------------------------------
 #
-homerrfs=${scrfunc_dir%/*/*}
+SR_WX_APP_TOP_DIR=${scrfunc_dir%/*/*}
 #
 #-----------------------------------------------------------------------
 #
@@ -58,7 +58,7 @@ homerrfs=${scrfunc_dir%/*/*}
 #
 #-----------------------------------------------------------------------
 #
-ushdir="$homerrfs/ush"
+ushdir="$SR_WX_APP_TOP_DIR/ush"
 #
 #-----------------------------------------------------------------------
 #

--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -27,24 +27,24 @@ scrfunc_dir=$( dirname "${scrfunc_fp}" )
 #
 #-----------------------------------------------------------------------
 #
-# Set the full path to the top-level directory of the regional_workflow 
-# repository.  We denote this path by homerrfs.  The current script 
+# Set the full path to the top-level directory of the UFS SRW App 
+# repository. We denote this path by SR_WX_APP_TOP_DIR. The current script 
 # should be located in the "tests/WE2E" subdirectory under this directory.
-# Thus, homerrfs is the directory two levels above the directory in which 
-# the current script is located.
+# Thus, SR_WX_APP_TOP_DIR is the directory two levels above the directory
+# in which the current script is located.
 #
 #-----------------------------------------------------------------------
 #
-homerrfs=${scrfunc_dir%/*/*}
+SR_WX_APP_TOP_DIR=${scrfunc_dir%/*/*}
 #
 #-----------------------------------------------------------------------
 #
-# Set other directories that depend on homerrfs.
+# Set other directories that depend on SR_WX_APP_TOP_DIR.
 #
 #-----------------------------------------------------------------------
 #
-ushdir="$homerrfs/ush"
-testsdir="$homerrfs/tests"
+ushdir="$SR_WX_APP_TOP_DIR/ush"
+testsdir="$SR_WX_APP_TOP_DIR/tests"
 WE2Edir="$testsdir/WE2E"
 #
 #-----------------------------------------------------------------------
@@ -203,9 +203,9 @@ STMP in the configuration files of all tests that will run in NCO mode.
 If it is not specified, STMP is (effectively) set as follows in the 
 configuration files (of all NCO mode tests to be run):
 
-    STMP=\$( readlink -f \"\$homerrfs/../../nco_dirs/stmp\" \)
+    STMP=\$( readlink -f \"\$SR_WX_APP_TOP_DIR/../nco_dirs/stmp\" \)
 
-Here, homerrfs is the base directory in which the regional_workflow
+Here, SR_WX_APP_TOP_DIR is the base directory in which the UFS SRW App
 repository is cloned.  Note that it is not possible to specify a different 
 value for STMP for each test via this argument; all tests will use the
 same value for STMP (either the value specified in the call to this 
@@ -993,7 +993,7 @@ COMIN=\"${COMIN}\""
 #
 # Set STMP and PTMP.
 #
-    nco_basedir=$( readlink -f "$homerrfs/../../nco_dirs" )
+    nco_basedir=$( readlink -f "$SR_WX_APP_TOP_DIR/../nco_dirs" )
     STMP=${stmp:-"${nco_basedir}/stmp"}
     PTMP=${ptmp:-"${nco_basedir}/ptmp"}
 

--- a/ush/config_defaults.yaml
+++ b/ush/config_defaults.yaml
@@ -231,9 +231,8 @@ platform:
   # files under the '00' directory). The script to pull the CCPA data 
   # from the NOAA HPSS has an example of how to account for this as well
   # as organizing the data into a more intuitive format: 
-  # regional_workflow/scripts/exregional_get_ccpa_files.sh. When a fix
-  # is provided, it will be accounted for in the
-  # exregional_get_ccpa_files.sh script.
+  # scripts/exregional_get_ccpa_files.sh. When a fix is provided, it will
+  # be accounted for in the exregional_get_ccpa_files.sh script.
   #
   # MRMS_OBS_DIR:
   # User-specified location of top-level directory where MRMS composite
@@ -260,9 +259,9 @@ platform:
   # and rename the MRMS composite reflectivity file to match the valid
   # time of the forecast.  The script to pull the MRMS data from the NOAA 
   # HPSS has an example of the expected file naming structure: 
-  # regional_workflow/scripts/exregional_get_mrms_files.sh. This script 
-  # calls the script used to identify the MRMS file closest to the valid 
-  # time: regional_workflow/ush/mrms_pull_topofhour.py.
+  # scripts/exregional_get_mrms_files.sh. This script calls the script
+  # used to identify the MRMS file closest to the valid time:
+  # ush/mrms_pull_topofhour.py.
   #
   # NDAS_OBS_DIR:
   # User-specified location of top-level directory where NDAS prepbufr 
@@ -283,7 +282,7 @@ platform:
   # month, and HH the 2-digit valid hour of the day. The script to pull 
   # the NDAS data from the NOAA HPSS has an example of how to rename the
   # NDAS data into a more intuitive format with the valid time listed in 
-  # the file name: regional_workflow/scripts/exregional_get_ndas_files.sh
+  # the file name: scripts/exregional_get_ndas_files.sh
   #
   #-----------------------------------------------------------------------
   #
@@ -349,7 +348,7 @@ workflow:
   # EXPT_BASEDIR:
   # The base directory in which the experiment directory will be created.  
   # If this is not specified or if it is set to an empty string, it will
-  # default to ${HOMErrfs}/../expt_dirs.  
+  # default to ${SR_WX_APP_TOP_DIR}/../expt_dirs.  
   #
   # EXPT_SUBDIR:
   # The name that the experiment directory (without the full path) will
@@ -1572,7 +1571,7 @@ task_run_fcst:
   # commonly used set of grid-dependent parameters.  The predefined grid 
   # parameters are specified in the script 
   #
-  #   $HOMErrfs/ush/set_predef_grid_params.sh
+  #   $SR_WX_APP_TOP_DIR/ush/set_predef_grid_params.sh
   #
   #-----------------------------------------------------------------------
   #

--- a/ush/load_modules_run_task.sh
+++ b/ush/load_modules_run_task.sh
@@ -111,23 +111,23 @@ for the workflow task specified by task_name failed:
 # sets environment variables (including prepending/appending to paths)
 # and loads modules.
 #
-# The regional_workflow repository contains module files for the
+# The UFS SRW App repository contains module files for the
 # workflow tasks in the template rocoto XML file for the FV3-LAM work-
 # flow that need modules not loaded in the BUILD_MOD_FN above.
 #
 # The full path to a module file for a given task is
 #
-#   $HOMErrfs/modulefiles/$machine/${task_name}.local
+#   $SR_WX_APP_TOP_DIR/modulefiles/$machine/${task_name}.local
 #
-# where HOMErrfs is the base directory of the workflow, machine is the
+# where SR_WX_APP_TOP_DIR is the base directory of the workflow, machine is the
 # name of the machine that we're running on (in lowercase), and task_-
 # name is the name of the current task (an input to this script).
 #
 #-----------------------------------------------------------------------
 #
-modules_dir="$HOMErrfs/modulefiles/tasks/$machine"
+modules_dir="$SR_WX_APP_TOP_DIR/modulefiles/tasks/$machine"
 modulefile_name="${task_name}"
-default_modules_dir="$HOMErrfs/modulefiles"
+default_modules_dir="$SR_WX_APP_TOP_DIR/modulefiles"
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -256,7 +256,7 @@ def setup():
     # directory of the current script.
     #
     SR_WX_APP_TOP_DIR = os.path.abspath(
-        os.path.dirname(__file__) + os.sep + os.pardir + os.sep + os.pardir
+        os.path.dirname(__file__) + os.sep + os.pardir
     )
 
     #
@@ -279,19 +279,6 @@ def setup():
         pass
     property_name = "local_path"
     cfg = load_ini_config(mng_extrns_cfg_fn)
-    #
-    # Get the path to the workflow scripts
-    #
-    external_name = "regional_workflow"
-    HOMErrfs = get_ini_value(cfg, external_name, property_name)
-
-    if not HOMErrfs:
-        print_err_msg_exit(
-            f"""
-            Externals.cfg does not contain "{external_name}"."""
-        )
-
-    HOMErrfs = os.path.join(SR_WX_APP_TOP_DIR, HOMErrfs)
     #
     # Get the base directory of the FV3 forecast model code.
     #
@@ -364,13 +351,13 @@ def setup():
     global USHDIR, SCRIPTSDIR, JOBSDIR, SORCDIR, SRC_DIR, PARMDIR, MODULES_DIR
     global EXECDIR, TEMPLATE_DIR, VX_CONFIG_DIR, METPLUS_CONF, MET_CONFIG
 
-    USHDIR = os.path.join(HOMErrfs, "ush")
-    SCRIPTSDIR = os.path.join(HOMErrfs, "scripts")
-    JOBSDIR = os.path.join(HOMErrfs, "jobs")
-    SORCDIR = os.path.join(HOMErrfs, "sorc")
+    USHDIR = os.path.join(SR_WX_APP_TOP_DIR, "ush")
+    SCRIPTSDIR = os.path.join(SR_WX_APP_TOP_DIR, "scripts")
+    JOBSDIR = os.path.join(SR_WX_APP_TOP_DIR, "jobs")
+    SORCDIR = os.path.join(SR_WX_APP_TOP_DIR, "sorc")
     SRC_DIR = os.path.join(SR_WX_APP_TOP_DIR, "src")
-    PARMDIR = os.path.join(HOMErrfs, "parm")
-    MODULES_DIR = os.path.join(HOMErrfs, "modulefiles")
+    PARMDIR = os.path.join(SR_WX_APP_TOP_DIR, "parm")
+    MODULES_DIR = os.path.join(SR_WX_APP_TOP_DIR, "modulefiles")
     EXECDIR = os.path.join(SR_WX_APP_TOP_DIR, EXEC_SUBDIR)
     TEMPLATE_DIR = os.path.join(USHDIR, "templates")
     VX_CONFIG_DIR = os.path.join(TEMPLATE_DIR, "parm")
@@ -1902,7 +1889,6 @@ def setup():
         # -----------------------------------------------------------------------
         #
         "SR_WX_APP_TOP_DIR": SR_WX_APP_TOP_DIR,
-        "HOMErrfs": HOMErrfs,
         "USHDIR": USHDIR,
         "SCRIPTSDIR": SCRIPTSDIR,
         "JOBSDIR": JOBSDIR,


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
 - Removes regional_workflow from Externals.cfg
 - Replaces uses of "HOMErrfs" with "SR_WX_APP_TOP_DIR"
 - Remove/replace other references to regional_workflow

### Type of change
- [x] Bug fix

## TESTS CONDUCTED: 
Tests all completed successfully, except for some expected failures and a few temporary problems on Hera
- [x] hera.intel
  - Comprehensive
  - Several tests failed, most expected failures, investigating the rest to ensure they are also failing previously
    - get_from_HPSS_ics_FV3GFS_lbcs_FV3GFS_fmt_nemsio
      - Temporary data retrieval failure
    - get_from_HPSS_ics_FV3GFS_lbcs_FV3GFS_fmt_nemsio_2019101818
      - Temporary data retrieval failure
    - get_from_HPSS_ics_FV3GFS_lbcs_FV3GFS_fmt_nemsio_2020022518
      - Temporary data retrieval failure
    - get_from_HPSS_ics_FV3GFS_lbcs_FV3GFS_fmt_nemsio_2021010100
      - Temporary data retrieval failure
    - get_from_NOMADS_ics_FV3GFS_lbcs_FV3GFS_fmt_nemsio
      - Temporary data retrieval failure
    - grid_CONUS_3km_GFDLgrid_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
      - Wallclock limit reached; re-running succeeded
    - *grid_RRFS_CONUS_25km_ics_GSMGFS_lbcs_GSMGFS_suite_GFS_v16
    - *subhourly_post
    - *subhourly_post_ensemble_2mems
  - ***expected failures**
- [x] orion.intel
  - Fundamental
  - No unexpected failures
- [x] cheyenne.intel
  - Fundamental
  - No failures
- [x] cheyenne.gnu
  - Fundamental
  - No unexpected failures
- [x] jet.intel
  - Fundamental
  - Two tests failed; both are pre-existing failures
    - pregen_grid_orog_sfc_climo
    - nco_ensemble

## DEPENDENCIES:
None

## DOCUMENTATION:
In-line documentation has been updated; user documentation will need to be updated in a future PR.
