### PR TITLE
[develop] Update Hera modulefiles to allow the SRW to build and run once again.

### DIFF
--- a/modulefiles/build_hera_intel
+++ b/modulefiles/build_hera_intel
@@ -20,9 +20,9 @@ module load hpc/1.2.0
 module load hpc-intel/2022.1.2
 module load hpc-impi/2022.1.2
 
-module load nccmp/1.8.9.0
 module load srw_common
 
+module load nccmp/1.8.9.0
 module load nco/4.9.3
 
 setenv CMAKE_C_COMPILER mpiicc

--- a/modulefiles/build_jet_intel
+++ b/modulefiles/build_jet_intel
@@ -18,9 +18,9 @@ module load hpc/1.2.0
 module load hpc-intel/2022.1.2
 module load hpc-impi/2022.1.2
 
-module load nccmp/1.8.9.0
 module load srw_common
 
+module load nccmp/1.8.9.0
 module load prod_util/1.2.2
 module load nco/4.9.3
 

--- a/modulefiles/build_orion_intel
+++ b/modulefiles/build_orion_intel
@@ -17,9 +17,9 @@ module load hpc/1.2.0
 module load hpc-intel/2022.1.2
 module load hpc-impi/2022.1.2
 
-module load nccmp/1.8.9.0
 module load srw_common
 
+module load nccmp/1.8.9.0
 module load nco/4.9.3
 
 setenv CMAKE_C_COMPILER mpiicc

--- a/modulefiles/srw_common
+++ b/modulefiles/srw_common
@@ -4,8 +4,6 @@ module load jasper/2.0.25
 module load zlib/1.2.11
 module load-any png/1.6.35 libpng/1.6.37
 
-module load ncio/1.1.2
-
 module load-any netcdf/4.7.4 netcdf-c/4.7.4
 module load-any netcdf/4.7.4 netcdf-fortran/4.5.4
 module load-any pio/2.5.3 parallelio/2.5.2
@@ -31,4 +29,5 @@ module load sigio/2.3.2
 module load w3nco/2.4.1
 module load wrf_io/1.2.0
 
+module load ncio/1.1.2
 module load wgrib2/2.0.8


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The HPC-stack on Hera was updated at 17:05 today, October 13.  This update caused the SRW to fail to build due to a new dependency on the nccmp module.  This update will correct the issue and allow the SRW to once again build and run on Hera.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
Following the modifications, the SRW was successfully built on Hera and the fundamental WE2E tests were submitted.  The tests are still running as of this time.

- [X] hera.intel - fundamental WE2E tests are still running at this time
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [X] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## CHECKLIST
<!-- Add an X to check off a box. -->
- [X] My code follows the style guidelines in the Contributor's Guide
- [X] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes do not require updates to the documentation (explain).
- [X] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published