### PR TITLE
[develop] Added return code to srw_build.sh script.

### DIFF
--- a/.cicd/scripts/srw_build.sh
+++ b/.cicd/scripts/srw_build.sh
@@ -26,8 +26,10 @@ fi
 
 # Build and install
 cd ${workspace}/tests
-export PID=$$
+set +e
 ./build.sh ${platform} ${SRW_COMPILER}
+build_exit=$?
+set -e
 cd -
 
 # Create combined log file for upload to s3
@@ -35,7 +37,4 @@ build_dir="${workspace}/build_${SRW_COMPILER}"
 cat ${build_dir}/log.cmake ${build_dir}/log.make \
     >${build_dir}/srw_build-${platform}-${SRW_COMPILER}.log
 
-TEST_OUTPUT="${workspace}/tests/build_test${PID}.out"
-
-failures=$(grep "FAIL:" ${TEST_OUTPUT} | wc -l)
-exit $failures
+exit $build_exit

--- a/.cicd/scripts/srw_build.sh
+++ b/.cicd/scripts/srw_build.sh
@@ -26,6 +26,7 @@ fi
 
 # Build and install
 cd ${workspace}/tests
+export PID=$$
 ./build.sh ${platform} ${SRW_COMPILER}
 cd -
 
@@ -34,3 +35,7 @@ build_dir="${workspace}/build_${SRW_COMPILER}"
 cat ${build_dir}/log.cmake ${build_dir}/log.make \
     >${build_dir}/srw_build-${platform}-${SRW_COMPILER}.log
 
+TEST_OUTPUT="${workspace}/tests/build_test${PID}.out"
+
+failures=$(grep "FAIL:" ${TEST_OUTPUT} | wc -l)
+exit $failures

--- a/sorc/CMakeLists.txt
+++ b/sorc/CMakeLists.txt
@@ -82,7 +82,7 @@ if (BUILD_UFS)
     endforeach()
   endif()
 
-  ExternalProject_Add(ufs-weather-model
+  ExternalProject_Add(UFS
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ufs-weather-model
     INSTALL_DIR ${CMAKE_INSTALL_PREFIX}

--- a/sorc/CMakeLists.txt
+++ b/sorc/CMakeLists.txt
@@ -82,7 +82,7 @@ if (BUILD_UFS)
     endforeach()
   endif()
 
-  ExternalProject_Add(UFS
+  ExternalProject_Add(ufs-weather-model
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ufs-weather-model
     INSTALL_DIR ${CMAKE_INSTALL_PREFIX}

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -28,7 +28,6 @@ machines=( hera jet cheyenne orion wcoss2 gaea odin singularity macos noaacloud 
 #-----------------------------------------------------------------------
 # Set some directories
 #-----------------------------------------------------------------------
-PID=$$
 TEST_DIR=$( pwd )                   # Directory with this script
 TOP_DIR=${TEST_DIR}/..              # Top level (umbrella repo) directory
 TEST_OUTPUT=${TEST_DIR}/build_test${PID}.out

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -28,7 +28,7 @@ machines=( hera jet cheyenne orion wcoss2 gaea odin singularity macos noaacloud 
 #-----------------------------------------------------------------------
 # Set some directories
 #-----------------------------------------------------------------------
-PID=${PID:-$$}
+PID=$$
 TEST_DIR=$( pwd )                   # Directory with this script
 TOP_DIR=${TEST_DIR}/..              # Top level (umbrella repo) directory
 TEST_OUTPUT=${TEST_DIR}/build_test${PID}.out
@@ -159,3 +159,6 @@ else
   msg="PASS"
 fi
 echo "$msg" >> ${TEST_OUTPUT}
+if [[ $n_fail -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -28,6 +28,7 @@ machines=( hera jet cheyenne orion wcoss2 gaea odin singularity macos noaacloud 
 #-----------------------------------------------------------------------
 # Set some directories
 #-----------------------------------------------------------------------
+PID=${PID:-$$}
 TEST_DIR=$( pwd )                   # Directory with this script
 TOP_DIR=${TEST_DIR}/..              # Top level (umbrella repo) directory
 TEST_OUTPUT=${TEST_DIR}/build_test${PID}.out


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The Jenkins build test doesn't exit with a return code, so if an executable fails to build, Jenkins will still continue to the test phase, leading to failures in the tests.  Exiting with a return code has been added to the `.cicd/scripts/srw_build.sh` script.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
- [X] hera.intel
 * Tested build manually on Hera using `devbuild.sh` and `srw_build.sh`
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [x] Jenkins
- [x] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## ISSUE: 
Fixes #460

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published