### PR TITLE
Fix setting of SRW_WE2E_COMPREHENSIVE_TESTS var

### DIFF
--- a/.cicd/Jenkinsfile
+++ b/.cicd/Jenkinsfile
@@ -167,8 +167,7 @@ pipeline {
                                     }
                                 }
 
-                                sh "export SRW_WE2E_COMPREHENSIVE_TESTS=${run_we2e_comprehensive_tests}"
-                                sh 'bash --login "${WORKSPACE}/.cicd/scripts/srw_test.sh"'
+                                sh "SRW_WE2E_COMPREHENSIVE_TESTS=${run_we2e_comprehensive_tests}" + ' bash --login "${WORKSPACE}/.cicd/scripts/srw_test.sh"'
                             }
                         }
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The SRW_WE2E_COMPREHENSIVE_TESTS variable was incorrectly set by a sh block that proceeded the call to srw_test.sh. This issue was hidden because Jenkins sets the parameters to environment variables, which are accessible from sh blocks. However, the parameters do not seem to be set as environment variables the first time a multi-branch pipeline is initialized. This resulted in an unbound variable error when the SRW_WE2E_COMPREHENSIVE_TESTS variable was accessed by the srw_test.sh script. This update sets SRW_WE2E_COMPREHENSIVE_TESTS in the same sh block as the srw_test.sh script call, while ensuring the WORKSPACE variable isn't evaluated until the sh block.

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [ ] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## CHECKLIST
<!-- Add an X to check off a box. -->
- [ ] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [x] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted
