### PR TITLE
[release/v2.1.0] Bugfix diff plotting script, silence warnings.

### DIFF
--- a/ush/Python/plot_allvars.py
+++ b/ush/Python/plot_allvars.py
@@ -62,6 +62,7 @@ from scipy import ndimage
 import pyproj
 import argparse
 import cartopy
+import warnings
 
 #--------------Define some functions ------------------#
 
@@ -233,6 +234,9 @@ parser.add_argument("Path to experiment directory")
 parser.add_argument("Path to base directory of cartopy shapefiles")
 parser.add_argument("Name of native domain used in forecast (and in constructing post file names)")
 args = parser.parse_args()
+
+# Throw away python warnings (mostly depreciation.)
+warnings.simplefilter("ignore")
 
 # Read date/time, forecast hour, and directory paths from command line
 ymdh = str(sys.argv[1])

--- a/ush/Python/plot_allvars_diff.py
+++ b/ush/Python/plot_allvars_diff.py
@@ -66,6 +66,7 @@ from scipy import ndimage
 import pyproj
 import argparse
 import cartopy
+import warnings
 
 #--------------Define some functions ------------------#
 
@@ -238,6 +239,9 @@ parser.add_argument("Path to experiment 2 directory")
 parser.add_argument("Path to base directory of cartopy shapefiles")
 parser.add_argument("Name of native domain used in forecasts (and in constructing post file names)")
 args = parser.parse_args()
+
+# Throw away python warnings (mostly depreciation.)
+warnings.simplefilter("ignore")
 
 # Read date/time, forecast hour, and directory paths from command line
 ymdh = str(sys.argv[1])
@@ -960,7 +964,8 @@ for fhr in fhours:
       cs_1.cmap.set_over('pink')
       cbar1 = plt.colorbar(cs_1,ax=ax1,orientation='horizontal',pad=0.05,shrink=0.6,extend='max')
       cbar1.set_label(units,fontsize=6)
-      cbar1.ax.set_xticklabels([0.1,0.5,1,1.5,2,3,5,10,20])
+      #cbar1.ax.set_xticklabels([0.1,0.5,1,1.5,2,3,5,10,20])
+      cbar1.ax.set_xticklabels([0.1, 0.3, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5, 7.5, 10, 15, 17.5, 20])
       cbar1.ax.tick_params(labelsize=6)
       ax1.text(.5,1.03,'FV3-LAM '+fhour+'-hr Accumulated Precipitation ('+units+') \n initialized: '+itime+' valid: '+vtime + ' (f'+fhour+')',horizontalalignment='center',fontsize=6,transform=ax1.transAxes,bbox=dict(facecolor='white',alpha=0.85,boxstyle='square,pad=0.2'))
 
@@ -969,7 +974,8 @@ for fhr in fhours:
       cs_2.cmap.set_over('pink')
       cbar2 = plt.colorbar(cs_2,ax=ax2,orientation='horizontal',pad=0.05,shrink=0.6,extend='max')
       cbar2.set_label(units,fontsize=6)
-      cbar2.ax.set_xticklabels([0.1,0.5,1,1.5,2,3,5,10,20])
+      #cbar2.ax.set_xticklabels([0.1,0.5,1,1.5,2,3,5,10,20])
+      cbar2.ax.set_xticklabels([0.1, 0.3, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5, 7.5, 10, 15, 17.5, 20])
       cbar2.ax.tick_params(labelsize=6)
       ax2.text(.5,1.03,'FV3-LAM-2 '+fhour+'-hr Accumulated Precipitation ('+units+') \n initialized: '+itime+' valid: '+vtime + ' (f'+fhour+')',horizontalalignment='center',fontsize=6,transform=ax2.transAxes,bbox=dict(facecolor='white',alpha=0.85,boxstyle='square,pad=0.2'))
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more paragraphs describing the problem, solution, and required changes. -->
This PR fixes an issue with diff plotting script I encountered regarding mismatch of labels and ticks.
And also silences warnings. This is the error message
```
Traceback (most recent call last):
  File "/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py", line 1100, in <module>
    main()
  File "/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py", line 459, in main
    plot_all(dom)
  File "/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py", line 963, in plot_all
    cbar1.ax.set_xticklabels([0.1,0.5,1,1.5,2,3,5,10,20])
  File "/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/matplotlib/axes/_base.py", line 75, in wrapper
    return get_method(self)(*args, **kwargs)
  File "/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/matplotlib/axis.py", line 1798, in _set_ticklabels
    return self.set_ticklabels(labels, minor=minor, **kwargs)
  File "/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/matplotlib/axis.py", line 1720, in set_ticklabels
    raise ValueError(
ValueError: The number of FixedLocator locations (18), usually from a call to set_ticks, does not match the number of ticklabels (9).
```
Compare original run with ton of warnings and the error above
```
$ python3 plot_allvars_diff.py 2019070100 0 6 3 /scratch2/BMC/gsd-hpcs/Daniel.Abdi/expt_dirs/grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_2017_gfdlmp_regional_plot /scratch2/BMC/gsd-hpcs/Daniel.Abdi/expt_dirs/grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_2017_gfdlmp_regional_plot /scratch2/BMC/det/UFS_SRW_App/develop/NaturalEarth RRFS_CONUS_25km
2019 7 1 0
[0 3 6]
Working on forecast hour 000
38.5
262.5
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:344: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  slpsmooth_1 = ndimage.filters.gaussian_filter(slp_1, 13.78)
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:346: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  slpsmooth_2 = ndimage.filters.gaussian_filter(slp_2, 13.78)
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:387: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  z500_1 = ndimage.filters.gaussian_filter(z500_1, 6.89)
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:389: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  z500_2 = ndimage.filters.gaussian_filter(z500_2, 6.89)
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:392: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  vort500_1 = ndimage.filters.gaussian_filter(vort500_1,1.7225)
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:395: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  vort500_2 = ndimage.filters.gaussian_filter(vort500_2,1.7225)
46.201 seconds to read all messages
Working on slp for conus
/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/cartopy/mpl/geoaxes.py:1597: UserWarning: The input coordinates to pcolormesh are interpreted as cell centers, but are not monotonically increasing or decreasing. This may lead to incorrectly calculated cell edges, in which case, please supply explicit cell edges to pcolormesh.
  X, Y, C, shading = self._pcolorargs('pcolormesh', *args,
/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/cartopy/crs.py:245: ShapelyDeprecationWarning: __len__ for multi-part geometries is deprecated and will be removed in Shapely 2.0. Check the length of the `geoms` property instead to get the  number of parts of a multi-part geometry.
  if len(multi_line_string) > 1:
/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/cartopy/crs.py:297: ShapelyDeprecationWarning: Iteration over multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry.
  for line in multi_line_string:
/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/cartopy/crs.py:364: ShapelyDeprecationWarning: __len__ for multi-part geometries is deprecated and will be removed in Shapely 2.0. Check the length of the `geoms` property instead to get the  number of parts of a multi-part geometry.
  if len(p_mline) > 0:
2.802 seconds to plot slp for: conus
Working on t2m for conus
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:135: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  xNorm=np.float(i)/(np.float(np.size(r))-1.0)
1.399 seconds to plot 2mt for: conus
Working on 2mdew for conus
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:157: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  xNorm=np.float(i)/(np.float(np.size(r))-1.0)
1.374 seconds to plot 2mdew for: conus
Working on 10mwspd for conus
skipping every 8 grid points to plot
1.517 seconds to plot 10mwspd for: conus
Working on surface-based CAPE/CIN for conus
3.460 seconds to plot surface-based CAPE/CIN for: conus
Working on 500 mb Hgt/Wind/Vort for conus
skipping every 8 grid points to plot
1.742 seconds to plot 500 mb Hgt/Wind/Vort for: conus
Working on 250 mb WIND for conus
skipping every 8 grid points to plot
1.571 seconds to plot 250 mb WIND for: conus
Working on composite reflectivity for conus
1.969 seconds to plot composite reflectivity for: conus
103.916 seconds to plot all variables for: conus
Working on forecast hour 003
38.5
262.5
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:344: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  slpsmooth_1 = ndimage.filters.gaussian_filter(slp_1, 13.78)
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:346: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  slpsmooth_2 = ndimage.filters.gaussian_filter(slp_2, 13.78)
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:387: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  z500_1 = ndimage.filters.gaussian_filter(z500_1, 6.89)
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:389: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  z500_2 = ndimage.filters.gaussian_filter(z500_2, 6.89)
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:392: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  vort500_1 = ndimage.filters.gaussian_filter(vort500_1,1.7225)
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:395: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
  vort500_2 = ndimage.filters.gaussian_filter(vort500_2,1.7225)
51.224 seconds to read all messages
Working on slp for conus
/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/cartopy/mpl/geoaxes.py:1597: UserWarning: The input coordinates to pcolormesh are interpreted as cell centers, but are not monotonically increasing or decreasing. This may lead to incorrectly calculated cell edges, in which case, please supply explicit cell edges to pcolormesh.
  X, Y, C, shading = self._pcolorargs('pcolormesh', *args,
/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/cartopy/crs.py:245: ShapelyDeprecationWarning: __len__ for multi-part geometries is deprecated and will be removed in Shapely 2.0. Check the length of the `geoms` property instead to get the  number of parts of a multi-part geometry.
  if len(multi_line_string) > 1:
/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/cartopy/crs.py:297: ShapelyDeprecationWarning: Iteration over multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry.
  for line in multi_line_string:
/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/cartopy/crs.py:364: ShapelyDeprecationWarning: __len__ for multi-part geometries is deprecated and will be removed in Shapely 2.0. Check the length of the `geoms` property instead to get the  number of parts of a multi-part geometry.
  if len(p_mline) > 0:
1.584 seconds to plot slp for: conus
Working on t2m for conus
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:135: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  xNorm=np.float(i)/(np.float(np.size(r))-1.0)
1.457 seconds to plot 2mt for: conus
Working on 2mdew for conus
/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py:157: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  xNorm=np.float(i)/(np.float(np.size(r))-1.0)
1.426 seconds to plot 2mdew for: conus
Working on 10mwspd for conus
skipping every 8 grid points to plot
1.514 seconds to plot 10mwspd for: conus
Working on surface-based CAPE/CIN for conus
3.153 seconds to plot surface-based CAPE/CIN for: conus
Working on 500 mb Hgt/Wind/Vort for conus
skipping every 8 grid points to plot
1.772 seconds to plot 500 mb Hgt/Wind/Vort for: conus
Working on 250 mb WIND for conus
skipping every 8 grid points to plot
1.648 seconds to plot 250 mb WIND for: conus
Working on total qpf for conus
Traceback (most recent call last):
  File "/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py", line 1100, in <module>
    main()
  File "/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py", line 459, in main
    plot_all(dom)
  File "/scratch2/BMC/gsd-hpcs/Daniel.Abdi/ufs-srweather-app/ush/Python/plot_allvars_diff.py", line 963, in plot_all
    cbar1.ax.set_xticklabels([0.1,0.5,1,1.5,2,3,5,10,20])
  File "/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/matplotlib/axes/_base.py", line 75, in wrapper
    return get_method(self)(*args, **kwargs)
  File "/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/matplotlib/axis.py", line 1798, in _set_ticklabels
    return self.set_ticklabels(labels, minor=minor, **kwargs)
  File "/scratch1/NCEPDEV/nems/role.epic/miniconda3/4.12.0/envs/regional_workflow/lib/python3.9/site-packages/matplotlib/axis.py", line 1720, in set_ticklabels
    raise ValueError(
ValueError: The number of FixedLocator locations (18), usually from a call to set_ticks, does not match the number of ticklabels (9).
```
with new run
```
$ python3 plot_allvars.py 2019070100 0 6 3 /scratch2/BMC/gsd-hpcs/Daniel.Abdi/expt_dirs/grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_2017_gfdlmp_regional_plot /scratch2/BMC/det/UFS_SRW_App/develop/NaturalEarth RRFS_CONUS_25km
2019 7 1 0
[0 3 6]
Working on forecast hour 000
38.5
262.5
23.020 seconds to read all messages
Working on slp for conus
2.617 seconds to plot slp for: conus
Working on t2m for conus
0.816 seconds to plot 2mt for: conus
Working on 2mdew for conus
0.866 seconds to plot 2mdew for: conus
Working on 10mwspd for conus
skipping every 8 grid points to plot
1.061 seconds to plot 10mwspd for: conus
Working on surface-based CAPE/CIN for conus
2.139 seconds to plot surface-based CAPE/CIN for: conus
Working on 500 mb Hgt/Wind/Vort for conus
1.258 seconds to plot 500 mb Hgt/Wind/Vort for: conus
Working on 250 mb WIND for conus
1.283 seconds to plot 250 mb WIND for: conus
Working on composite reflectivity for conus
1.329 seconds to plot composite reflectivity for: conus
41.353 seconds to plot all variables for forecast hour 000
Working on forecast hour 003
38.5
262.5
25.461 seconds to read all messages
Working on slp for conus
0.962 seconds to plot slp for: conus
Working on t2m for conus
0.959 seconds to plot 2mt for: conus
Working on 2mdew for conus
0.831 seconds to plot 2mdew for: conus
Working on 10mwspd for conus
skipping every 8 grid points to plot
1.114 seconds to plot 10mwspd for: conus
Working on surface-based CAPE/CIN for conus
1.959 seconds to plot surface-based CAPE/CIN for: conus
Working on 500 mb Hgt/Wind/Vort for conus
1.002 seconds to plot 500 mb Hgt/Wind/Vort for: conus
Working on 250 mb WIND for conus
1.234 seconds to plot 250 mb WIND for: conus
Working on total qpf for conus
1.386 seconds to plot total qpf for: conus
Working on composite reflectivity for conus
1.382 seconds to plot composite reflectivity for: conus
Working on Max/Min Hourly 2-5 km UH for conus
1.427 seconds to plot Max/Min Hourly 2-5 km UH for: conus
41.034 seconds to plot all variables for forecast hour 003
Working on forecast hour 006
38.5
262.5
27.526 seconds to read all messages
Working on slp for conus
1.002 seconds to plot slp for: conus
Working on t2m for conus
0.889 seconds to plot 2mt for: conus
Working on 2mdew for conus
0.860 seconds to plot 2mdew for: conus
Working on 10mwspd for conus
skipping every 8 grid points to plot
1.148 seconds to plot 10mwspd for: conus
Working on surface-based CAPE/CIN for conus
2.101 seconds to plot surface-based CAPE/CIN for: conus
Working on 500 mb Hgt/Wind/Vort for conus
1.078 seconds to plot 500 mb Hgt/Wind/Vort for: conus
Working on 250 mb WIND for conus
1.321 seconds to plot 250 mb WIND for: conus
Working on total qpf for conus
1.357 seconds to plot total qpf for: conus
Working on composite reflectivity for conus
1.431 seconds to plot composite reflectivity for: conus
Working on Max/Min Hourly 2-5 km UH for conus
1.428 seconds to plot Max/Min Hourly 2-5 km UH for: conus
41.353 seconds to plot all variables for forecast hour 006

```
I did encounter an issue with plotting 500mb vars, but can not reproduce it in release for some reason so I left those changes out.
### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [X] hera.intel
  You can run the above plot_diff command on Hera to verify the issue.
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
- ufs-community/regional_workflow/pull/<pr_number>
- ufs-community/UFS_UTILS/pull/<pr_number>
- ufs-community/ufs-weather-model/pull/<pr_number> -->

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here (Remember, issues must always be created before starting work on a PR branch!). For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/ufs-community/other_repository/pull/63" -->

## CHECKLIST
<!-- Add an X to check off a box. -->
- [ ] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

