### PR TITLE
Release/public v2 gaea update

### DIFF
--- a/etc/lmod-setup.csh
+++ b/etc/lmod-setup.csh
@@ -27,8 +27,11 @@ else if ( "$L_MACHINE" == singularity ) then
    module purge
 
 else if ( "$L_MACHINE" == gaea ) then
-   set ENV="/lustre/f2/pdata/esrl/gsd/contrib/lua-5.1.4.9/lmod/lmod/init/csh"
-   source $ENV
+
+   export LMOD_SYSTEM_DEFAULT_MODULES=modules/3.2.11.4
+   export BASH_ENV=/lustre/f2/dev/role.epic/contrib/apps/lmod/lmod/init/profile
+   source $BASH_ENV
+   module --initial_load restore
 
 else if ( "$L_MACHINE" == odin ) then
    module unload modules

--- a/etc/lmod-setup.sh
+++ b/etc/lmod-setup.sh
@@ -28,9 +28,10 @@ elif [ "$L_MACHINE" = singularity ]; then
    module purge
 
 elif [ "$L_MACHINE" = gaea ]; then
-   export BASH_ENV="/lustre/f2/pdata/esrl/gsd/contrib/lua-5.1.4.9/lmod/lmod/init/bash"
+   export LMOD_SYSTEM_DEFAULT_MODULES=modules/3.2.11.4
+   export BASH_ENV=/lustre/f2/dev/role.epic/contrib/apps/lmod/lmod/init/profile
    source $BASH_ENV
-   module purge
+   module --initial_load restore
 
 elif [ "$L_MACHINE" = odin ]; then
    module unload modules

--- a/modulefiles/build_gaea_intel
+++ b/modulefiles/build_gaea_intel
@@ -2,19 +2,25 @@
 
 proc ModulesHelp { } {
    puts stderr "This module loads libraries for building SRW on"
-   puts stderr "the NOAA RDHPC machine Gaea using Intel-18.0.6.288"
+   puts stderr "the NOAA RDHPC machine Gaea using Intel-2021.3.0"
 }
 
 module-whatis "Loads libraries needed for building SRW on Gaea"
 
-module use /lustre/f2/pdata/ncep_shared/hpc-stack/modulefiles/stack
-module load hpc/1.2.0 hpc-intel/18.0.6.288  hpc-cray-mpich/7.7.11
-module load srw_common
+module use /lustre/f2/dev/role.epic/contrib/hpc-stack/intel-2021.3.0/modulefiles/stack
+module load hpc/1.2.0
+module load intel/2021.3.0
+module load hpc-intel/2021.3.0
+module load hpc-cray-mpich/7.7.11
 
-module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+module load srw_common
+module load libpng/1.6.37
+
+module use /lustre/f2/dev/role.epic/contrib/modulefiles
+module load miniconda3/4.12.0
 module load rocoto
+
 module load cmake/3.20.1
-module load png/1.6.35 
 
 setenv CC cc
 setenv FC ftn
@@ -23,4 +29,3 @@ setenv CMAKE_C_COMPILER cc
 setenv CMAKE_CXX_COMPILER CC
 setenv CMAKE_Fortran_COMPILER ftn
 setenv CMAKE_Platform gaea.intel
-

--- a/modulefiles/wflow_gaea
+++ b/modulefiles/wflow_gaea
@@ -7,12 +7,14 @@ proc ModulesHelp { } {
 
 module-whatis "Loads libraries needed for running SRW on Gaea"
 
-module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+module use /lustre/f2/dev/role.epic/contrib/modulefiles
 module load rocoto
 module load miniconda3
 
 setenv CONDA_DEFAULT_ENV "regional_workflow"
-setenv PROJ_LIB /lustre/f2/pdata/esrl/gsd/contrib/miniconda3/4.8.3/envs/regional_workflow/share/proj
-#if { [module-info mode load] } {
-#   system "conda activate regional_workflow;"
-#}
+setenv PROJ_LIB /lustre/f2/dev/role.epic/contrib/miniconda3/4.12.0/envs/regional_workflow/share/proj
+
+if { [module-info mode load] } {
+  puts stderr "Please do the following to activate conda:
+       > conda activate regional_workflow"
+}


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

Changes to this SRW release/public-v2 branch are specific to Gaea, and reflect the recent updates to the Lmod/8.7.12, miniconda3/4.12.0, and the hpc-stack modules built with the updated Lmod and miniconda. All these packages and the module manager have been installed under the role.epic account, maintained by EPIC, and in a following common space on Gaea: 
**/lustre/f2/dev/wpo/role.epic/contrib/** 
(also linked as **/lustre/f2/dev/role.epic/contrib/**) 

These updates were found to be needed to address missing python packages in existing regional_workflow conda environments, when python plotting routines were used to generate basic plots of the model results.

The changes are related to Gaea only, and their sole purpose is to initialize Lmod properly (which is not installed system-wide on Gaea), and update the paths of the modules.

The files in the SRW repo that were updated, under the ./ufs-srweather-app/ main directory:

./etc/lmod-setup.sh, lmod_setup.csh
./modulefiles/build_gaea_intel
./modulefiles/wflow_gaea

Running the SRW also requred corresponding updates to the regional_workflow repository (yet unmerged, release/public-v2 branch), for which the PR-380 has been created in that repository:
[PR-380](https://github.com/ufs-community/regional_workflow/pull/830)

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 

The test has been done on Gaea, to build the SRW and to run a workflow using rocoto and crontab, or the following test case from the comprehensive tests suite:
grid_RRFS_CONUScompact_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16.

Because of the dependency of the PR-380 in the regional_workflow repo, temporary modifications to the **Externals.cfs** in the tested code have been made to use the following regional_workflow repository and branch:

```
[regional_workflow]
protocol = git
#repo_url = https://github.com/ufs-community/regional_workflow
repo_url = https://github.com/natalie-perlin/regional_workflow
# Specify either a branch name or a hash but not both.
branch = release/public-v2-gaea-update
local_path = regional_workflow
required = True
...
```

The test intended to provide the concept of loading the new Lmod, modules and packages properly, building the SRW code, and a functional workflow that launches and successfully completes the test.

Location of the test code built and launched on Gaea, under EPIC account:
/lustre/f2/dev/wpo/role.epic/sandbox/SRW/ufs-srw-pub-v2-update/

A corresponding test directory on Gaea is the following:
/lustre/f2/dev/wpo/role.epic/sandbox/SRW/expt_dirs/grid_RRFS_CONUScompact_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16

<!-- Add an X to check off a box. -->

- [ ] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [x] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [x] comprehensive tests (specify *which* if a subset was used)
expt_dirs/grid_RRFS_CONUScompact_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16


## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
- ufs-community/regional_workflow/pull/<380>

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here (Remember, issues must always be created before starting work on a PR branch!). For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/ufs-community/other_repository/pull/63" -->

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes - only tested the workflow functionality, a single test
- [ not yet, a dependent PR-380 is as described above] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->


