### PR TITLE
Restore correct `conda activate` message for Cheyenne

### DIFF
--- a/modulefiles/wflow_cheyenne.lua
+++ b/modulefiles/wflow_cheyenne.lua
@@ -14,7 +14,7 @@ load(pathJoin("conda", os.getenv("conda_ver") or "latest"))
 
 if mode() == "load" then
    LmodMsgRaw([===[Please do the following to activate conda:
-       > conda activate regional_workflow
+       > conda activate /glade/p/ral/jntp/UFS_SRW_app/conda/regional_workflow
 ]===])
 end
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
PR #413 inadvertently modified the `conda activate` message printed to screen for Cheyenne. Unlike NOAA RDHPC platforms, Cheyenne requires the full path to the conda environment to activate properly.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
- [x] cheyenne.intel
  - [x] Loaded module, confirmed correct message is now printed

This is a print-only change, but have kicked off automated tests on Hera and Jet out of an abundance of caution.

## DEPENDENCIES:
None

## DOCUMENTATION:
Self-documenting

## ISSUE: 
None

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published