### PR TITLE
[develop] Make CIs test NCO mode properly.

### DIFF
--- a/.cicd/scripts/srw_test.sh
+++ b/.cicd/scripts/srw_test.sh
@@ -28,6 +28,7 @@ fi
 # Test directories
 we2e_experiment_base_dir="${workspace}/expt_dirs"
 we2e_test_dir="${workspace}/tests/WE2E"
+nco_dir="${workspace}/nco_dirs"
 
 # Run the end-to-end tests.
 if "${SRW_WE2E_COMPREHENSIVE_TESTS}"; then
@@ -37,7 +38,7 @@ else
 fi
 
 cd ${we2e_test_dir}
-./setup_WE2E_tests.sh ${platform} ${SRW_PROJECT} ${SRW_COMPILER} ${test_type} ${we2e_experiment_base_dir}
+./setup_WE2E_tests.sh ${platform} ${SRW_PROJECT} ${SRW_COMPILER} ${test_type} ${we2e_experiment_base_dir} ${nco_dir}
 
 # Allow the tests to start before checking for status.
 # TODO: Create a parameter that sets the initial start delay.

--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -154,7 +154,7 @@ tasks; and the "FCST" type is used for the RUN_FCST_TN task.
 
   <log>
   {%- if run_envir == "nco"  %}
-    &LOGDIR;/FV3LAM_wflow_{{ workflow_id }}.log
+    &LOGDIR;/FV3LAM_wflow.{{ workflow_id }}.log
   {%- else %}
     &LOGDIR;/FV3LAM_wflow.log
   {%- endif %}

--- a/tests/WE2E/setup_WE2E_tests.sh
+++ b/tests/WE2E/setup_WE2E_tests.sh
@@ -25,13 +25,15 @@
 
 function usage {
   echo
-  echo "Usage: $0 machine slurm_account [compiler] [test_type] [expt_dirs] | -h"
+  echo "Usage: $0 machine slurm_account [compiler] [test_type] [expts_dir] [nco_dirs] [run_envir] | -h"
   echo
   echo "       machine       [required] is one of: ${machines[@]}"
   echo "       slurm_account [required] case sensitive name of the user-specific slurm account"
   echo "       compiler      [optional] compiler used for build"
   echo "       test_type     [optional] test type: fundamental or comprehensive or all or any other name"
   echo "       expts_dir     [optional] Experiment base directory"
+  echo "       nco_dirs      [optional] NCO operations root directory"
+  echo "       run_envir     [optional] either 'community' or 'nco' "
   echo "       -h            display this help"
   echo
   exit 1
@@ -61,6 +63,9 @@ SRW_APP_DIR=$( dirname "${TESTS_DIR}" )
 TOP_DIR=$( dirname "${SRW_APP_DIR}" )
 
 EXPTS_DIR=${5:-"${TOP_DIR}/expt_dirs"}
+NCO_DIR=${6:-"${TOP_DIR}/nco_dirs"}
+
+RUN_ENVIR=${7:-""}
 
 #----------------------------------------------------------------------
 # Use exec_subdir consistent with the automated build.
@@ -83,8 +88,9 @@ source ${SRW_APP_DIR}/ush/load_modules_wflow.sh ${machine}
   exec_subdir=${exec_subdir} \
   compiler=${compiler} \
   expt_basedir=${EXPTS_DIR} \
+  opsroot=${NCO_DIR} \
   debug="TRUE" \
   verbose="TRUE" \
   cron_relaunch_intvl_mnts=4 \
-  run_envir="community"
+  run_envir=${RUN_ENVIR}
 

--- a/ush/job_preamble.sh
+++ b/ush/job_preamble.sh
@@ -118,9 +118,18 @@ fi
 function job_postamble() {
 
     if [ "${RUN_ENVIR}" = "nco" ]; then
+
         # Remove temp directory
         cd ${DATAROOT}
         [[ $KEEPDATA = "FALSE" ]] && rm -rf $DATA $DATA_SHARED
+
+        # Create symlinks to log files
+        local EXPTLOG=${EXPTDIR}/log
+        mkdir_vrfy -p ${EXPTLOG}
+        for i in ${LOGDIR}/*.${WORKFLOW_ID}.log; do
+            local LOGB=$(basename $i .${WORKFLOW_ID}.log)
+            ln_vrfy -sf $i ${EXPTLOG}/${LOGB}.log
+        done
     fi
 
     # Print exit message


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more paragraphs describing the problem, solution, and required changes. -->
This PR addresses issue #416 through the alternative means described there
- Both Jenkins and Github actions should now be able to test NCO test cases properly.
- Symlinks to log files stored under the NCO operations directory are created under `EXPTDIR/log` making "nco" mode indistiguishable from "community" mode as far as the CIs are concerned
- Having symlinks to log files under the experiment directory is also convenient since user would need to know the workflow ID otherwise

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->
Run one test on Hera and Jet successfully in NCO mode and confirmed the EXPTDIR/log is populated with log files.
Test on one system should be enough for this PR.

- [X] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [X] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
- ufs-community/regional_workflow/pull/<pr_number>
- ufs-community/UFS_UTILS/pull/<pr_number>
- ufs-community/ufs-weather-model/pull/<pr_number> -->
None

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->
None required

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here (Remember, issues must always be created before starting work on a PR branch!). For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/ufs-community/other_repository/pull/63" -->
- #416 

## CHECKLIST
<!-- Add an X to check off a box. -->
- [X] My code follows the style guidelines in the Contributor's Guide
- [X] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

