### PR TITLE
[develop] Python-based crontab replacement

### DIFF
--- a/.cicd/scripts/srw_test.sh
+++ b/.cicd/scripts/srw_test.sh
@@ -40,12 +40,21 @@ fi
 cd ${we2e_test_dir}
 ./setup_WE2E_tests.sh ${platform} ${SRW_PROJECT} ${SRW_COMPILER} ${test_type} ${we2e_experiment_base_dir} ${nco_dir}
 
-# Allow the tests to start before checking for status.
-# TODO: Create a parameter that sets the initial start delay.
-sleep 300
+# Run the new run_srw_tests script if the machine is Cheyenne.
+if [[ "${platform}" = "cheyenne" ]]; then
+    cd ${workspace}/ush
+    ./run_srw_tests.py -e=${we2e_experiment_base_dir}
+    cd ${we2e_test_dir}
+fi
 
 # Progress file
 progress_file="${workspace}/we2e_test_results-${platform}-${SRW_COMPILER}.txt"
+
+# Allow the tests to start before checking for status.
+# TODO: Create a parameter that sets the initial start delay.
+if [[ "${platform}" != "cheyenne" ]]; then
+    sleep 300
+fi
 
 # Wait for all tests to complete.
 while true; do
@@ -72,10 +81,15 @@ done
 # TODO: Create parameter that sets the interval for the we2e cron jobs; this
 # value should be some factor of that interval to ensure the cron jobs execute
 # before the workspace is cleaned up.
-sleep 600
+if [[ "${platform}" != "cheyenne" ]]; then
+    sleep 600
+fi
 
 # Set exit code to number of failures
 set +e
 failures=$(grep "Workflow status:  FAILURE" ${progress_file} | wc -l)
+if [[ $failures -ne 0 ]]; then
+    failures=1
+fi
 set -e
 exit ${failures}

--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -396,6 +396,16 @@ The argument \"machine\" specifying the machine or platform on which to
 run the WE2E tests was not specified in the call to this script.  \
 ${help_msg}"
 fi
+  # Cheyenne-specific test limitation
+
+if [ "${machine,,}" = "cheyenne" ]; then
+  use_cron_to_relaunch=FALSE
+  echo "
+Due to system limitations, the 'use_cron_to_relaunch' command can not be used on
+the '${machine}' machine. Setting this variable to false.
+
+"
+fi
 
 if [ -z "${account}" ]; then
   print_err_msg_exit "\
@@ -1298,6 +1308,38 @@ Could not generate an experiment for the test specified by test_name:
   test_name = \"${test_name}\""
 
 done
+
+# Print notes about monitoring/running jobs if use_cron_to_relaunch = FALSE
+topdir=${scrfunc_dir%/*/*/*}
+expt_dirs_fullpath="${topdir}/expt_dirs"
+
+echo "
+  ========================================================================
+  ========================================================================
+
+  All experiments have been generated in the directory
+  ${expt_dirs_fullpath}
+
+  ========================================================================
+  ========================================================================
+"
+
+if [ "${use_cron_to_relaunch,,}" = "false" ]; then
+  echo "
+
+The variable 'use_cron_to_relaunch' has been set to FALSE. Jobs will not be automatically run via crontab.
+
+You can run each task manually in the experiment directory:
+(${expt_dirs_fullpath})
+
+Or you can use the 'run_srw_tests.py' script in the ush/ directory:
+
+  cd $USHdir
+  ./run_srw_tests.py -e=${expt_dirs_fullpath}
+
+"
+fi
+
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/run_srw_tests.py
+++ b/ush/run_srw_tests.py
@@ -19,11 +19,11 @@ class SRWTest:
   def __init__(self, exptdir):
     self.exptdir=exptdir
     # Get a list of test directories 
-    cmdstring="find . -maxdepth 1 -type d | tail -n+2"
+    cmdstring="find {} -maxdepth 1 -type d | tail -n+2".format(self.exptdir)
     status= subprocess.check_output(cmdstring,shell=True).strip().decode('utf-8')
     # Turn the stdout from the shell command into a list
     self.testDirectories = status.split("\n")
-    self.launchcmd = "./launch_FV3LAM_wflow.sh"
+    self.launchcmd = "./launch_FV3LAM_wflow.sh >& /dev/null"
     # Loop through each of the test directories and launch the initial jobs in the workflow
     for testD in self.testDirectories:
       print("starting {} workflow".format(testD))

--- a/ush/run_srw_tests.py
+++ b/ush/run_srw_tests.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import time
+import argparse
+
+# Python class to handle the launching of a set of SRW tests
+# The expectation is to have a "clean" experiment directory with only new experiments
+# that are ready to run (e.g. no _old* experiments left around from previous tests
+# This script takes only one parameter "-e" or "--exptdir" which points to the 
+# expt_basedir specified when the run_WE2E_tests.sh is run to set up the tests.
+# The script will work sequentially through each of the test directories and 
+# launch the workflow for each with a call to launch_FV3LAM_wflow.sh
+# After the initial launch, the checkTests method is called to monitor the
+# status of each test and call the launch_FV3LAM_wflow.sh script repeatedly 
+# in each uncompleted workflow until all workflows are done.
+class SRWTest:
+  def __init__(self, exptdir):
+    self.exptdir=exptdir
+    # Get a list of test directories 
+    cmdstring="find . -maxdepth 1 -type d | tail -n+2"
+    status= subprocess.check_output(cmdstring,shell=True).strip().decode('utf-8')
+    # Turn the stdout from the shell command into a list
+    self.testDirectories = status.split("\n")
+    self.launchcmd = "./launch_FV3LAM_wflow.sh"
+    # Loop through each of the test directories and launch the initial jobs in the workflow
+    for testD in self.testDirectories:
+      print("starting {} workflow".format(testD))
+      os.chdir(testD)
+      os.system(self.launchcmd)
+      os.chdir(self.exptdir)
+    # Now start monitoring the workflows
+    self.checkTests()
+
+  def checkTests(self):
+    while(len(self.testDirectories) > 0):
+      # Only continue running launch command for workflows that aren't complete
+      # so check for any that have failed or completed and cull them from the list
+      cmdstring="grep -L 'wflow_status =' */log.launch_FV3LAM_wflow | xargs dirname"
+      try:
+        status= subprocess.check_output(cmdstring,shell=True).strip().decode('utf-8')
+      except:
+        print("Tests have all completed")
+        return
+      self.testDirectories = status.split("\n")
+      # continue looping through directories
+      for testD in self.testDirectories:
+        os.chdir(testD)
+        os.system(self.launchcmd)
+        os.chdir(self.exptdir)
+        print("calling launch_FV3LAM_wflow.sh from {}".format(testD))
+        time.sleep(5.0)
+      time.sleep(30.0)
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description='Run through a set of SRW WE2E tests until they are complete')
+  parser.add_argument('-e','--exptdir', help='directory where experiments have been staged', required=False,default=os.getcwd())
+  args = vars(parser.parse_args())
+
+  test = SRWTest(args['exptdir'])
+


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- Basic python script that replaces the crontab functionality of repeatedly calling launch_FV3LAM_wflow.sh from every experiment directory for a set of WE2E tests. -->

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- This script has been tested on a number of different RDHPCS machines and cheyenne. It can be run on the head node or from a compute node via a batch script. After generating a set of WE2E tests using the use_cron_to_relaunch="FALSE" flag, this script will launch all the tests and continue to call launch_FV3LAM_wflow.sh from each subdirectory to keep the workflow moving until it either fails or succeeds. The script has only one parameter "-e or -exptdir" which is the same as the "expt_basedir" given to the run_WE2E_tests.sh script. Currently, the script sleeps for 5 seconds after each call to launch_FV3LAM_wflow.sh and for 30 seconds after iterating through all the unfinished tests.  -->

<!-- Add an X to check off a box. -->

- [x] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DOCUMENTATION:
<!-- New (short) documentation will need to be added when the final implementation is done. It is possible that the this script could be put into a batch job and launched automatically from the run_WE2E_tests.sh -->

## ISSUE: 
<!-- Addresses Issue #462  -->

## CHECKLIST
<!-- Add an X to check off a box. -->
- [ ] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [x] Work In Progress
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

