### PR TITLE
[develop] Remove my_load_any from modulefiles/srw_common.lua and use load_any

### DIFF
--- a/modulefiles/build_cheyenne_intel.lua
+++ b/modulefiles/build_cheyenne_intel.lua
@@ -23,7 +23,6 @@ load("srw_common")
 
 load(pathJoin("g2", os.getenv("g2_ver") or "3.4.5"))
 load(pathJoin("esmf", os.getenv("esmf_ver") or "8.3.0b09"))
-load(pathJoin("mapl", os.getenv("mapl_ver") or "2.11.0-esmf-8.3.0b09"))
 load(pathJoin("netcdf", os.getenv("netcdf_ver") or "4.7.4"))
 load(pathJoin("libpng", os.getenv("libpng_ver") or "1.6.37"))
 load(pathJoin("pio", os.getenv("pio_ver") or "2.5.3"))

--- a/modulefiles/srw_common.lua
+++ b/modulefiles/srw_common.lua
@@ -1,21 +1,11 @@
-
--- Until Cheyenne updates Lmod version to >=8.3.7
--- emulate load_any with try_load + isloaded() combo
-function my_load_any(pkg1, pkg2)
-   try_load(pkg1)
-   if not isloaded(pkg1) then
-      load(pkg2)
-   end
-end
-
 load("jasper/2.0.25")
 load("zlib/1.2.11")
-my_load_any("png/1.6.35", "libpng/1.6.37")
+load_any("png/1.6.35", "libpng/1.6.37")
 
-my_load_any("netcdf/4.7.4", "netcdf-c/4.7.4")
-my_load_any("netcdf/4.7.4", "netcdf-fortran/4.5.4")
-my_load_any("pio/2.5.3", "parallelio/2.5.2")
-my_load_any("esmf/8.3.0b09", "esmf/8.2.0")
+load_any("netcdf/4.7.4", "netcdf-c/4.7.4")
+load_any("netcdf/4.7.4", "netcdf-fortran/4.5.4")
+load_any("pio/2.5.3", "parallelio/2.5.2")
+load_any("esmf/8.3.0b09", "esmf/8.2.0")
 load("fms/2022.01")
 
 load("bufr/11.7.0")
@@ -27,9 +17,9 @@ load("ip/3.3.3")
 load("sp/2.3.3")
 load("w3emc/2.9.2")
 
-my_load_any("gftl-shared/v1.5.0", "gftl-shared/1.5.0")
-my_load_any("yafyaml/v0.5.1", "yafyaml/0.5.1")
-my_load_any("mapl/2.22.0-esmf-8.3.0b09", "mapl/2.11.0-esmf-8.2.0")
+load_any("gftl-shared/v1.5.0", "gftl-shared/1.5.0")
+load_any("yafyaml/v0.5.1", "yafyaml/0.5.1")
+load_any("mapl/2.22.0-esmf-8.3.0b09", "mapl/2.11.0-esmf-8.2.0")
 
 load("nemsio/2.5.4")
 load("sfcio/1.4.1")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Following Cheyenne's maintenance, it was noted that the version of `Lmod` available was updated from `8.1.7` to `8.7.13`.  An `Lmod` version >= `8.3.7` is required to use `Lmod's` `load_any` function.  A workaround was implemented when converting the modulefiles from TCL to Lua.  Now that `Lmod 8.7.13` is available, there is no longer a need for the `my_load_any` workaround solution.  This work removes the `my_load_any` function from `modulefiles/srw_common.lua` and uses `load_any` instead.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## TESTS CONDUCTED: 
The fundamental WE2E tests were run on Hera and Cheyenne (both Intel and GNU).

- [X] hera.intel
- [ ] orion.intel
- [X] cheyenne.intel
- [X] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [X] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## ISSUE: 
Fixes #429 

## CHECKLIST
- [X] My code follows the style guidelines in the Contributor's Guide
- [X] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes do not require updates to the documentation (explain).
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## CONTRIBUTORS (optional): 
@danielabdi-noaa and @christopherwharrop-noaa provided valuable insight with respect to issues encountered with loading the `modulefiles/build_cheyenne_intel.lua` modulefile.