### PR TITLE
[develop] Improve error messaging and logging for generate_FV3LAM_wflow.py

### DIFF
--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -65,6 +65,63 @@ WE2Edir="$TESTSdir/WE2E"
 #
 #-----------------------------------------------------------------------
 #
+# Run python checks
+#
+#-----------------------------------------------------------------------
+#
+
+# This line will return two numbers: the python major and minor versions
+pyversion=($(/usr/bin/env python3 -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major); print(minor)'))
+
+#Now, set an error check variable so that we can print all python errors rather than just the first
+pyerrors=0
+
+# Check that the call to python3 returned no errors, then check if the 
+# python3 minor version is 6 or higher
+if [[ -z "$pyversion" ]];then
+  print_info_msg "\
+
+  Error: python3 not found"
+  pyerrors=$((pyerrors+1))
+else
+  if [[ ${#pyversion[@]} -lt 2 ]]; then
+    print_info_msg "\
+
+  Error retrieving python3 version"
+    pyerrors=$((pyerrors+1))
+  elif [[ ${pyversion[1]} -lt 6 ]]; then
+    print_info_msg "\
+
+  Error: python version must be 3.6 or higher
+  python version: ${pyversion[*]}"
+    pyerrors=$((pyerrors+1))
+  fi
+fi
+
+#Next, check for the non-standard python packages: jinja2, yaml, and f90nml
+pkgs=(jinja2 yaml f90nml)
+for pkg in ${pkgs[@]}  ; do
+  if ! /usr/bin/env python3 -c "import ${pkg}" &> /dev/null; then
+  print_info_msg "\
+
+  Error: python module ${pkg} not available"
+  pyerrors=$((pyerrors+1))
+  fi
+done
+
+#Finally, check if the number of errors is >0, and if so exit with helpful message
+if [ $pyerrors -gt 0 ];then
+  print_err_msg_exit "\
+  Errors found: check your python environment
+
+  Instructions for setting up python environments can be found on the web:
+  https://github.com/ufs-community/ufs-srweather-app/wiki/Getting-Started
+
+"
+fi
+#
+#-----------------------------------------------------------------------
+#
 # Save current shell options (in a global array).  Then set new options
 # for this script or function.
 #

--- a/ush/config_defaults.yaml
+++ b/ush/config_defaults.yaml
@@ -54,7 +54,7 @@ user:
   #
   #-----------------------------------------------------------------------
   MACHINE: "BIG_COMPUTER"
-  ACCOUNT: "project_name"
+  ACCOUNT: ""
 
 #----------------------------
 # PLATFORM config parameters

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -101,7 +101,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
 
     # The setup function reads the user configuration file and fills in 
     # non-user-specified values from config_defaults.yaml
-    setup()
+    setup(logging.getLogger('root.setup'))
 
     # import all environment variables
     import_vars()

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -101,7 +101,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
 
     # The setup function reads the user configuration file and fills in 
     # non-user-specified values from config_defaults.yaml
-    setup(logging.getLogger('root.setup'))
+    setup()
 
     # import all environment variables
     import_vars()

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -1065,12 +1065,15 @@ if __name__ == "__main__":
     except:
         # If the call to the generate_FV3LAM_wflow function above was not successful, 
         # print out an error message and exit with a nonzero return code.
-        logging.exception(
+        logging.exception(dedent(
             f"""
+            *********************************************************************
             Experiment generation failed. See the error message(s) printed below.
             For more detailed information, check the log file from the workflow
-            generation script: {logfile}"""
-        )
+            generation script: {logfile}
+            *********************************************************************\n
+            """
+        ))
 
 class Testing(unittest.TestCase):
     def test_generate_FV3LAM_wflow(self):

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -431,8 +431,10 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
                 The variable \"settings\" specifying values of the rococo XML variables
                 has been set as follows:
                 #-----------------------------------------------------------------------
-                settings =\n\n""")
-        log_info(settings_str)
+                settings =\n\n""",
+                verbose=VERBOSE,
+            )
+        log_info(settings_str, verbose=VERBOSE)
 
         #
         # Call the python script to generate the experiment's actual XML file
@@ -472,6 +474,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
         workflow launch script (WFLOW_LAUNCH_SCRIPT_FP):
           EXPTDIR = \"{EXPTDIR}\"
           WFLOW_LAUNCH_SCRIPT_FP = \"{WFLOW_LAUNCH_SCRIPT_FP}\"''',
+        verbose=VERBOSE,
     )
 
     create_symlink_to_file(
@@ -499,6 +502,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
             Symlinking fixed files from system directory (FIXgsm) to a subdirectory (FIXam):
               FIXgsm = \"{FIXgsm}\"
               FIXam = \"{FIXam}\"''',
+            verbose=VERBOSE,
         )
 
         ln_vrfy(f'''-fsn "{FIXgsm}" "{FIXam}"''')
@@ -509,6 +513,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
             Copying fixed files from system directory (FIXgsm) to a subdirectory (FIXam):
               FIXgsm = \"{FIXgsm}\"
               FIXam = \"{FIXam}\"''',
+            verbose=VERBOSE,
         )
 
         check_for_preexist_dir_file(FIXam, "delete")
@@ -534,6 +539,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
               FIXaer = \"{FIXaer}\"
               FIXlut = \"{FIXlut}\"
               FIXclim = \"{FIXclim}\"''',
+            verbose=VERBOSE,
         )
 
         check_for_preexist_dir_file(FIXclim, "delete")
@@ -555,23 +561,27 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     log_info(
         f"""
         Copying templates of various input files to the experiment directory...""",
+        verbose=VERBOSE,
     )
 
     log_info(
         f"""
         Copying the template data table file to the experiment directory...""",
+        verbose=VERBOSE,
     )
     cp_vrfy(DATA_TABLE_TMPL_FP, DATA_TABLE_FP)
 
     log_info(
         f"""
         Copying the template field table file to the experiment directory...""",
+        verbose=VERBOSE,
     )
     cp_vrfy(FIELD_TABLE_TMPL_FP, FIELD_TABLE_FP)
 
     log_info(
         f"""
         Copying the template NEMS configuration file to the experiment directory...""",
+        verbose=VERBOSE,
     )
     cp_vrfy(NEMS_CONFIG_TMPL_FP, NEMS_CONFIG_FP)
     #
@@ -583,6 +593,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
         f"""
         Copying the CCPP physics suite definition XML file from its location in
         the forecast model directory sturcture to the experiment directory...""",
+        verbose=VERBOSE,
     )
     cp_vrfy(CCPP_PHYS_SUITE_IN_CCPP_FP, CCPP_PHYS_SUITE_FP)
     #
@@ -594,6 +605,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
         f"""
         Copying the field dictionary file from its location in the forecast
         model directory sturcture to the experiment directory...""",
+        verbose=VERBOSE,
     )
     cp_vrfy(FIELD_DICT_IN_UWM_FP, FIELD_DICT_FP)
     #
@@ -838,7 +850,9 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     log_info(
             f"""
             The variable \"settings\" specifying values of the weather model's
-            namelist variables has been set as follows:\n""")
+            namelist variables has been set as follows:\n""",
+        verbose=VERBOSE,
+    )
     log_info("\nsettings =\n\n" + settings_str)
     #
     # -----------------------------------------------------------------------

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -917,9 +917,11 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
 
         set_FV3nml_sfc_climo_filenames()
 
-    # Call script to get NOMADS data
+    # Call function to get NOMADS data
     if NOMADS:
-        get_nomads_data(NOMADS_file_type,EXPTDIR,USHdir,DATE_FIRST_CYCL,CYCL_HRS,FCST_LEN_HRS,LBC_SPEC_INTVL_HRS)
+        raise Exception("Nomads script does not work!")
+
+        # get_nomads_data(NOMADS_file_type,EXPTDIR,USHdir,DATE_FIRST_CYCL,CYCL_HRS,FCST_LEN_HRS,LBC_SPEC_INTVL_HRS)
 
     #
     # -----------------------------------------------------------------------
@@ -959,10 +961,9 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
         ========================================================================
         """
     )
-    #
     # -----------------------------------------------------------------------
     #
-    # If rocoto is required, print instructions on how to load and use it
+    # If rocoto is required, print instructions on how to use it
     #
     # -----------------------------------------------------------------------
     #
@@ -1007,9 +1008,8 @@ def get_nomads_data(NOMADS_file_type,EXPTDIR,USHdir,DATE_FIRST_CYCL,CYCL_HRS,FCS
     print(f"NOMADS_file_type= {NOMADS_file_type}")
     cd_vrfy(EXPTDIR)
     NOMADS_script = os.path.join(USHdir, "NOMADS_get_extrn_mdl_files.sh")
-    # run_command(f"""{NOMADS_script} {date_to_str(DATE_FIRST_CYCL,format="%Y%m%d")} \
-    #                 {date_to_str(DATE_FIRST_CYCL,format="%H")} {NOMADS_file_type} {FCST_LEN_HRS} {LBC_SPEC_INTVL_HRS}""")
-    raise Exception("Nomads script does not work")
+    run_command(f"""{NOMADS_script} {date_to_str(DATE_FIRST_CYCL,format="%Y%m%d")} \
+                    {date_to_str(DATE_FIRST_CYCL,format="%H")} {NOMADS_file_type} {FCST_LEN_HRS} {LBC_SPEC_INTVL_HRS}""")
 
 def setup_logging(logfile: str = 'log.generate_FV3LAM_wflow') -> None:
     """
@@ -1036,11 +1036,10 @@ if __name__ == "__main__":
     try:
         generate_FV3LAM_wflow(USHdir, logfile)
     except:
-        # If the call to the generate_FV3LAM_wflow function above was not successful, 
-        # print out an error message and exit with a nonzero return code.
         logging.exception(dedent(
             f"""
             *********************************************************************
+            FATAL ERROR:
             Experiment generation failed. See the error message(s) printed below.
             For more detailed information, check the log file from the workflow
             generation script: {logfile}

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -1047,8 +1047,8 @@ class Testing(unittest.TestCase):
     def test_generate_FV3LAM_wflow(self):
 
         # run workflows in separate process to avoid conflict between community and nco settings
-        def run_workflow():
-            p = Process(target=generate_FV3LAM_wflow)
+        def run_workflow(USHdir,logfile):
+            p = Process(target=generate_FV3LAM_wflow,args=(USHdir,logfile))
             p.start()
             p.join()
             exit_code = p.exitcode
@@ -1062,13 +1062,13 @@ class Testing(unittest.TestCase):
         # community test case
         cp_vrfy(f"{USHdir}/config.community.yaml", f"{USHdir}/config.yaml")
         run_command(f"""{SED} -i 's/MACHINE: hera/MACHINE: linux/g' {USHdir}/config.yaml""")
-        generate_FV3LAM_wflow(USHdir, logfile)
+        run_workflow(USHdir, logfile)
 
         # nco test case
         set_env_var("OPSROOT", f"{USHdir}/../../nco_dirs")
         cp_vrfy(f"{USHdir}/config.nco.yaml", f"{USHdir}/config.yaml")
         run_command(f"""{SED} -i 's/MACHINE: hera/MACHINE: linux/g' {USHdir}/config.yaml""")
-        generate_FV3LAM_wflow(USHdir, logfile)
+        run_workflow(USHdir, logfile)
 
     def setUp(self):
         define_macos_utilities()

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -853,7 +853,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
             namelist variables has been set as follows:\n""",
         verbose=VERBOSE,
     )
-    log_info("\nsettings =\n\n" + settings_str)
+    log_info("\nsettings =\n\n" + settings_str, verbose=VERBOSE)
     #
     # -----------------------------------------------------------------------
     #

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 from python_utils import (
     print_info_msg,
     print_err_msg_exit,
+    log_info,
     import_vars,
     cp_vrfy,
     cd_vrfy,
@@ -76,13 +77,11 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     # Set up logging to write to screen and logfile
     setup_logging(logfile)
 
-    logging.info(
-        dedent(
+    log_info(
             """
         ========================================================================
         Starting experiment generation...
         ========================================================================"""
-        )
     )
 
     # check python version
@@ -132,7 +131,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
 
         template_xml_fp = os.path.join(PARMdir, WFLOW_XML_FN)
 
-        logging.info(
+        log_info(
             f'''
             Creating rocoto workflow XML file (WFLOW_XML_FP) from jinja template XML
             file (template_xml_fp):
@@ -427,16 +426,13 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
         # End of "settings" variable.
         settings_str = cfg_to_yaml_str(settings)
 
-        logging.info(
-            dedent(
+        log_info(
                 f"""
                 The variable \"settings\" specifying values of the rococo XML variables
                 has been set as follows:
                 #-----------------------------------------------------------------------
-                settings =\n\n"""
-            )
-            + settings_str,
-        )
+                settings =\n\n""")
+        log_info(settings_str)
 
         #
         # Call the python script to generate the experiment's actual XML file
@@ -470,7 +466,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     #
     # -----------------------------------------------------------------------
     #
-    logging.info(
+    log_info(
         f'''
         Creating symlink in the experiment directory (EXPTDIR) that points to the
         workflow launch script (WFLOW_LAUNCH_SCRIPT_FP):
@@ -498,7 +494,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     #
     if SYMLINK_FIX_FILES:
 
-        logging.info(
+        log_info(
             f'''
             Symlinking fixed files from system directory (FIXgsm) to a subdirectory (FIXam):
               FIXgsm = \"{FIXgsm}\"
@@ -508,7 +504,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
         ln_vrfy(f'''-fsn "{FIXgsm}" "{FIXam}"''')
     else:
 
-        logging.info(
+        log_info(
             f'''
             Copying fixed files from system directory (FIXgsm) to a subdirectory (FIXam):
               FIXgsm = \"{FIXgsm}\"
@@ -531,7 +527,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     # -----------------------------------------------------------------------
     #
     if USE_MERRA_CLIMO:
-        logging.info(
+        log_info(
             f'''
             Copying MERRA2 aerosol climatology data files from system directory
             (FIXaer/FIXlut) to a subdirectory (FIXclim) in the experiment directory:
@@ -556,24 +552,24 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     #
     # -----------------------------------------------------------------------
     #
-    logging.info(
+    log_info(
         f"""
         Copying templates of various input files to the experiment directory...""",
     )
 
-    logging.info(
+    log_info(
         f"""
         Copying the template data table file to the experiment directory...""",
     )
     cp_vrfy(DATA_TABLE_TMPL_FP, DATA_TABLE_FP)
 
-    logging.info(
+    log_info(
         f"""
         Copying the template field table file to the experiment directory...""",
     )
     cp_vrfy(FIELD_TABLE_TMPL_FP, FIELD_TABLE_FP)
 
-    logging.info(
+    log_info(
         f"""
         Copying the template NEMS configuration file to the experiment directory...""",
     )
@@ -583,7 +579,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     # clone of the FV3 code repository to the experiment directory (EXPT-
     # DIR).
     #
-    logging.info(
+    log_info(
         f"""
         Copying the CCPP physics suite definition XML file from its location in
         the forecast model directory sturcture to the experiment directory...""",
@@ -594,7 +590,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     # clone of the FV3 code repository to the experiment directory (EXPT-
     # DIR).
     #
-    logging.info(
+    log_info(
         f"""
         Copying the field dictionary file from its location in the forecast
         model directory sturcture to the experiment directory...""",
@@ -607,7 +603,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     #
     # -----------------------------------------------------------------------
     #
-    logging.info(
+    log_info(
         f'''
         Setting parameters in weather model's namelist file (FV3_NML_FP):
         FV3_NML_FP = \"{FV3_NML_FP}\"'''
@@ -839,16 +835,11 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
 
     settings_str = cfg_to_yaml_str(settings)
 
-    logging.info(
-        dedent(
+    log_info(
             f"""
             The variable \"settings\" specifying values of the weather model's
-            namelist variables has been set as follows:
-
-            settings =\n\n"""
-        )
-        + settings_str,
-    )
+            namelist variables has been set as follows:\n""")
+    log_info("\nsettings =\n\n" + settings_str)
     #
     # -----------------------------------------------------------------------
     #
@@ -941,7 +932,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
         rocotorun_cmd = f"rocotorun -w {WFLOW_XML_FN} -d {wflow_db_fn} -v 10"
         rocotostat_cmd = f"rocotostat -w {WFLOW_XML_FN} -d {wflow_db_fn} -v 10"
 
-    logging.info(
+    log_info(
         f"""
         ========================================================================
         ========================================================================
@@ -963,7 +954,7 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     #
     if WORKFLOW_MANAGER == "rocoto":
 
-        logging.info(
+        log_info(
             f"""
             To launch the workflow, change location to the experiment directory
             (EXPTDIR) and issue the rocotrun command, as follows:
@@ -1012,7 +1003,7 @@ def setup_logging(logfile: str = 'log.generate_FV3LAM_wflow') -> None:
     messages with detailed timing and routine info in the specified text file.
     """
     logging.basicConfig(level=logging.DEBUG,
-                        format='%(name)-12s %(levelname)-8s %(message)s',
+                        format='%(name)-22s %(levelname)-8s %(message)s',
                         filename=logfile,
                         filemode='w')
     logging.debug(f'Finished setting up debug file logging in {logfile}')

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -1046,6 +1046,15 @@ if __name__ == "__main__":
 class Testing(unittest.TestCase):
     def test_generate_FV3LAM_wflow(self):
 
+        # run workflows in separate process to avoid conflict between community and nco settings
+        def run_workflow():
+            p = Process(target=generate_FV3LAM_wflow)
+            p.start()
+            p.join()
+            exit_code = p.exitcode
+            if exit_code != 0:
+                sys.exit(exit_code)
+
         USHdir = os.path.dirname(os.path.abspath(__file__))
         logfile='log.generate_FV3LAM_wflow'
         SED = get_env_var("SED")

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -123,8 +123,8 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     # Create a multiline variable that consists of a yaml-compliant string
     # specifying the values that the jinja variables in the template rocoto
     # XML should be set to.  These values are set either in the user-specified
-    # workflow configuration file (EXPT_CONFIG_FN) or in the setup.sh script
-    # sourced above.  Then call the python script that generates the XML.
+    # workflow configuration file (EXPT_CONFIG_FN) or in the setup() function
+    # called above.  Then call the python script that generates the XML.
     #
     # -----------------------------------------------------------------------
     #
@@ -492,19 +492,9 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     #
     if USE_CRON_TO_RELAUNCH:
         add_crontab_line()
-    #
-    # -----------------------------------------------------------------------
-    #
-    # Create the FIXam directory under the experiment directory.  In NCO mode,
-    # this will be a symlink to the directory specified in FIXgsm, while in
-    # community mode, it will be an actual directory with files copied into
-    # it from FIXgsm.
-    #
-    # -----------------------------------------------------------------------
-    #
 
     #
-    # Symlink fix files
+    # Copy or symlink fix files
     #
     if SYMLINK_FIX_FILES:
 
@@ -516,9 +506,6 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
         )
 
         ln_vrfy(f'''-fsn "{FIXgsm}" "{FIXam}"''')
-    #
-    # Copy relevant fix files.
-    #
     else:
 
         logging.info(
@@ -637,9 +624,6 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
     # For the physics suites that use RUC LSM, set the parameter kice to 9,
     # Otherwise, leave it unspecified (which means it gets set to the default
     # value in the forecast model).
-    #
-    # NOTE:
-    # May want to remove kice from FV3.input.yml (and maybe input.nml.FV3).
     #
     kice = None
     if SDF_USES_RUC_LSM:
@@ -981,22 +965,6 @@ def generate_FV3LAM_wflow(USHdir, logfile: str = 'log.generate_FV3LAM_wflow') ->
 
         logging.info(
             f"""
-            To launch the workflow, first ensure that you have a compatible version
-            of rocoto available. For most pre-configured platforms, rocoto can be
-            loaded via a module:
-
-              > module load rocoto
-
-            For more details on rocoto, see the User's Guide.
-
-            To launch the workflow, first ensure that you have a compatible version
-            of rocoto loaded.  For example, to load version 1.3.1 of rocoto, use
-
-              > module load rocoto/1.3.1
-
-            (This version has been tested on hera; later versions may also work but
-            have not been tested.)
-
             To launch the workflow, change location to the experiment directory
             (EXPTDIR) and issue the rocotrun command, as follows:
 

--- a/ush/get_crontab_contents.py
+++ b/ush/get_crontab_contents.py
@@ -104,7 +104,8 @@ def add_crontab_line():
     log_info(
         f'''
         Copying contents of user cron table to backup file:
-          crontab_backup_fp = \"{crontab_backup_fp}\"'''
+          crontab_backup_fp = \"{crontab_backup_fp}\"''',
+        verbose=VERBOSE,
     )
 
     global called_from_cron
@@ -137,7 +138,8 @@ def add_crontab_line():
             f'''
             Adding the following line to the user's cron table in order to automatically
             resubmit SRW workflow:
-              CRONTAB_LINE = \"{CRONTAB_LINE}\"'''
+              CRONTAB_LINE = \"{CRONTAB_LINE}\"''',
+            verbose=VERBOSE,
         )
 
         # add new line to crontab contents if it doesn't have one

--- a/ush/get_crontab_contents.py
+++ b/ush/get_crontab_contents.py
@@ -6,6 +6,7 @@ import unittest
 import argparse
 from datetime import datetime
 from logging import getLogger
+from textwrap import dedent
 
 from python_utils import (
     import_vars,

--- a/ush/get_crontab_contents.py
+++ b/ush/get_crontab_contents.py
@@ -5,6 +5,7 @@ import sys
 import unittest
 import argparse
 from datetime import datetime
+from logging import getLogger
 
 from python_utils import (
     import_vars,
@@ -90,6 +91,7 @@ def get_crontab_contents(called_from_cron):
 def add_crontab_line():
     """Add crontab line to cron table"""
 
+    logger = getLogger(__name__)
     # import selected env vars
     IMPORTS = ["MACHINE", "USER", "CRONTAB_LINE", "VERBOSE", "EXPTDIR"]
     import_vars(env_vars=IMPORTS)
@@ -99,12 +101,11 @@ def add_crontab_line():
     #
     time_stamp = datetime.now().strftime("%F_%T")
     crontab_backup_fp = os.path.join(EXPTDIR, f"crontab.bak.{time_stamp}")
-    print_info_msg(
+    logger.info(dedent(
         f'''
         Copying contents of user cron table to backup file:
-          crontab_backup_fp = \"{crontab_backup_fp}\"''',
-        verbose=VERBOSE,
-    )
+          crontab_backup_fp = \"{crontab_backup_fp}\"'''
+    ))
 
     global called_from_cron
     try:
@@ -123,22 +124,21 @@ def add_crontab_line():
     # Add crontab line
     if CRONTAB_LINE in crontab_contents:
 
-        print_info_msg(
+        logger.info(dedent(
             f'''
             The following line already exists in the cron table and thus will not be
             added:
               CRONTAB_LINE = \"{CRONTAB_LINE}\"'''
-        )
+        ))
 
     else:
 
-        print_info_msg(
+        logger.info(dedent(
             f'''
             Adding the following line to the user's cron table in order to automatically
             resubmit SRW workflow:
-              CRONTAB_LINE = \"{CRONTAB_LINE}\"''',
-            verbose=VERBOSE,
-        )
+              CRONTAB_LINE = \"{CRONTAB_LINE}\"'''
+        ))
 
         # add new line to crontab contents if it doesn't have one
         NEWLINE_CHAR = ""

--- a/ush/get_crontab_contents.py
+++ b/ush/get_crontab_contents.py
@@ -5,10 +5,10 @@ import sys
 import unittest
 import argparse
 from datetime import datetime
-from logging import getLogger
 from textwrap import dedent
 
 from python_utils import (
+    log_info,
     import_vars,
     set_env_var,
     print_input_args,
@@ -92,7 +92,6 @@ def get_crontab_contents(called_from_cron):
 def add_crontab_line():
     """Add crontab line to cron table"""
 
-    logger = getLogger(__name__)
     # import selected env vars
     IMPORTS = ["MACHINE", "USER", "CRONTAB_LINE", "VERBOSE", "EXPTDIR"]
     import_vars(env_vars=IMPORTS)
@@ -102,11 +101,11 @@ def add_crontab_line():
     #
     time_stamp = datetime.now().strftime("%F_%T")
     crontab_backup_fp = os.path.join(EXPTDIR, f"crontab.bak.{time_stamp}")
-    logger.info(dedent(
+    log_info(
         f'''
         Copying contents of user cron table to backup file:
           crontab_backup_fp = \"{crontab_backup_fp}\"'''
-    ))
+    )
 
     global called_from_cron
     try:
@@ -125,21 +124,21 @@ def add_crontab_line():
     # Add crontab line
     if CRONTAB_LINE in crontab_contents:
 
-        logger.info(dedent(
+        log_info(
             f'''
             The following line already exists in the cron table and thus will not be
             added:
               CRONTAB_LINE = \"{CRONTAB_LINE}\"'''
-        ))
+        )
 
     else:
 
-        logger.info(dedent(
+        log_info(
             f'''
             Adding the following line to the user's cron table in order to automatically
             resubmit SRW workflow:
               CRONTAB_LINE = \"{CRONTAB_LINE}\"'''
-        ))
+        )
 
         # add new line to crontab contents if it doesn't have one
         NEWLINE_CHAR = ""

--- a/ush/python_utils/__init__.py
+++ b/ush/python_utils/__init__.py
@@ -28,7 +28,7 @@ from .filesys_cmds_vrfy import (
 from .get_elem_inds import get_elem_inds
 from .interpol_to_arbit_CRES import interpol_to_arbit_CRES
 from .print_input_args import print_input_args
-from .print_msg import print_info_msg, print_err_msg_exit
+from .print_msg import print_info_msg, print_err_msg_exit, log_info
 from .run_command import run_command
 from .get_charvar_from_netcdf import get_charvar_from_netcdf
 from .xml_parser import load_xml_file, has_tag_with_value

--- a/ush/python_utils/check_for_preexist_dir_file.py
+++ b/ush/python_utils/check_for_preexist_dir_file.py
@@ -2,7 +2,8 @@
 
 import os
 from datetime import datetime
-from .print_msg import print_info_msg, print_err_msg_exit
+from logging import getLogger
+from textwrap import dedent
 from .check_var_valid_value import check_var_valid_value
 from .filesys_cmds_vrfy import rm_vrfy, mv_vrfy
 
@@ -27,17 +28,17 @@ def check_for_preexist_dir_file(path, method):
             now = datetime.now()
             d = now.strftime("_old_%Y%m%d_%H%M%S")
             new_path = path + d
-            print_info_msg(
+            logger.info(dedent(
                 f"""
                 Specified directory or file already exists:
                     {path}
                 Moving (renaming) preexisting directory or file to:
                     {new_path}"""
-            )
+            ))
             mv_vrfy(path, new_path)
         else:
-            print_err_msg_exit(
+            raise FileExistsError(dedent(
                 f"""
                 Specified directory or file already exists
                     {path}"""
-            )
+            ))

--- a/ush/python_utils/check_for_preexist_dir_file.py
+++ b/ush/python_utils/check_for_preexist_dir_file.py
@@ -19,7 +19,14 @@ def check_for_preexist_dir_file(path, method):
         None
     """
 
-    check_var_valid_value(method, ["delete", "rename", "quit"])
+    try:
+        check_var_valid_value(method, ["delete", "rename", "quit"])
+    except ValueError:
+        errmsg = dedent(f'''
+                        Invalid method for dealing with pre-existing directory specified
+                        {method=}
+                        ''')
+        raise ValueError(errmsg) from None
 
     if os.path.exists(path):
         if method == "delete":

--- a/ush/python_utils/check_for_preexist_dir_file.py
+++ b/ush/python_utils/check_for_preexist_dir_file.py
@@ -2,11 +2,10 @@
 
 import os
 from datetime import datetime
-from logging import getLogger
 from textwrap import dedent
 from .check_var_valid_value import check_var_valid_value
 from .filesys_cmds_vrfy import rm_vrfy, mv_vrfy
-
+from .print_msg import log_info
 
 def check_for_preexist_dir_file(path, method):
     """Check for a preexisting directory or file and, if present, deal with it
@@ -18,8 +17,6 @@ def check_for_preexist_dir_file(path, method):
     Returns:
         None
     """
-
-    logger = getLogger(__name__)
 
     try:
         check_var_valid_value(method, ["delete", "rename", "quit"])
@@ -37,13 +34,13 @@ def check_for_preexist_dir_file(path, method):
             now = datetime.now()
             d = now.strftime("_old_%Y%m%d_%H%M%S")
             new_path = path + d
-            logger.info(dedent(
+            log_info(
                 f"""
                 Specified directory or file already exists:
                     {path}
                 Moving (renaming) preexisting directory or file to:
                     {new_path}"""
-            ))
+            )
             mv_vrfy(path, new_path)
         else:
             raise FileExistsError(dedent(

--- a/ush/python_utils/check_for_preexist_dir_file.py
+++ b/ush/python_utils/check_for_preexist_dir_file.py
@@ -23,7 +23,7 @@ def check_for_preexist_dir_file(path, method):
     except ValueError:
         errmsg = dedent(f'''
                         Invalid method for dealing with pre-existing directory specified
-                        {method=}
+                        method = {method}
                         ''')
         raise ValueError(errmsg) from None
 

--- a/ush/python_utils/check_for_preexist_dir_file.py
+++ b/ush/python_utils/check_for_preexist_dir_file.py
@@ -19,6 +19,8 @@ def check_for_preexist_dir_file(path, method):
         None
     """
 
+    logger = getLogger(__name__)
+
     try:
         check_var_valid_value(method, ["delete", "rename", "quit"])
     except ValueError:

--- a/ush/python_utils/check_var_valid_value.py
+++ b/ush/python_utils/check_var_valid_value.py
@@ -1,23 +1,17 @@
 #!/usr/bin/env python3
 
-from .print_msg import print_err_msg_exit
-
-
-def check_var_valid_value(var, values, err_msg=None):
+def check_var_valid_value(var, values):
     """Check if specified variable has a valid value
 
     Args:
         var: the variable
         values: list of valid values
-        err_msg: additional error message to print
     Returns:
         True: if var has valid value, exit(1) otherwise
     """
 
-    if var not in values:
-        if err_msg is not None:
-            err_msg = f"The value specified in var = {var} is not supported."
-        print_err_msg_exit(
-            err_msg + f"{var} must be set to one of the following:\n   {values}"
-        )
+    if not var:
+        var = ""
+    if not var or var not in values:
+        raise ValueError(f"Got '{var}', expected one of the following:\n   {values}")
     return True

--- a/ush/python_utils/check_var_valid_value.py
+++ b/ush/python_utils/check_var_valid_value.py
@@ -12,6 +12,6 @@ def check_var_valid_value(var, values):
 
     if not var:
         var = ""
-    if not var or var not in values:
+    if var not in values:
         raise ValueError(f"Got '{var}', expected one of the following:\n   {values}")
     return True

--- a/ush/python_utils/config_parser.py
+++ b/ush/python_utils/config_parser.py
@@ -44,11 +44,8 @@ from .run_command import run_command
 def load_yaml_config(config_file):
     """Safe load a yaml file"""
 
-    try:
-        with open(config_file, "r") as f:
-            cfg = yaml.safe_load(f)
-    except yaml.YAMLError as e:
-        raise Exception(f"Unable to load yaml file {config_file}")
+    with open(config_file, "r") as f:
+        cfg = yaml.safe_load(f)
 
     return cfg
 

--- a/ush/python_utils/config_parser.py
+++ b/ush/python_utils/config_parser.py
@@ -36,7 +36,6 @@ import xml.etree.ElementTree as ET
 from xml.dom import minidom
 
 from .environment import list_to_str, str_to_list
-from .print_msg import print_err_msg_exit
 from .run_command import run_command
 
 ##########
@@ -49,7 +48,7 @@ def load_yaml_config(config_file):
         with open(config_file, "r") as f:
             cfg = yaml.safe_load(f)
     except yaml.YAMLError as e:
-        print_err_msg_exit(str(e))
+        raise Exception(f"Unable to load yaml file {config_file}")
 
     return cfg
 
@@ -102,7 +101,7 @@ def load_json_config(config_file):
         with open(config_file, "r") as f:
             cfg = json.load(f)
     except json.JSONDecodeError as e:
-        print_err_msg_exit(str(e))
+        raise Exception(f"Unable to load json file {config_file}")
 
     return cfg
 
@@ -218,11 +217,10 @@ def load_ini_config(config_file, return_string=0):
     """Load a config file with a format similar to Microsoft's INI files"""
 
     if not os.path.exists(config_file):
-        print_err_msg_exit(
-            f'''
-            The specified configuration file does not exist:
-                  \"{config_file}\"'''
-        )
+        raise FileNotFoundError(dedent(f'''
+                                The specified configuration file does not exist:
+                                "{config_file}"'''
+        ))
 
     config = configparser.RawConfigParser()
     config.optionxform = str
@@ -238,12 +236,7 @@ def get_ini_value(config, section, key):
     """Finds the value of a property in a given section"""
 
     if not section in config:
-        print_err_msg_exit(
-            f'''
-            Section not found:
-              section = \"{section}\"
-              valid sections = \"{config.keys()}\"'''
-        )
+        raise KeyError(f'Section not found: {section}')
     else:
         return config[section][key]
 

--- a/ush/python_utils/print_msg.py
+++ b/ush/python_utils/print_msg.py
@@ -2,7 +2,8 @@
 
 import traceback
 import sys
-from textwrap import dedent
+from textwrap import dedent, indent
+from logging import getLogger
 
 
 def print_err_msg_exit(error_msg="", stack_trace=True):
@@ -39,3 +40,21 @@ def print_info_msg(info_msg, verbose=True):
         print(dedent(info_msg))
         return True
     return False
+
+def log_info(info_msg, ddent=True):
+    """Function to print information message using the logging module. This function
+    should not be used if python logging has not been initialized.
+
+    Args:
+        info_msg : info message to print
+        ddent : set to False to disable "dedenting" (print string as-is)
+    Returns:
+        None
+    """
+
+    logger=getLogger(sys._getframe().f_back.f_code.co_name)
+    if ddent:
+        logger.info(indent(dedent(info_msg), '  '))
+    else:
+        logger.info(info_msg)
+

--- a/ush/python_utils/print_msg.py
+++ b/ush/python_utils/print_msg.py
@@ -41,14 +41,14 @@ def print_info_msg(info_msg, verbose=True):
         return True
     return False
 
-def log_info(info_msg, verbose=True, ddent=True):
+def log_info(info_msg, verbose=True, dedent_=True):
     """Function to print information message using the logging module. This function
     should not be used if python logging has not been initialized.
 
     Args:
         info_msg : info message to print
         verbose : set to False to silence printing
-        ddent : set to False to disable "dedenting" (print string as-is)
+        dedent_ : set to False to disable "dedenting" (print string as-is)
     Returns:
         None
     """
@@ -57,7 +57,7 @@ def log_info(info_msg, verbose=True, ddent=True):
     logger=getLogger(sys._getframe().f_back.f_code.co_name)
 
     if verbose:
-        if ddent:
+        if dedent_:
             logger.info(indent(dedent(info_msg), '  '))
         else:
             logger.info(info_msg)

--- a/ush/python_utils/print_msg.py
+++ b/ush/python_utils/print_msg.py
@@ -52,6 +52,7 @@ def log_info(info_msg, ddent=True):
         None
     """
 
+    # "sys._getframe().f_back.f_code.co_name" returns the name of the calling function
     logger=getLogger(sys._getframe().f_back.f_code.co_name)
     if ddent:
         logger.info(indent(dedent(info_msg), '  '))

--- a/ush/python_utils/print_msg.py
+++ b/ush/python_utils/print_msg.py
@@ -41,12 +41,13 @@ def print_info_msg(info_msg, verbose=True):
         return True
     return False
 
-def log_info(info_msg, ddent=True):
+def log_info(info_msg, verbose=True, ddent=True):
     """Function to print information message using the logging module. This function
     should not be used if python logging has not been initialized.
 
     Args:
         info_msg : info message to print
+        verbose : set to False to silence printing
         ddent : set to False to disable "dedenting" (print string as-is)
     Returns:
         None
@@ -54,8 +55,10 @@ def log_info(info_msg, ddent=True):
 
     # "sys._getframe().f_back.f_code.co_name" returns the name of the calling function
     logger=getLogger(sys._getframe().f_back.f_code.co_name)
-    if ddent:
-        logger.info(indent(dedent(info_msg), '  '))
-    else:
-        logger.info(info_msg)
+
+    if verbose:
+        if ddent:
+            logger.info(indent(dedent(info_msg), '  '))
+        else:
+            logger.info(info_msg)
 

--- a/ush/set_ozone_param.py
+++ b/ush/set_ozone_param.py
@@ -3,9 +3,9 @@
 import os
 import unittest
 from textwrap import dedent
-from logging import getLogger
 
 from python_utils import (
+    log_info,
     import_vars,
     export_vars,
     set_env_var,
@@ -45,7 +45,6 @@ def set_ozone_param(ccpp_phys_suite_fp):
         ozone_param: a string
     """
 
-    logger = getLogger(__name__)
     print_input_args(locals())
 
     # import all environment variables
@@ -149,23 +148,17 @@ def set_ozone_param(ccpp_phys_suite_fp):
     # -----------------------------------------------------------------------
     #
     if fixgsm_ozone_fn_is_set:
-
-        msg = dedent(
+        log_info(
             f"""
             After setting the file name of the ozone production/loss file in the
             FIXgsm directory (based on the ozone parameterization specified in the
             CCPP suite definition file), the array specifying the mapping between
             the symlinks that need to be created in the cycle directories and the
             files in the FIXam directory is:
-
-            """
-        )
-        msg += dedent(
-            f"""
+            """)
+        log_info(f"""
               CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING = {list_to_str(CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING)}
-            """
-        )
-        logger.info(msg)
+            """, ddent=False)
 
     else:
 

--- a/ush/set_ozone_param.py
+++ b/ush/set_ozone_param.py
@@ -3,6 +3,7 @@
 import os
 import unittest
 from textwrap import dedent
+from logging import getLogger
 
 from python_utils import (
     import_vars,
@@ -10,14 +11,11 @@ from python_utils import (
     set_env_var,
     list_to_str,
     print_input_args,
-    print_info_msg,
-    print_err_msg_exit,
     define_macos_utilities,
     load_xml_file,
     has_tag_with_value,
     find_pattern_in_str,
 )
-
 
 def set_ozone_param(ccpp_phys_suite_fp):
     """Function that does the following:
@@ -47,6 +45,7 @@ def set_ozone_param(ccpp_phys_suite_fp):
         ozone_param: a string
     """
 
+    logger = getLogger(__name__)
     print_input_args(locals())
 
     # import all environment variables
@@ -92,12 +91,11 @@ def set_ozone_param(ccpp_phys_suite_fp):
         fixgsm_ozone_fn = "global_o3prdlos.f77"
         ozone_param = "ozphys"
     else:
-        print_err_msg_exit(
+        raise Exception(
             f'''
             Unknown or no ozone parameterization
             specified in the CCPP physics suite file (ccpp_phys_suite_fp):
-              ccpp_phys_suite_fp = \"{ccpp_phys_suite_fp}\"
-              ozone_param = \"{ozone_param}\"'''
+              ccpp_phys_suite_fp = \"{ccpp_phys_suite_fp}\"'''
         )
     #
     # -----------------------------------------------------------------------
@@ -167,11 +165,11 @@ def set_ozone_param(ccpp_phys_suite_fp):
               CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING = {list_to_str(CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING)}
             """
         )
-        print_info_msg(msg, verbose=VERBOSE)
+        logger.info(msg)
 
     else:
 
-        print_err_msg_exit(
+        raise Exception(
             f'''
             Unable to set name of the ozone production/loss file in the FIXgsm directory
             in the array that specifies the mapping between the symlinks that need to

--- a/ush/set_ozone_param.py
+++ b/ush/set_ozone_param.py
@@ -155,10 +155,10 @@ def set_ozone_param(ccpp_phys_suite_fp):
             CCPP suite definition file), the array specifying the mapping between
             the symlinks that need to be created in the cycle directories and the
             files in the FIXam directory is:
-            """)
+            """, verbose=VERBOSE)
         log_info(f"""
               CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING = {list_to_str(CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING)}
-            """, ddent=False)
+            """, verbose=VERBOSE, ddent=False)
 
     else:
 

--- a/ush/set_ozone_param.py
+++ b/ush/set_ozone_param.py
@@ -90,12 +90,8 @@ def set_ozone_param(ccpp_phys_suite_fp):
         fixgsm_ozone_fn = "global_o3prdlos.f77"
         ozone_param = "ozphys"
     else:
-        raise Exception(
-            f'''
-            Unknown or no ozone parameterization
-            specified in the CCPP physics suite file (ccpp_phys_suite_fp):
-              ccpp_phys_suite_fp = \"{ccpp_phys_suite_fp}\"'''
-        )
+        raise KeyError(f'Unknown or no ozone parameterization specified in the '
+                        'CCPP physics suite file "{ccpp_phys_suite_fp}"')
     #
     # -----------------------------------------------------------------------
     #
@@ -158,7 +154,7 @@ def set_ozone_param(ccpp_phys_suite_fp):
             """, verbose=VERBOSE)
         log_info(f"""
               CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING = {list_to_str(CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING)}
-            """, verbose=VERBOSE, ddent=False)
+            """, verbose=VERBOSE, dedent_=False)
 
     else:
 

--- a/ush/set_predef_grid_params.py
+++ b/ush/set_predef_grid_params.py
@@ -2,6 +2,7 @@
 
 import unittest
 import os
+from textwrap import dedent
 
 from python_utils import (
     import_vars,
@@ -37,7 +38,14 @@ def set_predef_grid_params():
 
     USHdir = os.path.dirname(os.path.abspath(__file__))
     params_dict = load_config_file(os.path.join(USHdir, "predef_grid_params.yaml"))
-    params_dict = params_dict[PREDEF_GRID_NAME]
+    try:
+        params_dict = params_dict[PREDEF_GRID_NAME]
+    except KeyError:
+        errmsg = dedent(f'''
+                        {PREDEF_GRID_NAME=} not found in predef_grid_params.yaml
+                        Check your config file settings.''')
+        raise Exception(errmsg) from None
+
 
     # if QUILTING = False, remove key
     if not QUILTING:

--- a/ush/set_predef_grid_params.py
+++ b/ush/set_predef_grid_params.py
@@ -42,7 +42,7 @@ def set_predef_grid_params():
         params_dict = params_dict[PREDEF_GRID_NAME]
     except KeyError:
         errmsg = dedent(f'''
-                        {PREDEF_GRID_NAME=} not found in predef_grid_params.yaml
+                        PREDEF_GRID_NAME = {PREDEF_GRID_NAME} not found in predef_grid_params.yaml
                         Check your config file settings.''')
         raise Exception(errmsg) from None
 

--- a/ush/set_thompson_mp_fix_files.py
+++ b/ush/set_thompson_mp_fix_files.py
@@ -3,9 +3,9 @@
 import os
 import unittest
 from textwrap import dedent
-from logging import getLogger
 
 from python_utils import (
+    log_info,
     import_vars,
     export_vars,
     set_env_var,
@@ -35,7 +35,6 @@ def set_thompson_mp_fix_files(ccpp_phys_suite_fp, thompson_mp_climo_fn):
         boolean: sdf_uses_thompson_mp
     """
 
-    logger = getLogger(__name__)
     print_input_args(locals())
 
     # import all environment variables
@@ -90,7 +89,7 @@ def set_thompson_mp_fix_files(ccpp_phys_suite_fp, thompson_mp_climo_fn):
             mapping = f"{fix_file} | {fix_file}"
             CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING.append(mapping)
 
-        msg = dedent(
+        log_info(
             f"""
             Since the Thompson microphysics parameterization is being used by this
             physics suite (CCPP_PHYS_SUITE), the names of the fixed files needed by
@@ -100,21 +99,19 @@ def set_thompson_mp_fix_files(ccpp_phys_suite_fp, thompson_mp_climo_fn):
             CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING.  After these modifications, the
             values of these parameters are as follows:
 
+            CCPP_PHYS_SUITE = \"{CCPP_PHYS_SUITE}\"
             """
         )
-        msg += dedent(
+        log_info(
             f"""
-                CCPP_PHYS_SUITE = \"{CCPP_PHYS_SUITE}\"
-
                 FIXgsm_FILES_TO_COPY_TO_FIXam = {list_to_str(FIXgsm_FILES_TO_COPY_TO_FIXam)}
             """
         )
-        msg += dedent(
+        log_info(
             f"""
                 CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING = {list_to_str(CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING)}
             """
         )
-        logger.info(msg)
 
         EXPORTS = [
             "CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING",

--- a/ush/set_thompson_mp_fix_files.py
+++ b/ush/set_thompson_mp_fix_files.py
@@ -3,6 +3,7 @@
 import os
 import unittest
 from textwrap import dedent
+from logging import getLogger
 
 from python_utils import (
     import_vars,
@@ -10,8 +11,6 @@ from python_utils import (
     set_env_var,
     list_to_str,
     print_input_args,
-    print_info_msg,
-    print_err_msg_exit,
     define_macos_utilities,
     load_xml_file,
     has_tag_with_value,
@@ -36,6 +35,7 @@ def set_thompson_mp_fix_files(ccpp_phys_suite_fp, thompson_mp_climo_fn):
         boolean: sdf_uses_thompson_mp
     """
 
+    logger = getLogger(__name__)
     print_input_args(locals())
 
     # import all environment variables
@@ -114,7 +114,7 @@ def set_thompson_mp_fix_files(ccpp_phys_suite_fp, thompson_mp_climo_fn):
                 CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING = {list_to_str(CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING)}
             """
         )
-        print_info_msg(msg)
+        logger.info(msg)
 
         EXPORTS = [
             "CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING",

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -542,6 +542,7 @@ def setup():
     # If using a custom post configuration file, make sure that it exists.
     if USE_CUSTOM_POST_CONFIG_FILE:
         try:
+            #os.path.exists returns exception if passed an empty string or None, so use "try/except" as a 2-for-1 error catch
             if not os.path.exists(CUSTOM_POST_CONFIG_FP):
                 raise
         except:
@@ -556,6 +557,7 @@ def setup():
     # satellite products from the UPP, make sure the CRTM fix file directory exists.
     if USE_CRTM:
         try:
+            #os.path.exists returns exception if passed an empty string or None, so use "try/except" as a 2-for-1 error catch
             if not os.path.exists(CRTM_DIR):
                 raise
         except:

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -1123,17 +1123,6 @@ def setup():
     # Set the full path to the forecast model executable.
     global FV3_EXEC_FP
     FV3_EXEC_FP = os.path.join(EXECdir, FV3_EXEC_FN)
-    if not os.path.exists(FV3_EXEC_FP):
-        raise FileNotFoundError(dedent(
-            f'''
-            The forecast model executable
-
-            {FV3_EXEC_FP=}
-
-            does not exist! Ensure you have successfully built the SRW App executables
-            prior to running this script!'''
-        ))
-
     #
     # -----------------------------------------------------------------------
     #

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import datetime
+import traceback
 from textwrap import dedent
 from logging import getLogger
 
@@ -88,8 +89,7 @@ def setup():
                   "FV3GFS_FILE_FMT_ICS", "FV3GFS_FILE_FMT_LBCS"])
 
 
-    # Load the user config file, containing contains user-specified values 
-    # variables that override their default values. Ensure all user-specified
+    # Load the user config file, then ensure all user-specified
     # variables correspond to a default value. 
     if not os.path.exists(EXPT_CONFIG_FN):
         raise FileNotFoundError(f'User config file not found: EXPT_CONFIG_FN = {EXPT_CONFIG_FN}')
@@ -99,16 +99,16 @@ def setup():
     except:
         errmsg = dedent(f'''\n
                         Could not load YAML config file:  {EXPT_CONFIG_FN}
-                        The file may be formatted incorrectly; reference the Users Guide for more info 
+                        Reference the above traceback for more information.
                         ''')
-        raise Exception(errmsg) from None
+        raise Exception(errmsg)
 
     cfg_u = flatten_dict(cfg_u)
     for key in cfg_u:
         if key not in flatten_dict(cfg_d):
             raise Exception(dedent(f'''
                             User-specified variable "{key}" in {EXPT_CONFIG_FN} is not valid
-                            Check {EXPT_DEFAULT_CONFIG_FN} for allowed user-specified variables\n'''))
+                            Check {EXPT_DEFAULT_CONFIG_FN} for allowed user-specified variables.\n'''))
 
     # Mandatory variables *must* be set in the user's config; the default value is invalid
     mandatory = ['MACHINE']
@@ -429,9 +429,10 @@ def setup():
 
     # Mandatory variables *must* be set in the user's config or the machine file; the default value is invalid
     mandatory = ['NCORES_PER_NODE', 'FIXgsm', 'FIXaer', 'FIXlut', 'TOPO_DIR', 'SFC_CLIMO_INPUT_DIR']
+    globalvars = globals()
     for val in mandatory:
         # globals() returns dictionary of global variables
-        if not globals()[val]:
+        if not globalvars[val]:
             raise Exception(dedent(f'''
                             Mandatory variable "{val}" not found in:
                             user config file {EXPT_CONFIG_FN}

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -1504,11 +1504,13 @@ def setup():
     if QUILTING:
         PE_MEMBER01 = PE_MEMBER01 + WRTCMP_write_groups * WRTCMP_write_tasks_per_group
 
-    log_info(
+    if VERBOSE:
+        log_info(
         f"""
         The number of MPI tasks for the forecast (including those for the write
         component if it is being used) are:
           PE_MEMBER01 = {PE_MEMBER01}""",
+        verbose=VERBOSE,
     )
     #
     # -----------------------------------------------------------------------
@@ -1843,9 +1845,8 @@ def setup():
     #
 
     # print content of var_defns if DEBUG=True
-    if DEBUG:
-        all_lines = cfg_to_yaml_str(cfg_d)
-        log_info(all_lines)
+    all_lines = cfg_to_yaml_str(cfg_d)
+    log_info(all_lines, verbose=DEBUG)
 
     # print info message
     log_info(

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -107,7 +107,7 @@ def setup():
     for key in cfg_u:
         if key not in flatten_dict(cfg_d):
             raise Exception(dedent(f'''
-                            User-specified variable "{key}" in {EXPT_CONFIG_FN} is not valid
+                            User-specified variable "{key}" in {EXPT_CONFIG_FN} is not valid.
                             Check {EXPT_DEFAULT_CONFIG_FN} for allowed user-specified variables.\n'''))
 
     # Mandatory variables *must* be set in the user's config; the default value is invalid

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -1123,6 +1123,17 @@ def setup():
     # Set the full path to the forecast model executable.
     global FV3_EXEC_FP
     FV3_EXEC_FP = os.path.join(EXECdir, FV3_EXEC_FN)
+    if not os.path.exists(FV3_EXEC_FP):
+        raise FileNotFoundError(dedent(
+            f'''
+            The forecast model executable
+
+            {FV3_EXEC_FP=}
+
+            does not exist! Ensure you have successfully built the SRW App executables
+            prior to running this script!'''
+        ))
+
     #
     # -----------------------------------------------------------------------
     #

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -92,7 +92,7 @@ def setup():
     # variables that override their default values. Ensure all user-specified
     # variables correspond to a default value. 
     if not os.path.exists(EXPT_CONFIG_FN):
-        raise FileNotFoundError(f'User config file not found: {EXPT_CONFIG_FN=}')
+        raise FileNotFoundError(f'User config file not found: EXPT_CONFIG_FN = {EXPT_CONFIG_FN}')
 
     try:
         cfg_u = load_config_file(os.path.join(USHdir, EXPT_CONFIG_FN))
@@ -134,7 +134,7 @@ def setup():
         raise FileNotFoundError(dedent(
             f"""
             The machine file {MACHINE_FILE} does not exist.
-            Check that you have specified the correct machine ({MACHINE=}) in your config file {EXPT_CONFIG_FN}"""
+            Check that you have specified the correct machine ({MACHINE}) in your config file {EXPT_CONFIG_FN}"""
         ))
     machine_cfg = load_config_file(MACHINE_FILE)
 
@@ -307,14 +307,14 @@ def setup():
                 All MYNN PBL, MYNN SFC, GSL GWD, Thompson MP, or RRTMG SPP-related namelist
                 variables set in {EXPT_CONFIG_FN} must be equal in number of entries to what is
                 found in SPP_VAR_LIST:
-                  {len(SPP_VAR_LIST)=}
-                  {len(SPP_MAG_LIST)=}
-                  {len(SPP_LSCALE)=}
-                  {len(SPP_TSCALE)=}
-                  {len(SPP_SIGTOP1)=}
-                  {len(SPP_SIGTOP2)=}
-                  {len(SPP_STDDEV_CUTOFF)=}
-                  {len(ISEED_SPP)=}
+                  SPP_VAR_LIST (length {len(SPP_VAR_LIST)})
+                  SPP_MAG_LIST (length {len(SPP_MAG_LIST)})
+                  SPP_LSCALE (length {len(SPP_LSCALE)})
+                  SPP_TSCALE (length {len(SPP_TSCALE)})
+                  SPP_SIGTOP1 (length {len(SPP_SIGTOP1)})
+                  SPP_SIGTOP2 (length {len(SPP_SIGTOP2)})
+                  SPP_STDDEV_CUTOFF (length {len(SPP_STDDEV_CUTOFF)})
+                  ISEED_SPP (length {len(ISEED_SPP)})
                 '''
             )
     #
@@ -337,10 +337,10 @@ def setup():
                 All Noah or RUC-LSM SPP-related namelist variables (except ISEED_LSM_SPP)
                 set in {EXPT_CONFIG_FN} must be equal in number of entries to what is found in
                 SPP_VAR_LIST:
-                  {len(LSM_SPP_VAR_LIST)=}
-                  {len(LSM_SPP_MAG_LIST)=}
-                  {len(LSM_SPP_LSCALE)=}
-                  {len(LSM_SPP_TSCALE)=}
+                  LSM_SPP_VAR_LIST (length {len(LSM_SPP_VAR_LIST)})
+                  LSM_SPP_MAG_LIST (length {len(LSM_SPP_MAG_LIST)})
+                  LSM_SPP_LSCALE (length {len(LSM_SPP_LSCALE)})
+                  LSM_SPP_TSCALE (length {len(LSM_SPP_TSCALE)})
                   '''
             )
     #
@@ -479,7 +479,7 @@ def setup():
         if not ACCOUNT:
             raise Exception(dedent(f'''
                   ACCOUNT must be specified in config or machine file if using a workflow manager.
-                  {WORKFLOW_MANAGER=}\n'''
+                  WORKFLOW_MANAGER = {WORKFLOW_MANAGER}\n'''
             ))
     #
     # -----------------------------------------------------------------------
@@ -522,7 +522,7 @@ def setup():
 
     # Make sure RESTART_INTERVAL is set to an integer value
     if not isinstance(RESTART_INTERVAL, int):
-        raise Exception(f"\n{RESTART_INTERVAL=}, must be an integer value\n")
+        raise Exception(f"\nRESTART_INTERVAL = {RESTART_INTERVAL}, must be an integer value\n")
 
     # Check that input dates are in a date format
 
@@ -547,7 +547,7 @@ def setup():
             raise FileNotFoundError(dedent(
                 f'''
                 USE_CUSTOM_POST_CONFIG_FILE has been set, but the custom post configuration file
-                {CUSTOM_POST_CONFIG_FP=}
+                CUSTOM_POST_CONFIG_FP = {CUSTOM_POST_CONFIG_FP}
                 could not be found.'''
             )) from None
 
@@ -561,7 +561,7 @@ def setup():
             raise FileNotFoundError(dedent(
                 f'''
                 USE_CRTM has been set, but the external CRTM fix file directory:
-                {CRTM_DIR=}
+                CRTM_DIR = {CRTM_DIR}
                 could not be found.'''
             )) from None
 
@@ -739,13 +739,13 @@ def setup():
     except ValueError:
         logger.exception(f'''
                         Check that the following values are valid:
-                        {EXPTDIR=}
-                        {PREEXISTING_DIR_METHOD=}
+                        EXPTDIR {EXPTDIR}
+                        PREEXISTING_DIR_METHOD {PREEXISTING_DIR_METHOD}
                         ''')
         raise
     except FileExistsError:
         errmsg = dedent(f'''
-                        {EXPTDIR=} already exists, and {PREEXISTING_DIR_METHOD=}
+                        EXPTDIR ({EXPTDIR}) already exists, and PREEXISTING_DIR_METHOD = {PREEXISTING_DIR_METHOD}
 
                         To ignore this error, delete the directory, or set 
                         PREEXISTING_DIR_METHOD = delete, or
@@ -1221,7 +1221,7 @@ def setup():
 
             msg = dedent(f"""
                GRID_DIR not specified!
-               Setting {GRID_DIR=}
+               Setting GRID_DIR = {GRID_DIR}
             """)
             logger.warning(msg)
 
@@ -1246,7 +1246,7 @@ def setup():
 
             msg = dedent(f"""
                OROG_DIR not specified!
-               Setting {OROG_DIR=}
+               Setting OROG_DIR = {OROG_DIR}
             """)
             logger.warning(msg)
 
@@ -1271,7 +1271,7 @@ def setup():
 
             msg = dedent(f"""
                SFC_CLIMO_DIR not specified!
-               Setting {SFC_CLIMO_DIR=}
+               Setting SFC_CLIMO_DIR ={SFC_CLIMO_DIR}
             """)
             logger.warning(msg)
 

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -86,18 +86,19 @@ def setup(logger: Logger = getLogger()):
                   "EXTRN_MDL_NAME_ICS", "EXTRN_MDL_NAME_LBCS",
                   "FV3GFS_FILE_FMT_ICS", "FV3GFS_FILE_FMT_LBCS"])
 
-    #
-    # -----------------------------------------------------------------------
-    #
-    # Load the user config file but don't source it yet.
-    #
-    # -----------------------------------------------------------------------
-    #
+
+    # Load the user config file, containing contains user-specified values 
+    # variables that override their default values. Ensure all user-specified
+    # variables correspond to a default value. 
     if not os.path.exists(EXPT_CONFIG_FN):
         raise FileNotFoundError(f'User config file not found: {EXPT_CONFIG_FN=}')
 
     cfg_u = load_config_file(os.path.join(USHdir, EXPT_CONFIG_FN))
     cfg_u = flatten_dict(cfg_u)
+    for key in cfg_u:
+        if key not in cfg_d:
+            raise Exception(dedent(f'''User-specified variable {key} in {EXPT_CONFIG_FN} is not valid
+                           Check {EXPT_DEFAULT_CONFIG_FN} for allowed user-specified variables\n'''))
     import_vars(dictionary=cfg_u, env_vars=["MACHINE",
                    "EXTRN_MDL_NAME_ICS", "EXTRN_MDL_NAME_LBCS",
                    "FV3GFS_FILE_FMT_ICS", "FV3GFS_FILE_FMT_LBCS"])

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -733,7 +733,18 @@ def setup():
     #
     global EXPTDIR
     EXPTDIR = os.path.join(EXPT_BASEDIR, EXPT_SUBDIR)
-    check_for_preexist_dir_file(EXPTDIR, PREEXISTING_DIR_METHOD)
+    try:
+        check_for_preexist_dir_file(EXPTDIR, PREEXISTING_DIR_METHOD)
+    except FileExistsError:
+        errmsg = dedent(f'''
+                        {EXPTDIR=} already exists, and {PREEXISTING_DIR_METHOD=}
+
+                        To ignore this error, delete the directory, or set 
+                        PREEXISTING_DIR_METHOD = delete, or
+                        PREEXISTING_DIR_METHOD = rename
+                        in your config file.
+                        ''')
+        raise Exception(errmsg) from None
     #
     # -----------------------------------------------------------------------
     #

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 from logging import getLogger
 
 from python_utils import (
+    log_info,
     cd_vrfy,
     mkdir_vrfy,
     rm_vrfy,
@@ -64,12 +65,12 @@ def setup():
     import_vars()
 
     # print message
-    logger.info(dedent(
+    log_info(
         f"""
         ========================================================================
         Starting function setup() in \"{os.path.basename(__file__)}\"...
         ========================================================================"""
-    ))
+    )
     #
     # -----------------------------------------------------------------------
     #
@@ -193,7 +194,7 @@ def setup():
     #
     global WORKFLOW_ID
     WORKFLOW_ID = "id_" + str(int(datetime.datetime.now().timestamp()))
-    logger.info(f"""WORKFLOW ID = {WORKFLOW_ID}""")
+    log_info(f"""WORKFLOW ID = {WORKFLOW_ID}""")
 
     #
     # -----------------------------------------------------------------------
@@ -220,7 +221,7 @@ def setup():
     #
     global VERBOSE
     if DEBUG and not VERBOSE:
-        logger.info(
+        log_info(
             """
             Resetting VERBOSE to \"TRUE\" because DEBUG has been set to \"TRUE\"..."""
         )
@@ -1503,7 +1504,7 @@ def setup():
     if QUILTING:
         PE_MEMBER01 = PE_MEMBER01 + WRTCMP_write_groups * WRTCMP_write_tasks_per_group
 
-    logger.info(
+    log_info(
         f"""
         The number of MPI tasks for the forecast (including those for the write
         component if it is being used) are:
@@ -1844,10 +1845,10 @@ def setup():
     # print content of var_defns if DEBUG=True
     if DEBUG:
         all_lines = cfg_to_yaml_str(cfg_d)
-        logger.info(all_lines)
+        log_info(all_lines)
 
     # print info message
-    logger.info(
+    log_info(
         f"""
         Generating the global experiment variable definitions file specified by
         GLOBAL_VAR_DEFNS_FN:

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -735,6 +735,13 @@ def setup():
     EXPTDIR = os.path.join(EXPT_BASEDIR, EXPT_SUBDIR)
     try:
         check_for_preexist_dir_file(EXPTDIR, PREEXISTING_DIR_METHOD)
+    except ValueError:
+        logger.exception(f'''
+                        Check that the following values are valid:
+                        {EXPTDIR=}
+                        {PREEXISTING_DIR_METHOD=}
+                        ''')
+        raise
     except FileExistsError:
         errmsg = dedent(f'''
                         {EXPTDIR=} already exists, and {PREEXISTING_DIR_METHOD=}
@@ -744,7 +751,7 @@ def setup():
                         PREEXISTING_DIR_METHOD = rename
                         in your config file.
                         ''')
-        raise Exception(errmsg) from None
+        raise FileExistsError(errmsg) from None
     #
     # -----------------------------------------------------------------------
     #

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -1348,10 +1348,9 @@ def setup():
     #
     # -----------------------------------------------------------------------
     #
-    # Create a new experiment directory.  Note that at this point we are
-    # guaranteed that there is no preexisting experiment directory. For
-    # platforms with no workflow manager, we need to create LOGDIR as well,
-    # since it won't be created later at runtime.
+    # Create a new experiment directory. For platforms with no workflow 
+    # manager we need to create LOGDIR as well, since it won't be created
+    # later at runtime.
     #
     # -----------------------------------------------------------------------
     #
@@ -1359,7 +1358,7 @@ def setup():
     mkdir_vrfy(f' -p "{LOGDIR}"')
     #
     # -----------------------------------------------------------------------
-    #
+    # NOTE: currently this is executed no matter what, should it be dependent on the logic described below??
     # If not running the MAKE_GRID_TN, MAKE_OROG_TN, and/or MAKE_SFC_CLIMO
     # tasks, create symlinks under the FIXlam directory to pregenerated grid,
     # orography, and surface climatology files.  In the process, also set
@@ -1455,17 +1454,16 @@ def setup():
     CRES = ""
     if not RUN_TASK_MAKE_GRID:
         CRES = f"C{RES_IN_FIXLAM_FILENAMES}"
-    #
-    # -----------------------------------------------------------------------
-    #
-    # Make sure that WRITE_DOPOST is set to a valid value.
-    #
-    # -----------------------------------------------------------------------
-    #
+
     global RUN_TASK_RUN_POST
     if WRITE_DOPOST:
         # Turn off run_post
-        RUN_TASK_RUN_POST = False
+        if RUN_TASK_RUN_POST:
+            logger.warning(dedent(f"""
+                           Inline post is turned on, deactivating post-processing tasks:
+                           RUN_TASK_RUN_POST = False
+                           """))
+            RUN_TASK_RUN_POST = False
 
         # Check if SUB_HOURLY_POST is on
         if SUB_HOURLY_POST:
@@ -1742,62 +1740,50 @@ def setup():
         # the make_grid task is complete.
         #
         "CRES": CRES,
+        #
+        # -----------------------------------------------------------------------
+        #
+        # Flag in the \"{MODEL_CONFIG_FN}\" file for coupling the ocean model to
+        # the weather model.
+        #
+        # -----------------------------------------------------------------------
+        #
+        "CPL": CPL,
+        #
+        # -----------------------------------------------------------------------
+        #
+        # Name of the ozone parameterization.  The value this gets set to depends
+        # on the CCPP physics suite being used.
+        #
+        # -----------------------------------------------------------------------
+        #
+        "OZONE_PARAM": OZONE_PARAM,
+        #
+        # -----------------------------------------------------------------------
+        #
+        # Computational parameters.
+        #
+        # -----------------------------------------------------------------------
+        #
+        "PE_MEMBER01": PE_MEMBER01,
+        #
+        # -----------------------------------------------------------------------
+        #
+        # IF DO_SPP is set to "TRUE", N_VAR_SPP specifies the number of physics
+        # parameterizations that are perturbed with SPP.  If DO_LSM_SPP is set to
+        # "TRUE", N_VAR_LNDP specifies the number of LSM parameters that are
+        # perturbed.  LNDP_TYPE determines the way LSM perturbations are employed
+        # and FHCYC_LSM_SPP_OR_NOT sets FHCYC based on whether LSM perturbations
+        # are turned on or not.
+        #
+        # -----------------------------------------------------------------------
+        #
+        "N_VAR_SPP": N_VAR_SPP,
+        "N_VAR_LNDP": N_VAR_LNDP,
+        "LNDP_TYPE": LNDP_TYPE,
+        "LNDP_MODEL_TYPE": LNDP_MODEL_TYPE,
+        "FHCYC_LSM_SPP_OR_NOT": FHCYC_LSM_SPP_OR_NOT,
     }
-    #
-    # -----------------------------------------------------------------------
-    #
-    # Continue appending variable definitions to the variable definitions
-    # file.
-    #
-    # -----------------------------------------------------------------------
-    #
-    settings.update(
-        {
-            #
-            # -----------------------------------------------------------------------
-            #
-            # Flag in the \"{MODEL_CONFIG_FN}\" file for coupling the ocean model to
-            # the weather model.
-            #
-            # -----------------------------------------------------------------------
-            #
-            "CPL": CPL,
-            #
-            # -----------------------------------------------------------------------
-            #
-            # Name of the ozone parameterization.  The value this gets set to depends
-            # on the CCPP physics suite being used.
-            #
-            # -----------------------------------------------------------------------
-            #
-            "OZONE_PARAM": OZONE_PARAM,
-            #
-            # -----------------------------------------------------------------------
-            #
-            # Computational parameters.
-            #
-            # -----------------------------------------------------------------------
-            #
-            "PE_MEMBER01": PE_MEMBER01,
-            #
-            # -----------------------------------------------------------------------
-            #
-            # IF DO_SPP is set to "TRUE", N_VAR_SPP specifies the number of physics
-            # parameterizations that are perturbed with SPP.  If DO_LSM_SPP is set to
-            # "TRUE", N_VAR_LNDP specifies the number of LSM parameters that are
-            # perturbed.  LNDP_TYPE determines the way LSM perturbations are employed
-            # and FHCYC_LSM_SPP_OR_NOT sets FHCYC based on whether LSM perturbations
-            # are turned on or not.
-            #
-            # -----------------------------------------------------------------------
-            #
-            "N_VAR_SPP": N_VAR_SPP,
-            "N_VAR_LNDP": N_VAR_LNDP,
-            "LNDP_TYPE": LNDP_TYPE,
-            "LNDP_MODEL_TYPE": LNDP_MODEL_TYPE,
-            "FHCYC_LSM_SPP_OR_NOT": FHCYC_LSM_SPP_OR_NOT,
-        }
-    )
 
     # write derived settings
     cfg_d["derived"] = settings


### PR DESCRIPTION
This PR is now open for review

## DESCRIPTION OF CHANGES: 
The error messaging in the generate_FV3LAM_wflow.py has been overhauled to be more pythonic *and* more user-friendly. The old bash-like `print_err_msg_exit()` calls are replaced with proper exception handling, and `print_info_msg()` calls are replaced with the use of Python's built-in logging module. The latter has the added benefit of giving the same "tee"-like functionality--where messages are printed to screen and written to a log file simultaneously--without the need for messy subprocesses and the confusing error messages that come with them. 

Errors are now handled in a consistent way, with the errors clearly highlighted both on screen and in the log file, as well as an easy-to-follow exception traceback for those wanting that information. In addition, several error conditions that were previously **not** caught at the generate step now cause the script to fail with helpful error messages.

From the user perspective, functionality will not change, aside from differences when error conditions are present. Successful runs will remain the same, except that some log messaging has been clarified, and the log *file* contains additional information for each message, as well as some indentation changes for ease of reading.

### Example output
In this example, I specified an invalid variable "INVALID_VAR" in config.yaml. In the current code, the script *succeeds*, which is a dangerous condition that can produce unexpected results:
**Updated code**:
```
./generate_FV3LAM_wflow.py 

  ========================================================================
  Starting experiment generation...
  ========================================================================

  ========================================================================
  Starting function setup() in "setup.py"...
  ========================================================================

*********************************************************************
Experiment generation failed. See the error message(s) printed below.
For more detailed information, check the log file from the workflow
generation script: /mnt/lfs4/BMC/gsd-fv3-dev/kavulich/workdir/PR_414/ufs-srweather-app/ush/log.generate_FV3LAM_wflow
*********************************************************************

Traceback (most recent call last):
  File "./generate_FV3LAM_wflow.py", line 1037, in <module>
    generate_FV3LAM_wflow(USHdir, logfile)
  File "./generate_FV3LAM_wflow.py", line 103, in generate_FV3LAM_wflow
    setup()
  File "/mnt/lfs4/BMC/gsd-fv3-dev/kavulich/workdir/PR_414/ufs-srweather-app/ush/setup.py", line 107, in setup
    raise Exception(dedent(f'''
Exception: 
User-specified variable "INVALID_VAR" in config.yaml is not valid
Check config_defaults.yaml for allowed user-specified variables

```
For this same case, the log file shows the following text:
```
root                   DEBUG    Finished setting up debug file logging in /mnt/lfs4/BMC/gsd-fv3-dev/kavulich/workdir/PR_414/ufs-srweather-app/ush/log.generate_FV3LAM_wflow
root                   DEBUG    Logging set up successfully
generate_FV3LAM_wflow  INFO
  ========================================================================
  Starting experiment generation...
  ========================================================================
setup                  INFO
  ========================================================================
  Starting function setup() in "setup.py"...
  ========================================================================
root                   ERROR
*********************************************************************
Experiment generation failed. See the error message(s) printed below.
For more detailed information, check the log file from the workflow
generation script: /mnt/lfs4/BMC/gsd-fv3-dev/kavulich/workdir/PR_414/ufs-srweather-app/ush/log.generate_FV3LAM_wflow
*********************************************************************

Traceback (most recent call last):
  File "./generate_FV3LAM_wflow.py", line 1037, in <module>
    generate_FV3LAM_wflow(USHdir, logfile)
  File "./generate_FV3LAM_wflow.py", line 103, in generate_FV3LAM_wflow
    setup()
  File "/mnt/lfs4/BMC/gsd-fv3-dev/kavulich/workdir/PR_414/ufs-srweather-app/ush/setup.py", line 107, in setup
    raise Exception(dedent(f'''
Exception:
User-specified variable "INVALID_VAR" in config.yaml is not valid
Check config_defaults.yaml for allowed user-specified variables
```

In the log file you can see the above-mentioned additional information. Before each message, the subroutine writing the message is listed (a few top-level processes involving setting up logging and printing the error message are logged as "root"). Next on the line is a note of the "logging level"; see [Logging HOWTO](https://docs.python.org/3/howto/logging.html) for more details, but basically this denotes the "urgency" of the message, with "debug" being the lowest and "error" being the highest used here, indicating the script has failed in some way. While not implemented here, this will allow us to properly quarantine lower-priority printouts to the log file, or only print them to screen if DEBUG=TRUE, by making use of lower-priority levels such as logging.debug. And finally, log messages that extend to multiple lines are indented by two spaces, to make individual messages easier to parse visually.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## TESTS CONDUCTED: 
- [x] hera.intel
  - Attempted to run as many error condition checks as possible to ensure smooth error handling/messaging
    - [x] Ran ./generate_FV3LAM_wflow.py with a number of different failure conditions
      - [x] Prior to checking out code
      - [x] Prior to building code
        - Note: currently this does *not* exit with an error (in develop or with these new changes), as it would break existing tests. Will need to re-visit this in the future.
      - [x] Prior to loading regional_workflow conda environment
        - Note: On some platforms this error will be impossible to catch gracefully, due to not even being able to start running the script
      - [x] Removed Externals.cfg
      - [x] malformed Externals.cfg
      - [x] With no config.yaml
      - [x] With malformed config.yaml
      - [x] PREEXISTING_DIR_METHOD = quit
      - [ ] Incorrect config.yaml settings
        - [x] Did not include `MACHINE`
        - [x] Did not include `ACCOUNT` with `WORKFLOW_MANAGER=rocoto`
        - [x] Included invalid variable
        - [x] Mismatch between SPP array sizes
        - [x] Mismatch between LSM_SPP array sizes
        - [x] Incorrect PREDEF_GRID_NAME
        - [x] RESTART_INTERVAL set to non-int value
        - [x] DATE_FIRST_CYCL or DATE_LAST_CYCL set to non-date value
        - [x] USE_CUSTOM_POST_CONFIG_FILE true but CUSTOM_POST_CONFIG_FP does not exist
        - [x] USE_CRTM true but CRTM_DIR does not exist
        - [x] FCST_LEN_HRS > 999
        - [x] FCST_LEN_HRS not evenly divisible by LBC_SPEC_INTVL_HRS
        - [x] Mandatory variables (DT_ATMOS, LAYOUT_X, LAYOUT_Y, BLOCKSIZE) not set
        - [x] CCPP_PHYS_SUITE not valid
        - [x] EXTRN_MDL_SOURCE_BASEDIR_ICS, EXTRN_MDL_SOURCE_BASEDIR_LBCS set to non-existent location while USE_USER_STAGED_EXTRN_FILES is True
        - [x] RUN_TASK_VX_ENSGRID or RUN_TASK_VX_ENSPOINT set True while DO_ENSEMBLE is False
        - [x] With RUN_TASK_MAKE_GRID = False
          - [x] Set GRID_DIR to non-existent location
          - [x] Set GRID_DIR to ""
        - [x] With RUN_TASK_MAKE_OROG = False
          - [x] Set OROG_DIR to non-existent location
          - [x] Set OROG_DIR to ""
        - [x] With RUN_TASK_MAKE_SFC_CLIMO = False
          - [x] Set SFC_CLIMO_DIR to non-existent location
          - [x] Set SFC_CLIMO_DIR to ""
        - [x] Set PREEXISTING_DIR_METHOD to ""
      - [x] Incorrect machine file settings
        - [x] "MACHINE" does not correspond to a machine file
        - [x] machine file is malformed
    - [x] Ran ./run_WE2E_tests.sh with a number of different failure conditions
      - [x] Prior to checking out code
      - [x] Prior to loading regional_workflow conda environment
    - [x] Ran ALL WE2E tests, compared output to current develop
      - Develop: /scratch2/BMC/fv3lam/kavulich/UFS/workdir/issue_385/before_and_after_testing/develop/expt_dirs
      - This branch: /scratch2/BMC/fv3lam/kavulich/UFS/workdir/issue_385/before_and_after_testing/after/expt_dirs/
      - [x] No unexpected differences
- [ ] cheyenne.intel
    - [ ] Ran fundamental suite of WE2E tests
- [ ] cheyenne.gnu
    - [ ] Ran fundamental suite of WE2E tests
- [x] Jenkins testing
- [x] All CI checks passed

## DEPENDENCIES:
None

## DOCUMENTATION:
None, though the new, clearer error messaging and removal of extraneous comments could be considered a type of documentation change. 

Check the comments on #385 for more examples of the differences in error messages.

## ISSUE: 
Fixes #385 

## CHECKLIST
<!-- Add an X to check off a box. -->
- [ ] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

