### PR TITLE
[develop] Update ufs-weather-model hash and add WoFS_v0 to suites and tests

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -12,7 +12,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 52072c5
+hash = 84b28ec
 local_path = sorc/ufs-weather-model
 required = True
 

--- a/parm/FV3.input.yml
+++ b/parm/FV3.input.yml
@@ -33,6 +33,36 @@ FV3_RRFS_v1beta:
     iopt_trs: 2
     lsm: 2
     lsoil_lsm: 4
+FV3_WoFS_v0:
+  gfs_physics_nml:
+    do_deep: False
+    imfdeepcnv: 0
+    imfshalcnv: 0
+    iopt_alb: 2
+    iopt_btr: 1
+    iopt_crs: 1
+    iopt_dveg: 2
+    iopt_frz: 1
+    iopt_inf: 1
+    iopt_rad: 1
+    iopt_run: 1
+    iopt_sfc: 1
+    iopt_snf: 4
+    iopt_stc: 1
+    iopt_tbot: 2
+    do_mynnsfclay: True
+    imfdeepcnv: -1
+    imfshalcnv: -1
+    lsm: 1
+    lsoil_lsm: 4
+    imp_physics: 17
+    nssl_cccn: 0.6e+9
+    nssl_hail_on: True
+    nssl_ccn_on: True
+  fv_core_nml:
+    nwat: 7
+  fv_diagnostics_nml:
+    do_hailcast: True
 
 FV3_HRRR:
   fv_core_nml:

--- a/parm/diag_table.FV3_WoFS_v0
+++ b/parm/diag_table.FV3_WoFS_v0
@@ -1,0 +1,349 @@
+{{ starttime.strftime("%Y%m%d.%H") }}Z.{{ cres }}.32bit.non-hydro.regional
+{{ starttime.strftime("%Y %m %d %H %M %S") }}
+
+"grid_spec",              -1,  "months",   1, "days",  "time"
+"atmos_static",           -1,  "hours",    1, "hours", "time"
+#"atmos_4xdaily",           1,  "hours",    1, "days",  "time"
+"fv3_history",             1,  "years",    1, "hours", "time"
+"fv3_history2d",           1,  "years",    1, "hours", "time"
+
+#
+#=======================
+# ATMOSPHERE DIAGNOSTICS
+#=======================
+###
+# grid_spec
+###
+ "dynamics", "grid_lon", "grid_lon", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_lat", "grid_lat", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_lont", "grid_lont", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_latt", "grid_latt", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "area",     "area",     "grid_spec", "all", .false.,  "none", 2,
+###
+# 4x daily output
+###
+# "dynamics",  "slp",         "slp",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "vort850",     "vort850",    "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "vort200",     "vort200",    "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "us",          "us",         "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u1000",       "u1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u850",        "u850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u700",        "u700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u500",        "u500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u200",        "u200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u100",        "u100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u50",         "u50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "u10",         "u10",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "vs",          "vs",         "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v1000",       "v1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v850",        "v850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v700",        "v700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v500",        "v500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v200",        "v200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v100",        "v100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v50",         "v50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "v10",         "v10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "tm",          "tm",         "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t1000",       "t1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t850",        "t850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t700",        "t700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t500",        "t500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t200",        "t200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t100",        "t100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t50",         "t50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "t10",         "t10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "z1000",       "z1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z850",        "z850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z700",        "z700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z500",        "z500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z200",        "z200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z100",        "z100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z50",         "z50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "z10",         "z10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "w1000",       "w1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w850",        "w850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w700",        "w700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w500",        "w500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "w200",        "w200",       "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "q1000",       "q1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q850",        "q850",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q700",        "q700",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q500",        "q500",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q200",        "q200",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q100",        "q100",       "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q50",         "q50",        "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "q10",         "q10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+# "dynamics",  "rh1000",      "rh1000",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh850",       "rh850",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh700",       "rh700",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh500",       "rh500",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "rh200",       "rh200",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg1000",     "omg1000",    "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg850",      "omg850",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg700",      "omg700",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg500",      "omg500",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg200",      "omg200",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg100",      "omg100",     "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg50",       "omg50",      "atmos_4xdaily", "all", .false.,  "none", 2
+# "dynamics",  "omg10",       "omg10",      "atmos_4xdaily", "all", .false.,  "none", 2
+###
+# gfs static data
+###
+ "dynamics",      "pk",          "pk",           "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "bk",          "bk",           "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "hyam",        "hyam",         "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "hybm",        "hybm",         "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "zsurf",       "zsurf",        "atmos_static",      "all", .false.,  "none", 2
+###
+# FV3 variabls needed for NGGPS evaluation
+###
+"gfs_dyn",     "ucomp",       "ugrd",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "vcomp",       "vgrd",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "sphum",       "spfh",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "temp",        "tmp",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "liq_wat",     "clwmr",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "o3mr",        "o3mr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "delp",        "dpres",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "delz",        "delz",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "w",           "dzdt",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ice_wat",     "icmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "rainwat",     "rwmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "snowwat",     "snmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "graupel",     "grle",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "hailwat",     "hailmr",    "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "water_nc",    "ccw",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ice_nc",      "cci",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "rain_nc",     "ntrnc",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "snow_nc",     "ntsnc",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "graupel_nc",  "ntgnc",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "hail_nc",     "nthnc",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ccn_nc",      "ccn",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ps",          "pressfc",   "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "hs",          "hgtsfc",    "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "refl_10cm"    "refl_10cm"  "fv3_history",    "all",  .false.,  "none",  2
+#"gfs_phys",    "cldfra",      "cldfra",    "fv3_history",    "all",  .false.,  "none",  2
+
+"gfs_dyn",   "wmaxup",        "upvvelmax",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "wmaxdn",        "dnvvelmax",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmax03",       "uhmax03",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmax25",       "uhmax25",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmin03",       "uhmin03",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "uhmin25",       "uhmin25",     "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "maxvort01",     "maxvort01",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "maxvort02",     "maxvort02",   "fv3_history",           "all",  .false.,  "none", 2
+"gfs_dyn",   "maxvorthy1",    "maxvorthy1",  "fv3_history",           "all",  .false.,  "none", 2
+
+"gfs_phys",  "ALBDO_ave",     "albdo_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "cnvprcp_ave",   "cprat_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "cnvprcpb_ave",  "cpratb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "totprcp_ave",   "prate_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "totprcpb_ave",  "prateb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DLWRF",         "dlwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DLWRFI",        "dlwrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRF",         "ulwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFI",        "ulwrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRF",         "dswrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFI",        "dswrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRF",         "uswrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRFI",        "uswrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFtoa",      "dswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRFtoa",      "uswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFtoa",      "ulwrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "gflux_ave",     "gflux_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "hpbl",          "hpbl",        "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "lhtfl_ave",     "lhtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "shtfl_ave",     "shtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "pwat",          "pwatclm",     "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "soilm",         "soilm",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_aveclm",   "tcdc_aveclm", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avebndcl", "tcdc_avebndcl",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avehcl",   "tcdc_avehcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avelcl",   "tcdc_avelcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avemcl",   "tcdc_avemcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDCcnvcl",     "tcdccnvcl",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PREScnvclt",    "prescnvclt",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PREScnvclb",    "prescnvclb",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avehct",   "pres_avehct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avehcb",   "pres_avehcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avehct",   "tmp_avehct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avemct",   "pres_avemct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avemcb",   "pres_avemcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avemct",   "tmp_avemct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avelct",   "pres_avelct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avelcb",   "pres_avelcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avelct",   "tmp_avelct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "u-gwd_ave",     "u-gwd_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "v-gwd_ave",     "v-gwd_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "dusfc",         "uflx_ave",    "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "dvsfc",         "vflx_ave",    "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "cnvw",          "cnvcldwat",   "fv3_history2d",         "all",  .false.,  "none",  2
+
+"gfs_phys",    "psurf",       "pressfc",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "u10m",        "ugrd10m",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "v10m",        "vgrd10m",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "crain",       "crain",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tprcp",       "tprcp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hgtsfc",      "orog",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "weasd",       "weasd",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "f10m",        "f10m",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "q2m",         "spfh2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "t2m",         "tmp2m",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tsfc",        "tmpsfc",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "vtype",       "vtype",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "stype",       "sotyp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slmsksfc",    "land",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "vfracsfc",    "veg",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "zorlsfc",     "sfcr",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "uustar",      "fricv",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt1",      "soilt1"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt2",      "soilt2"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt3",      "soilt3"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt4",      "soilt4"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw1",      "soilw1"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw2",      "soilw2"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw3",      "soilw3"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw4",      "soilw4"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_1",       "soill1",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_2",       "soill2",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_3",       "soill3",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_4",       "soill4",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slope",       "sltyp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alnsf",       "alnsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alnwf",       "alnwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alvsf",       "alvsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alvwf",       "alvwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "canopy",      "cnwat",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "facsf",       "facsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "facwf",       "facwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "ffhh",        "ffhh",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "ffmm",        "ffmm",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "fice",        "icec",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hice",        "icetk",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snoalb",      "snoalb",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "shdmax",      "shdmax",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "shdmin",      "shdmin",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snowd",       "snod",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tg3",         "tg3",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tisfc",       "tisfc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tref",        "tref",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "z_c",         "zc",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "c_0",         "c0",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "c_d",         "cd",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "w_0",         "w0",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "w_d",         "wd",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xt",          "xt",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xz",          "xz",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "dt_cool",     "dtcool",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xs",          "xs",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xu",          "xu",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xv",          "xv",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xtts",        "xtts",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xzts",        "xzts",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "d_conv",      "dconv",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "qrain",       "qrain",     "fv3_history2d",  "all",  .false.,  "none",  2
+
+"gfs_phys",    "acond",        "acond",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cduvb_ave",    "cduvb_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cpofp",        "cpofp",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "duvb_ave",     "duvb_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csdlf_ave",    "csdlf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csusf_ave",    "csusf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csusf_avetoa", "csusftoa",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csdsf_ave",    "csdsf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csulf_ave",    "csulf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csulf_avetoa", "csulftoa",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cwork_ave",    "cwork_aveclm",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evbs_ave",     "evbs_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evcw_ave",     "evcw_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "fldcp",        "fldcp",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "hgt_hyblev1",  "hgt_hyblev1",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfh_hyblev1", "spfh_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ugrd_hyblev1", "ugrd_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vgrd_hyblev1", "vgrd_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmp_hyblev1",  "tmp_hyblev1",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "gfluxi",       "gflux",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "lhtfl",        "lhtfl",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "shtfl",        "shtfl",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pevpr",        "pevpr",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pevpr_ave",    "pevpr_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sbsno_ave",    "sbsno_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sfexc",        "sfexc",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snohf",        "snohf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snowc_ave",    "snowc_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfhmax2m",    "spfhmax_max2m", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfhmin2m",    "spfhmin_min2m", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmpmax2m",     "tmax_max2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmpmin2m",     "tmin_min2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ssrun_acc",    "ssrun_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sunsd_acc",    "sunsd_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "watr_acc",     "watr_acc",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "wilt",         "wilt",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vbdsf_ave",    "vbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vddsf_ave",    "vddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nbdsf_ave",    "nbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nddsf_ave",    "nddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "trans_ave",    "trans_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+# Aerosols (CCN, IN) from Thompson microphysics
+#"gfs_phys",    "nwfa",         "nwfa",          "fv3_history",    "all",  .false.,  "none",  2
+#"gfs_phys",    "nifa",         "nifa",          "fv3_history",    "all",  .false.,  "none",  2
+#"gfs_sfc",     "nwfa2d",       "nwfa2d",        "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_sfc",     "nifa2d",       "nifa2d",        "fv3_history2d",  "all",  .false.,  "none",  2
+# Cloud effective radii from Thompson and WSM6 microphysics
+"gfs_phys",    "cleffr",       "cleffr",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "cieffr",       "cieffr",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "cseffr",       "cseffr",        "fv3_history",    "all",  .false.,  "none",  2
+# Prognostic/diagnostic variables from MYNN
+"gfs_phys",    "QC_BL",        "qc_bl",         "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "CLDFRA_BL",    "cldfra_bl",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "EL_PBL",       "el_pbl",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "QKE",          "qke",           "fv3_history",    "all",  .false.,  "none",  2
+"gfs_sfc",     "maxmf",        "maxmf",         "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_sfc",     "nupdraft",     "nupdrafts",     "fv3_history2d",  "all",  .false.,  "none",  2
+#"gfs_sfc",     "ktop_shallow", "ktop_shallow",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "zol",          "zol",           "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "flhc",         "flhc",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "flqc",         "flqc",          "fv3_history2d",  "all",  .false.,  "none",  2
+# Prognostic/diagnostic variables from RUC LSM
+"gfs_sfc",     "snowfall_acc",     "snowfall_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "swe_snowfall_acc", "swe_snowfall_acc", "fv3_history2d",  "all",  .false.,  "none",  2
+
+"gfs_dyn",     "hailcast_dhail_max", "HAILCAST_DHAIL", "fv3_history2d",  "all",  .false.,  "none",  2
+
+#=============================================================================================
+#
+#====> This file can be used with diag_manager/v2.0a (or higher) <====
+#
+#
+#  FORMATS FOR FILE ENTRIES (not all input values are used)
+#  ------------------------
+#
+#"file_name", output_freq, "output_units", format, "time_units", "long_name",
+#
+#
+#output_freq:  > 0  output frequency in "output_units"
+#              = 0  output frequency every time step
+#              =-1  output frequency at end of run
+#
+#output_units = units used for output frequency
+#               (years, months, days, minutes, hours, seconds)
+#
+#time_units   = units used to label the time axis
+#               (days, minutes, hours, seconds)
+#
+#
+#  FORMAT FOR FIELD ENTRIES (not all input values are used)
+#  ------------------------
+#
+#"module_name", "field_name", "output_name", "file_name" "time_sampling", time_avg, "other_opts", packing
+#
+#time_avg = .true. or .false.
+#
+#packing  = 1  double precision
+#         = 2  float
+#         = 4  packed 16-bit integers
+#         = 8  packed 1-byte (not tested?)

--- a/parm/field_table.FV3_WoFS_v0
+++ b/parm/field_table.FV3_WoFS_v0
@@ -1,0 +1,91 @@
+# added by FRE: sphum must be present in atmos
+# specific humidity for moist runs
+ "TRACER", "atmos_mod", "sphum"
+           "longname",     "specific humidity"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic cloud water mixing ratio
+ "TRACER", "atmos_mod", "liq_wat"
+           "longname",     "cloud water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic ice water mixing ratio
+ "TRACER", "atmos_mod", "ice_wat"
+           "longname",     "cloud ice mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic rain water mixing ratio
+ "TRACER", "atmos_mod", "rainwat"
+           "longname",     "rain water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic snow water mixing ratio
+ "TRACER", "atmos_mod", "snowwat"
+           "longname",     "snow mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic graupel mixing ratio
+ "TRACER", "atmos_mod", "graupel"
+           "longname",     "graupel mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic hail mixing ratio
+ "TRACER", "atmos_mod", "hailwat"
+           "longname",     "hail mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=0" /
+# prognostic cloud water number concentration
+ "TRACER", "atmos_mod", "water_nc"
+           "longname",     "cloud liquid water number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic rain number concentration
+ "TRACER", "atmos_mod", "rain_nc"
+           "longname",     "rain number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic cloud ice number concentration
+ "TRACER", "atmos_mod", "ice_nc"
+           "longname",     "cloud ice number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic snow number concentration
+ "TRACER", "atmos_mod", "snow_nc"
+           "longname",     "snow number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic graupel number concentration
+ "TRACER", "atmos_mod", "graupel_nc"
+           "longname",     "graupel number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic hail number concentration
+ "TRACER", "atmos_mod", "hail_nc"
+           "longname",     "hail number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic graupel volume
+ "TRACER", "atmos_mod", "graupel_vol"
+           "longname",     "graupel water particle volume"
+           "units",        "m3/kg"
+       "profile_type", "fixed", "surface_value=0" /
+# prognostic hail volume
+ "TRACER", "atmos_mod", "hail_vol"
+           "longname",     "hail water particle volume"
+           "units",        "m3/kg"
+       "profile_type", "fixed", "surface_value=0" /
+# prognostic CCN number concentration
+ "TRACER", "atmos_mod", "ccn_nc"
+           "longname",     "ccn number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0" /
+# prognostic ozone mixing ratio tracer
+ "TRACER", "atmos_mod", "o3mr"
+           "longname",     "ozone mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic subgrid scale turbulent kinetic energy
+ "TRACER", "atmos_mod", "sgs_tke"
+           "longname",     "subgrid scale turbulent kinetic energy"
+           "units",        "m2/s2"
+       "profile_type", "fixed", "surface_value=0.0" /

--- a/scripts/exregional_make_ics.sh
+++ b/scripts/exregional_make_ics.sh
@@ -124,6 +124,7 @@ case "${CCPP_PHYS_SUITE}" in
 #
   "FV3_RRFS_v1beta" | \
   "FV3_GFS_v15_thompson_mynn_lam3km" | \
+  "FV3_WoFS_v0" | \
   "FV3_HRRR" )
     if [ "${EXTRN_MDL_NAME_ICS}" = "RAP" ] || \
        [ "${EXTRN_MDL_NAME_ICS}" = "HRRR" ]; then

--- a/scripts/exregional_make_lbcs.sh
+++ b/scripts/exregional_make_lbcs.sh
@@ -122,6 +122,7 @@ case "${CCPP_PHYS_SUITE}" in
 #
   "FV3_RRFS_v1beta" | \
   "FV3_GFS_v15_thompson_mynn_lam3km" | \
+  "FV3_WoFS_v0" | \
   "FV3_HRRR" )
     if [ "${EXTRN_MDL_NAME_LBCS}" = "RAP" ] || \
        [ "${EXTRN_MDL_NAME_LBCS}" = "HRRR" ]; then

--- a/sorc/CMakeLists.txt
+++ b/sorc/CMakeLists.txt
@@ -38,7 +38,7 @@ if (BUILD_UFS)
   list(APPEND TARGET_LIST ufs-weather-model)
 
   if(NOT CCPP_SUITES)
-    set(CCPP_SUITES "FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_GFS_v15_thompson_mynn_lam3km")
+    set(CCPP_SUITES "FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_regional,FV3_GFS_v15p2,FV3_GFS_v16,FV3_RRFS_v1beta,FV3_HRRR,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0")
   endif()
   
   if(NOT APP)

--- a/tests/WE2E/test_configs/grids_extrn_mdls_suites_community/config.grid_SUBCONUS_Ind_3km_ics_FV3GFS_lbcs_FV3GFS_suite_WoFS_v0.yaml
+++ b/tests/WE2E/test_configs/grids_extrn_mdls_suites_community/config.grid_SUBCONUS_Ind_3km_ics_FV3GFS_lbcs_FV3GFS_suite_WoFS_v0.yaml
@@ -1,0 +1,23 @@
+metadata:
+  description: |-
+    This test is to ensure that the workflow running in community mode
+    completes successfully on the RRFS_SUBCONUS_3km grid using the WoFS_v0
+    physics suite with ICs and LBCs derived from the FV3GFS.
+user:
+  RUN_ENVIR: community
+workflow:
+  CCPP_PHYS_SUITE: FV3_WoFS_v0
+  PREDEF_GRID_NAME: SUBCONUS_Ind_3km
+  DATE_FIRST_CYCL: '20190615'
+  DATE_LAST_CYCL: '20190615'
+  FCST_LEN_HRS: 6
+  PREEXISTING_DIR_METHOD: rename
+task_get_extrn_ics:
+  EXTRN_MDL_NAME_ICS: FV3GFS
+  FV3GFS_FILE_FMT_ICS: grib2
+  USE_USER_STAGED_EXTRN_FILES: true
+task_get_extrn_lbcs:
+  EXTRN_MDL_NAME_LBCS: FV3GFS
+  LBC_SPEC_INTVL_HRS: 3
+  FV3GFS_FILE_FMT_LBCS: grib2
+  USE_USER_STAGED_EXTRN_FILES: true

--- a/tests/WE2E/test_configs/grids_extrn_mdls_suites_community/config.grid_SUBCONUS_Ind_3km_ics_HRRR_lbcs_RAP_suite_WoFS_v0.yaml
+++ b/tests/WE2E/test_configs/grids_extrn_mdls_suites_community/config.grid_SUBCONUS_Ind_3km_ics_HRRR_lbcs_RAP_suite_WoFS_v0.yaml
@@ -1,0 +1,25 @@
+metadata:
+  description: |-
+    This test is to ensure that the workflow running in community mode
+    completes successfully on the SUBCONUS_Ind_3km grid using the HRRR
+    physics suite with ICs derived from HRRR and LBCs derived from the RAP.
+user:
+  RUN_ENVIR: community
+workflow:
+  CCPP_PHYS_SUITE: FV3_WoFS_v0
+  PREDEF_GRID_NAME: SUBCONUS_Ind_3km
+  DATE_FIRST_CYCL: '2020081000'
+  DATE_LAST_CYCL: '2020081000'
+  FCST_LEN_HRS: 6
+  PREEXISTING_DIR_METHOD: rename
+task_get_extrn_ics:
+  EXTRN_MDL_NAME_ICS: HRRR
+  USE_USER_STAGED_EXTRN_FILES: true
+  EXTRN_MDL_FILES_ICS:
+    - '{yy}{jjj}{hh}00{fcst_hr:02d}00'
+task_get_extrn_lbcs:
+  EXTRN_MDL_NAME_LBCS: RAP
+  LBC_SPEC_INTVL_HRS: 6
+  USE_USER_STAGED_EXTRN_FILES: true
+  EXTRN_MDL_FILES_LBCS:
+    - '{yy}{jjj}{hh}00{fcst_hr:02d}00'

--- a/ush/valid_param_vals.yaml
+++ b/ush/valid_param_vals.yaml
@@ -40,6 +40,7 @@ valid_vals_CCPP_PHYS_SUITE: [
 "FV3_GFS_v15_thompson_mynn_lam3km",
 "FV3_GFS_v16",
 "FV3_RRFS_v1beta",
+"FV3_WoFS_v0",
 "FV3_HRRR"
 ] 
 valid_vals_GFDLgrid_NUM_CELLS: [48, 96, 192, 384, 768, 1152, 3072]


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The ufs-weather-model hash was updated in the release/public-v2.1.0 branch to 84b28ec.  This hash brings in the WoFS_v0 SDF.  This PR will update the ufs-weather-model hash to 84b28ec in the authoritative develop branch and bring in the components for developers to use the WoFS_v0 SDF.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
- [X] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [X] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## CHECKLIST
- [X] My code follows the style guidelines in the Contributor's Guide
- [X] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes do not require updates to the documentation (explain).
@gspetro-NOAA has already updated the documentation in develop, noting that WoFS_v0 is a currently supported CCPP parameter.
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published