### PR TITLE
[develop] bugfix: set PDYext and cycext in get_extrn_ics/lbcs for time-offset

### DIFF
--- a/scripts/exregional_get_extrn_mdl_files.sh
+++ b/scripts/exregional_get_extrn_mdl_files.sh
@@ -90,7 +90,7 @@ mm=${yyyymmddhh:4:2}
 dd=${yyyymmddhh:6:2}
 hh=${yyyymmddhh:8:2}
 
-% Re-define to use the pre-defined data paths in the machine file (ush/machine/).
+# Re-define to use the pre-defined data paths in the machine file (ush/machine/).
 PDY=${yyyymmdd}
 cyc=${hh}
 #

--- a/scripts/exregional_get_extrn_mdl_files.sh
+++ b/scripts/exregional_get_extrn_mdl_files.sh
@@ -90,9 +90,9 @@ mm=${yyyymmddhh:4:2}
 dd=${yyyymmddhh:6:2}
 hh=${yyyymmddhh:8:2}
 
-# Re-define to use the pre-defined data paths in the machine file (ush/machine/).
-PDY=${yyyymmdd}
-cyc=${hh}
+# Set to use the pre-defined data paths in the machine file (ush/machine/).
+PDYext=${yyyymmdd}
+cycext=${hh}
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exregional_get_extrn_mdl_files.sh
+++ b/scripts/exregional_get_extrn_mdl_files.sh
@@ -90,6 +90,9 @@ mm=${yyyymmddhh:4:2}
 dd=${yyyymmddhh:6:2}
 hh=${yyyymmddhh:8:2}
 
+% Re-define to use the pre-defined data paths in the machine file (ush/machine/).
+PDY=${yyyymmdd}
+cyc=${hh}
 #
 #-----------------------------------------------------------------------
 #

--- a/tests/WE2E/test_configs/grids_extrn_mdls_suites_nco/config.nco_grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_timeoffset_suite_GFS_v16.yaml
+++ b/tests/WE2E/test_configs/grids_extrn_mdls_suites_nco/config.nco_grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_timeoffset_suite_GFS_v16.yaml
@@ -5,8 +5,6 @@ metadata:
     suite with time-offset ICs/LBCs derived from the FV3GFS.
 user:
   RUN_ENVIR: nco
-nco:
-  envir: prod
 workflow:
   CCPP_PHYS_SUITE: FV3_GFS_v16
   DATE_FIRST_CYCL: '2022081012'

--- a/tests/WE2E/test_configs/grids_extrn_mdls_suites_nco/config.nco_grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_timeoffset_suite_GFS_v16.yaml
+++ b/tests/WE2E/test_configs/grids_extrn_mdls_suites_nco/config.nco_grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_timeoffset_suite_GFS_v16.yaml
@@ -5,6 +5,8 @@ metadata:
     suite with time-offset ICs/LBCs derived from the FV3GFS.
 user:
   RUN_ENVIR: nco
+nco:
+  envir: prod
 workflow:
   CCPP_PHYS_SUITE: FV3_GFS_v16
   DATE_FIRST_CYCL: '2022081012'

--- a/ush/machine/wcoss2.yaml
+++ b/ush/machine/wcoss2.yaml
@@ -33,9 +33,9 @@ task_run_fcst:
   FIXgsm: /lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_am
   FIXlut: /lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_lut
 data:
-  GSMGFS: compath.py ${envir}/gsmgfs/${gsmgfs_ver}/gsmgfs.${PDY}
-  FV3GFS: compath.py ${envir}/gfs/${gfs_ver}/gfs.${PDY}/${hh}/atmos
-  RAP: compath.py ${envir}/rap/${rap_ver}/rap.${PDY}
-  NAM: compath.py ${envir}/nam/${nam_ver}/nam.${PDY}
-  HRRR: compath.py ${envir}/hrrr/${hrrr_ver}/hrrr.${PDY}/conus
+  GSMGFS: compath.py ${envir}/gsmgfs/${gsmgfs_ver}/gsmgfs.${yyyymmdd}
+  FV3GFS: compath.py ${envir}/gfs/${gfs_ver}/gfs.${yyyymmdd}/${hh}/atmos
+  RAP: compath.py ${envir}/rap/${rap_ver}/rap.${yyyymmdd}
+  NAM: compath.py ${envir}/nam/${nam_ver}/nam.${yyyymmdd}
+  HRRR: compath.py ${envir}/hrrr/${hrrr_ver}/hrrr.${yyyymmdd}/conus
 

--- a/ush/machine/wcoss2.yaml
+++ b/ush/machine/wcoss2.yaml
@@ -33,9 +33,9 @@ task_run_fcst:
   FIXgsm: /lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_am
   FIXlut: /lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_lut
 data:
-  GSMGFS: compath.py ${envir}/gsmgfs/${gsmgfs_ver}/gsmgfs.${PDY}
-  FV3GFS: compath.py ${envir}/gfs/${gfs_ver}/gfs.${PDY}/${cyc}/atmos
-  RAP: compath.py ${envir}/rap/${rap_ver}/rap.${PDY}
-  NAM: compath.py ${envir}/nam/${nam_ver}/nam.${PDY}
-  HRRR: compath.py ${envir}/hrrr/${hrrr_ver}/hrrr.${PDY}/conus
+  GSMGFS: compath.py ${envir}/gsmgfs/${gsmgfs_ver}/gsmgfs.${PDYext}
+  FV3GFS: compath.py ${envir}/gfs/${gfs_ver}/gfs.${PDYext}/${cycext}/atmos
+  RAP: compath.py ${envir}/rap/${rap_ver}/rap.${PDYext}
+  NAM: compath.py ${envir}/nam/${nam_ver}/nam.${PDYext}
+  HRRR: compath.py ${envir}/hrrr/${hrrr_ver}/hrrr.${PDYext}/conus
 

--- a/ush/machine/wcoss2.yaml
+++ b/ush/machine/wcoss2.yaml
@@ -33,9 +33,9 @@ task_run_fcst:
   FIXgsm: /lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_am
   FIXlut: /lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_lut
 data:
-  GSMGFS: compath.py ${envir}/gsmgfs/${gsmgfs_ver}/gsmgfs.${yyyymmdd}
-  FV3GFS: compath.py ${envir}/gfs/${gfs_ver}/gfs.${yyyymmdd}/${hh}/atmos
-  RAP: compath.py ${envir}/rap/${rap_ver}/rap.${yyyymmdd}
-  NAM: compath.py ${envir}/nam/${nam_ver}/nam.${yyyymmdd}
-  HRRR: compath.py ${envir}/hrrr/${hrrr_ver}/hrrr.${yyyymmdd}/conus
+  GSMGFS: compath.py ${envir}/gsmgfs/${gsmgfs_ver}/gsmgfs.${PDY}
+  FV3GFS: compath.py ${envir}/gfs/${gfs_ver}/gfs.${PDY}/${cyc}/atmos
+  RAP: compath.py ${envir}/rap/${rap_ver}/rap.${PDY}
+  NAM: compath.py ${envir}/nam/${nam_ver}/nam.${PDY}
+  HRRR: compath.py ${envir}/hrrr/${hrrr_ver}/hrrr.${PDY}/conus
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The `PDY` in the paths for the real-time external data in `ush/machine/wcoss2.yaml' is replaced with `yyyymmdd` to fix the time-offset issue on WCOSS2.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
- WE2E tests:
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_2017_gfdlmp_regional
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_RAP_suite_HRRR
grid_RRFS_CONUScompact_25km_ics_HRRR_lbcs_HRRR_suite_RRFS_v1beta
nco_grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_timeoffset_suite_GFS_v16

- [ ] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [x] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## ISSUE: 
Fixes issue mentioned in #474 

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published