### PR TITLE
created devclean.sh

### DIFF
--- a/devclean.sh
+++ b/devclean.sh
@@ -3,6 +3,7 @@
 # usage instructions
 usage () {
 cat << EOF_USAGE
+
 Clean the UFS-SRW Application build
 Usage: $0 [OPTIONS] ...
 
@@ -10,22 +11,21 @@ OPTIONS
   -h, --help
       show this help guide
   -a, --all
-      removes bin directory, build directory, and all the submodules
+      removes "bin", "build" directories, and other build artifacts
   --remove
-      removes existing build directories, including those in submodules
+      removes the "build" directory, keeps the "bin", "lib" and other build artifacts intact
   --clean
-      removes existing build directories and all other build artifacts
+      removes "bin", "build" directories, and other build artifacts (same as "-a", "--all")
+  --install-dir=INSTALL_DIR  
+      installation  directory name (\${SRW_DIR} by default)
   --build-dir=BUILD_DIR
-      main build directory
+      main build directory, absolute path (\${SRW_DIR}/build/ by default)
   --bin-dir=BIN_DIR
-      installation binary directory name ("bin" by default; any name is available)
+      binary directory name ("exec" by default); full path is \${INSTALL_DIR}/\${BIN_DIR})
   --sub-modules
-      remove sub-component modules
+      remove sub-module directories. They will need to be checked out again by sourcing "\${SRW_DIR}/manage_externals/checkout_externals" before attempting subsequent builds
   -v, --verbose
-      build with verbose output
-
-
-default = show all new files
+      provide more verbose output
 
 EOF_USAGE
 }
@@ -35,10 +35,16 @@ settings () {
 cat << EOF_SETTINGS
 Settings:
 
+  INSTALL_DIR=${INSTALL_DIR}
   BUILD_DIR=${BUILD_DIR}
   BIN_DIR=${BIN_DIR}
   REMOVE=${REMOVE}
   VERBOSE=${VERBOSE}
+
+Default cleaning options: (if no arguments provided, then nothing is cleaned)
+ REMOVE=${REMOVE}
+ CLEAN=${CLEAN}
+ INCLUDE_SUB_MODULES=${INCLUDE_SUB_MODULES}
 
 EOF_SETTINGS
 }
@@ -51,19 +57,18 @@ usage_error () {
 }
 
 # default settings
-set -x
-LCL_PID=$$
-BUILD_DIR="build"
+SRW_DIR=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
+INSTALL_DIR=${INSTALL_DIR:-${SRW_DIR}}
+BUILD_DIR=${BUILD_DIR:-"${SRW_DIR}/build"}
 BIN_DIR="exec"
 REMOVE=false
 VERBOSE=false
 
-# Make options
+# default clean options
+REMOVE=false
 CLEAN=false
-BUILD=false
-CLEAN_SUB_MODULES=false #change default to true later
+INCLUDE_SUB_MODULES=false #changes to true if '--sub-modules' option is provided
 
-set +x
 # process requires arguments
 if [[ ("$1" == "--help") || ("$1" == "-h") ]]; then
   usage
@@ -77,18 +82,20 @@ while :; do
     --remove) REMOVE=true ;;
     --remove=?*|--remove=) usage_error "$1 argument ignored." ;;
     --clean) CLEAN=true ;;
+    --install-dir=?*) INSTALL_DIR=${1#*=} ;;
+    --install-dir|--install-dir=) usage_error "$1 requires argument." ;;
     --build-dir=?*) BUILD_DIR=${1#*=} ;;
     --build-dir|--build-dir=) usage_error "$1 requires argument." ;;
     --bin-dir=?*) BIN_DIR=${1#*=} ;;
     --bin-dir|--bin-dir=) usage_error "$1 requires argument." ;;
-    --sub-modules) CLEAN_SUB_MODULES=true ;;
+    --sub-modules) INCLUDE_SUB_MODULES=true ;;
     --verbose|-v) VERBOSE=true ;;
     --verbose=?*|--verbose=) usage_error "$1 argument ignored." ;;
     # targets
     default) ALL_CLEAN=false ;;
     # unknown
     -?*|?*) usage_error "Unknown option $1" ;;
-    *) break
+    *) usage; break ;;
   esac
   shift
 done
@@ -96,7 +103,6 @@ done
 # choose defaults to clean
 if [ "${ALL_CLEAN}" = true ]; then
   CLEAN=true
-  CLEAN_SUB_MODULES=true
 fi
 
 # print settings
@@ -104,47 +110,37 @@ if [ "${VERBOSE}" = true ] ; then
   settings
 fi
 
-# clean if build directory already exists then exit
-if [ "${REMOVE}" = true ]; then
-  printf "Remove build directory: \n"
-  printf "  BUILD_DIR=${BUILD_DIR}\n\n"
-  [[ -d ${BUILD_DIR} ]] && rm -rf ${BUILD_DIR} && echo "rm -rf ${BUILD_DIR}"
-  build_subdirs=$(find . -type d -name build )
-  echo "Remove build subdirectories: "
-  for build_sub in ${build_subdirs}; do
-    rm -rf ${build_sub} && echo "rm -rf ${build_sub}"
-  done
+# clean if build directory already exists 
+if [ "${REMOVE}" = true ] && [ "${CLEAN}" = false ] ; then
+  printf '%s\n' "Remove the \"build\" directory only, BUILD_DIR = $BUILD_DIR "
+  [[ -d ${BUILD_DIR} ]] && rm -rf ${BUILD_DIR} && printf '%s\n' "rm -rf ${BUILD_DIR}"
 elif [ "${CLEAN}" = true ]; then
-  printf "Remove build directory, bin directory \n"
-  printf "... and other build artifacts\n"
-  printf "  BUILD_DIR=${BUILD_DIR}\n\n"
-  printf "  BIN_DIR=${BIN_DIR}\n\n"
-  rm -rf share
-  rm -rf include
-  rm -rf lib
-  rm -f manage_externals/manic/*.pyc
-  subs=$(find . -name .git -type d | sed 's|\.git$||g' | egrep -v '^.$|^./$')
-  if [ ${CLEAN_SUB_MODULES} == true ]; then
-    printf "remove submodule clones: ${subs}\n"
-    for sub in ${subs}; do ( set -x ; rm -rf $sub ); done
-  fi
-  [[ -n ${BIN_DIR} ]] && rm -rf ${BIN_DIR} && echo "rm -rf ${BIN_DIR}"
-  [[ -n ${BUILD_DIR} ]] && rm -rf ${BUILD_DIR} && echo "rm -rf ${BUILD_DIR}"
-  echo "Remove build subdirectories: "
-  build_subdirs=$(find . -type d -name build )
-  for build_sub in ${build_subdirs}; do
-    rm -rf ${build_sub} && echo "rm -rf ${build_sub}"
-  done
-  echo "... cleaned."
-else
-  [[ -d "${BUILD_DIR}" ]]  && echo "build directory exists: ${BUILD_DIR}"
-  build_subdirs=$(find . -type d -name build )
-  for build_sub in ${build_subdirs}; do
-    echo "build directory exists in sub-modules: ${build_sub} "
-  done
-  [[ -d "${BIN_DIR}" ]] && echo "bin directory with executables exists: ${BIN_DIR}"
+  printf '%s\n' "Remove build directory, bin directory, and other build artifacts "
+  printf '%s\n' " from the installation directory = ${INSTALL_DIR} "
+  [[ -d "${BUILD_DIR}" ]] && rm -rf ${BUILD_DIR}  && printf '%s\n' "rm -rf ${BUILD_DIR}"
+  [[ -d "${INSTALL_DIR}/${BIN_DIR}" ]] && ( rm -rf ${INSTALL_DIR}/${BIN_DIR}  && printf '%s\n' "rm -rf ${INSTALL_DIR}/${BIN_DIR}" )
+  [[ -d "${INSTALL_DIR}/lib" ]] && ( rm -rf ${INSTALL_DIR}/share  && printf '%s\n' "rm -rf ${INSTALL_DIR}/share" )
+  [[ -d "${INSTALL_DIR}/include" ]] && ( rm -rf ${INSTALL_DIR}/include  && printf '%s\n' "rm -rf ${INSTALL_DIR}/include" )
+  [[ -d "${INSTALL_DIR}/lib" ]] && rm -rf ${INSTALL_DIR}/lib  && printf '%s\n' "rm -rf ${INSTALL_DIR}/lib"
+  [[ -d "${SRW_DIR}/manage_externals/manic" ]] && rm -f ${SRW_DIR}/manage_externals/manic/*.pyc  && printf '%s\n' "rm -f ${SRW_DIR}/manage_externals/manic/*.pyc"
+  echo " "
 fi
-
-git status
+# Clean all the submodules if requested. NB: Need to check out them again before attempting subsequent builds, by sourcing ${SRW_DIR}/manage_externals/checkout_externals
+if [ ${INCLUDE_SUB_MODULES} == true ]; then
+  printf '%s\n' "Removing submodules ..."
+  declare -a submodules='()'
+  submodules=(${SRW_DIR}/sorc/*) 
+# echo " submodules are: ${submodules[@]} (total of ${#submodules[@]}) " 
+  if [ ${#submodules[@]} -ge 1 ]; then
+    for sub in ${submodules[@]}; do [[ -d "${sub}" ]] && ( rm -rf ${sub} && printf '%s\n' "rm -rf ${sub}" ); done
+  fi
+  printf '%s\n' "NB: Need to check out submodules again for any subsequent builds, " \
+    " by sourcing ${SRW_DIR}/manage_externals/checkout_externals "
+fi
+#
+echo " " 
+echo "All the requested cleaning tasks have been completed"
+echo " " 
 
 exit 0
+

--- a/devclean.sh
+++ b/devclean.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+  
+# usage instructions
+usage () {
+cat << EOF_USAGE
+Clean the UFS-SRW Application build
+Usage: $0 [OPTIONS] ...
+
+OPTIONS
+  -h, --help
+      show this help guide
+  -a, --all
+      removes bin directory, build directory, and all the submodules
+  --remove
+      removes existing build directories, including those in submodules
+  --clean
+      removes existing build directories and all other build artifacts
+  --build-dir=BUILD_DIR
+      main build directory
+  --bin-dir=BIN_DIR
+      installation binary directory name ("bin" by default; any name is available)
+  --sub-modules
+      remove sub-component modules
+  -v, --verbose
+      build with verbose output
+
+
+default = show all new files
+
+EOF_USAGE
+}
+
+# print settings
+settings () {
+cat << EOF_SETTINGS
+Settings:
+
+  BUILD_DIR=${BUILD_DIR}
+  BIN_DIR=${BIN_DIR}
+  REMOVE=${REMOVE}
+  VERBOSE=${VERBOSE}
+
+EOF_SETTINGS
+}
+
+# print usage error and exit
+usage_error () {
+  printf "ERROR: $1\n" >&2
+  usage >&2
+  exit 1
+}
+
+# default settings
+set -x
+LCL_PID=$$
+BUILD_DIR="build"
+BIN_DIR="exec"
+REMOVE=false
+VERBOSE=false
+
+# Make options
+CLEAN=false
+BUILD=false
+CLEAN_SUB_MODULES=false #change default to true later
+
+set +x
+# process requires arguments
+if [[ ("$1" == "--help") || ("$1" == "-h") ]]; then
+  usage
+  exit 0
+fi
+# process optional arguments
+while :; do
+  case $1 in
+    --help|-h) usage; exit 0 ;;
+    --all|-a) ALL_CLEAN=true ;;
+    --remove) REMOVE=true ;;
+    --remove=?*|--remove=) usage_error "$1 argument ignored." ;;
+    --clean) CLEAN=true ;;
+    --build-dir=?*) BUILD_DIR=${1#*=} ;;
+    --build-dir|--build-dir=) usage_error "$1 requires argument." ;;
+    --bin-dir=?*) BIN_DIR=${1#*=} ;;
+    --bin-dir|--bin-dir=) usage_error "$1 requires argument." ;;
+    --sub-modules) CLEAN_SUB_MODULES=true ;;
+    --verbose|-v) VERBOSE=true ;;
+    --verbose=?*|--verbose=) usage_error "$1 argument ignored." ;;
+    # targets
+    default) ALL_CLEAN=false ;;
+    # unknown
+    -?*|?*) usage_error "Unknown option $1" ;;
+    *) break
+  esac
+  shift
+done
+
+# choose defaults to clean
+if [ "${ALL_CLEAN}" = true ]; then
+  CLEAN=true
+  CLEAN_SUB_MODULES=true
+fi
+
+# print settings
+if [ "${VERBOSE}" = true ] ; then
+  settings
+fi
+
+# clean if build directory already exists then exit
+if [ "${REMOVE}" = true ]; then
+  printf "Remove build directory: \n"
+  printf "  BUILD_DIR=${BUILD_DIR}\n\n"
+  [[ -d ${BUILD_DIR} ]] && rm -rf ${BUILD_DIR} && echo "rm -rf ${BUILD_DIR}"
+  build_subdirs=$(find . -type d -name build )
+  echo "Remove build subdirectories: "
+  for build_sub in ${build_subdirs}; do
+    rm -rf ${build_sub} && echo "rm -rf ${build_sub}"
+  done
+elif [ "${CLEAN}" = true ]; then
+  printf "Remove build directory, bin directory \n"
+  printf "... and other build artifacts\n"
+  printf "  BUILD_DIR=${BUILD_DIR}\n\n"
+  printf "  BIN_DIR=${BIN_DIR}\n\n"
+  rm -rf share
+  rm -rf include
+  rm -rf lib
+  rm -f manage_externals/manic/*.pyc
+  subs=$(find . -name .git -type d | sed 's|\.git$||g' | egrep -v '^.$|^./$')
+  if [ ${CLEAN_SUB_MODULES} == true ]; then
+    printf "remove submodule clones: ${subs}\n"
+    for sub in ${subs}; do ( set -x ; rm -rf $sub ); done
+  fi
+  [[ -n ${BIN_DIR} ]] && rm -rf ${BIN_DIR} && echo "rm -rf ${BIN_DIR}"
+  [[ -n ${BUILD_DIR} ]] && rm -rf ${BUILD_DIR} && echo "rm -rf ${BUILD_DIR}"
+  echo "Remove build subdirectories: "
+  build_subdirs=$(find . -type d -name build )
+  for build_sub in ${build_subdirs}; do
+    rm -rf ${build_sub} && echo "rm -rf ${build_sub}"
+  done
+  echo "... cleaned."
+else
+  [[ -d "${BUILD_DIR}" ]]  && echo "build directory exists: ${BUILD_DIR}"
+  build_subdirs=$(find . -type d -name build )
+  for build_sub in ${build_subdirs}; do
+    echo "build directory exists in sub-modules: ${build_sub} "
+  done
+  [[ -d "${BIN_DIR}" ]] && echo "bin directory with executables exists: ${BIN_DIR}"
+fi
+
+git status
+
+exit 0


### PR DESCRIPTION
a script to clean all the SRW App builds, including submodules, binaries directory (bin or exec), submodules themselves.


## DESCRIPTION OF CHANGES: 
<!-- One or more paragraphs describing the problem, solution, and required changes. -->

A script that allows cleaning up the builds of the SRW App, including main build directory and any ./build/ subdirectories in the submodules, a binaries directory, and submodules themselves if requested.

`./devclean.sh -h ` provides a summary of the options


 ` -h, --help`
      show this help guide
 ` -a, --all`
      removes "bin", "build" directories, and other build artifacts
 ` --remove`
      removes the "build" directory, keeps the "bin", "lib" and other build artifacts intact
`  --clean`
      removes "bin", "build" directories, and other build artifacts (same as "-a", "--all")
`  --install-dir=INSTALL_DIR  `
      installation  directory name (\${SRW_DIR} by default)
`  --build-dir=BUILD_DIR`
      main build directory, absolute path (\${SRW_DIR}/build/ by default)
`  --bin-dir=BIN_DIR`
      binary directory name ("exec" by default); full path is \${INSTALL_DIR}/\${BIN_DIR})
`  --sub-modules`
      remove sub-module directories. They will need to be checked out again by sourcing "\${SRW_DIR}/manage_externals/checkout_externals" before attempting subsequent builds
`  -v, --verbose`
      provide more verbose output

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

Post-build tests conducted to clean up the build and the submodules, in case of non-standard customized installation directory, build, and bin directories. The SRW app was built successfully after the cleanup. Additional cleanup was performed to remove the sub-modules; the submodules were checked out again (./manage_externals/checkout_externals) and the SRW App was built successfully after that.

Tested on the following platforms:
[x] Hera 
[x] Gaea 
[x] Jet 
[x] Orion
[x] Cheyenne.

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->
[x] documentation update needed for this additional cleanup option

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here (Remember, issues must always be created before starting work on a PR branch!). For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/ufs-community/other_repository/pull/63" -->

This PR resolves the issue mentioned in [SRW-Issues/?] 

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [N/A] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [x] enhancement

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

@ Bruce Kropp - provided an initial script draft
