### PR TITLE
[develop] URGENT PATCH: Update run_WE2E_tests.sh

### DIFF
--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -412,7 +412,7 @@ elif [ "${test_type}" = "all" ] ; then
     user_spec_tests+=("$(basename $fp | cut -f 2 -d .)")
   done
 
-elif [ -n "${tests_file}" ] | [ -n "${test_type}" ] ; then
+elif [ -n "${tests_file}" ] || [ -n "${test_type}" ] ; then
 
   # User wants to run a set of tests from a file, either their own or
   # one managed in the repo


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
PR #411 introduced new logic to allow users to specify a test_type or a test_name on the command line, in addition to the old tests_file logic which required a user to provide a file containing a lists of tests. This PR broke that old logic, so anyone using the old method to specify their own list of tests will be unable to run the end-to-end tests. The script now fails with the following error message:

```
Performing sanity checks on user-specified list of WE2E tests to run...
./run_WE2E_tests.sh: line 585: user_spec_tests: unbound variable
End run_WE2E_tests.sh at Fri Oct 14 22:06:38 UTC 2022 with error code 1 (time elapsed: 00:00:47)

```

The fix is a simple change from `|` (output pipe) to the intended `||` (double pipe == "OR")

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
Ran a random set of WE2E tests on the following platforms with the tests_file logic. While broken in the current develop, with these changes the script runs to completion.

- [x] hera.intel
- [x] orion.intel
- [x] cheyenne.intel

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE: 
None