### PR TITLE
[develop] Updates for building and running on MacOS (x86_64 and M1)

### DIFF
--- a/etc/lmod-setup.csh
+++ b/etc/lmod-setup.csh
@@ -16,8 +16,9 @@ endif
 source /etc/csh.login
    
 if ( "$L_MACHINE" == macos ) then
-   set ENV="/opt/homebrew/opt/lmod/init/csh"
-   # setenv ENV "/usr/local/opt/lmod/init/csh"
+   arch=$(uname -m)
+   [[ "$arch" = arm64 ]] && export ENV="/opt/homebrew/opt/lmod/init/csh"
+   [[ "$arch" = x86_64 ]] && export ENV="/usr/local/opt/lmod/init/csh"
    source $ENV
 
    module purge

--- a/etc/lmod-setup.sh
+++ b/etc/lmod-setup.sh
@@ -23,8 +23,9 @@ $has_mu && set -u
 $has_me && set -e
 
 if [ "$L_MACHINE" = macos ]; then
-   export BASH_ENV="/opt/homebrew/opt/lmod/init/bash"
-   # export BASH_ENV="/usr/local/opt/lmod/init/bash"
+   arch=$(uname -m)
+   [[ "$arch" = arm64 ]] && export BASH_ENV="/opt/homebrew/opt/lmod/init/bash"
+   [[ "$arch" = x86_64 ]] && export BASH_ENV="/usr/local/opt/lmod/init/bash"
    source $BASH_ENV
 
    module purge

--- a/modulefiles/build_macos_gnu.lua
+++ b/modulefiles/build_macos_gnu.lua
@@ -1,8 +1,6 @@
 help([[
-This module needs to be customized for the user's Linux environment:
+This module needs to be customized for the user's MacOS environment:
 specify compilers, path for HPC-stack, load the modules, set compiler and linker flags
-   Option 1: M1/arm64 platform, OS BigSur, Monterey (Darwin 20,21)
-   Option 2: Intel/x86_64 platform, OS Catalina (Darwin 19)
 ]])
 
 whatis([===[Loads libraries needed for building the UFS SRW App on macos ]===])
@@ -23,48 +21,27 @@ load("hpc-gnu")
 load("openmpi")
 load("hpc-openmpi")
 
-load("jasper/2.0.25")
-load("zlib/1.2.11")
+load("srw_common")
 
-load("hdf5/1.10.6")
-load("netcdf/4.7.4")
-load("pio/2.5.3")
-load("esmf/8.3.0b09")
-load("fms/2022.01")
-
-load("bacio/2.4.1")
-load("crtm/2.3.0")
-load("g2/3.4.3")
-load("g2tmpl/1.10.0")
-load("ip/3.3.3")
-load("sp/2.3.3")
-load("w3nco/2.4.1")
-load("upp/10.0.10")
-
-load("gftl-shared/1.3.3")
-load("yafyaml/0.5.1")
-load("mapl/2.12.2-esmf-8.3.0b09")
-load("gfsio/1.4.1")
-load("landsfcutil/2.4.1")
-load("nemsio/2.5.4")
-load("nemsiogfs/2.5.3")
-load("sfcio/1.4.1")
-load("sigio/2.3.2")
-load("w3emc/2.9.2")
-load("wgrib2/2.0.8")
 
 -- Option 1 compiler paths: 
 setenv("CC", "/opt/homebrew/bin/gcc")
 setenv("FC", "/opt/homebrew/bin/gfortran")
 setenv("CXX", "/opt/homebrew/bin/g++")
 
--- Option 2 compiler paths:
---[[
-setenv("CC", "/usr/local/bin/gcc")
-setenv("FC", "/usr/local/bin/gfortran")
-setenv("CXX", "/usr/local/bin/g++")
---]]
---
+-- MacOS with arm64 architecture: `uname -m` expands to arm64
+-- MacOS with Intel architecture: `uname -m` expands to x86_64
+local arch = 'eval $(uname -m)'
+if (arch == "arm64") then
+  setenv("CC", "/opt/homebrew/bin/gcc")
+  setenv("FC", "/opt/homebrew/bin/gfortran")
+  setenv("CXX", "/opt/homebrew/bin/g++")
+else
+  setenv("CC", "/usr/local/bin/gcc")
+  setenv("FC", "/usr/local/bin/gfortran")
+  setenv("CXX", "/usr/local/bin/g++")
+end
+
 -- Set MPI compilers depending on the MPI libraries built:
 local MPI_CC="mpicc"
 local MPI_CXX="mpicxx"

--- a/modulefiles/build_macos_gnu.lua
+++ b/modulefiles/build_macos_gnu.lua
@@ -23,12 +23,6 @@ load("hpc-openmpi")
 
 load("srw_common")
 
-
--- Option 1 compiler paths: 
-setenv("CC", "/opt/homebrew/bin/gcc")
-setenv("FC", "/opt/homebrew/bin/gfortran")
-setenv("CXX", "/opt/homebrew/bin/g++")
-
 -- MacOS with arm64 architecture: `uname -m` expands to arm64
 -- MacOS with Intel architecture: `uname -m` expands to x86_64
 local arch = 'eval $(uname -m)'

--- a/modulefiles/wflow_macos.lua
+++ b/modulefiles/wflow_macos.lua
@@ -14,12 +14,8 @@ load(rocoto)
 --]]
 
 if mode() == "load" then
-   LmodMsgRaw([===[Please do the following to activate python virtual environment:
+   LmodMsgRaw([===[Please do the following to activate conda virtual environment:
        > conda activate $VENV "
 ]===])
 end
 
---[[if mode() == "unload" then
-   execute{cmd="deactivate", modeA={"unload"}}
-end
---]]

--- a/modulefiles/wflow_macos.lua
+++ b/modulefiles/wflow_macos.lua
@@ -1,11 +1,11 @@
 help([[
-This module activates python environement for running the UFS SRW App on general macOS
+This module set a path needed to activate conda environement for running UFS SRW App on general macOS
 ]])
 
-whatis([===[This module activates python environment for running the UFS SRW App on macOS]===])
+whatis([===[This module activates conda environment for running the UFS SRW App on macOS]===])
 
 setenv("CMAKE_Platform", "macos")
-setenv("VENV", pathJoin(os.getenv("HOME"), "venv/regional_workflow"))
+setenv("VENV", pathJoin(os.getenv("HOME"), "condaenv/envs/regional_workflow"))
 
 --[[
 local ROCOTOmod="/Users/username/modules"
@@ -14,13 +14,12 @@ load(rocoto)
 --]]
 
 if mode() == "load" then
-   LmodMsgRaw([===[Verify the Python virtual environment path \$VENV shown below is correct, "
-set to the correct path otherwise: "
-VENV=$env(VENV) "
-Please do the following to activate python virtual environment:
-       > source \$VENV/bin/activate "
+   LmodMsgRaw([===[Please do the following to activate python virtual environment:
+       > conda activate $VENV "
 ]===])
 end
-if mode() == "unload" then
+
+--[[if mode() == "unload" then
    execute{cmd="deactivate", modeA={"unload"}}
 end
+--]]


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updates to modulefiles and Lmod initialization for MacOS machines, architecture-independent scripts.
Build modulefile now uses srw_common module with list of standard software modules for the release.

The following files have been updated:
**./modulefiles/build_macos_gnu.lua
./modulefiles/wflow_macos.lua
./etc/lmod-setup.sh
./etc/lmod-setup.csh** 

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->

- [x] Update of a supported feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
- NOAA-EMC/hpc-stack/pull/505

## DOCUMENTATION:
Some documentation updates are needed for the prerequisites (HPC-stack), and for using conda environment instead of python environment

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 

- [x] enhancement
- [ ] documentation
- [x] release
- [ ] high priority


