### PR TITLE
[develop] modulefile updates for generic linux

### DIFF
--- a/modulefiles/build_linux_gnu.lua
+++ b/modulefiles/build_linux_gnu.lua
@@ -17,40 +17,14 @@ load("hpc-gnu")
 load("openmpi")
 load("hpc-openmpi")
 
-load("jasper/2.0.25")
-load("zlib/1.2.11")
+load("srw_common")
 
-load("hdf5/1.10.6")
-load("netcdf/4.7.4")
-load("pio/2.5.3")
-load("esmf/8.3.0b09")
-load("fms/2022.01")
 
-load("bacio/2.4.1")
-load("crtm/2.3.0")
-load("g2/3.4.3")
-load("g2tmpl/1.10.0")
-load("ip/3.3.3")
-load("sp/2.3.3")
-load("w3nco/2.4.1")
-load("upp/10.0.10")
 
-load("gftl-shared/1.3.3")
-load("yafyaml/0.5.1")
-load("mapl/2.11.0-esmf-8.3.0b09")
-load("gfsio/1.4.1")
-load("landsfcutil/2.4.1")
-load("nemsio/2.5.2")
-load("nemsiogfs/2.5.3")
-load("sfcio/1.4.1")
-load("sigio/2.3.2")
-load("w3emc/2.7.3")
-load("wgrib2/2.0.8")
-
--- Set the env. variables for the serial compilers (CC, FC, CXX), if not present
-setenv("CC", "/usr/local/bin/gcc")
-setenv("FC", "/usr/local/bin/gfortran")
-setenv("CXX", "/usr/local/bin/g++")
+-- Set the env. variables for the serial compilers (CC, FC, CXX)
+setenv("CC", "gcc")
+setenv("FC", "gfortran")
+setenv("CXX", "g++")
 
 -- Set MPI compilers depending on the MPI libraries built:
 local MPI_CC="mpicc"
@@ -82,6 +56,6 @@ if mode() == "load" then
      The example below is for the GNU compilers built with OpenMPI libraries
   NB: After the module is customized, comment out the this line and lines above
   Please export env. variable LDFLAGS after the module is successfully loaded:
-       > export LDFLAGS=\"-L\$MPI_ROOT/lib \"
+       > export LDFLAGS=" -L$MPI_ROOT/lib $LDFLAGS"
   ]===])
 end

--- a/modulefiles/build_linux_gnu.lua
+++ b/modulefiles/build_linux_gnu.lua
@@ -19,8 +19,6 @@ load("hpc-openmpi")
 
 load("srw_common")
 
-
-
 -- Set the env. variables for the serial compilers (CC, FC, CXX)
 setenv("CC", "gcc")
 setenv("FC", "gfortran")
@@ -56,6 +54,6 @@ if mode() == "load" then
      The example below is for the GNU compilers built with OpenMPI libraries
   NB: After the module is customized, comment out the this line and lines above
   Please export env. variable LDFLAGS after the module is successfully loaded:
-       > export LDFLAGS=" -L$MPI_ROOT/lib $LDFLAGS"
+       > export LDFLAGS+=" -L$MPI_ROOT/lib "
   ]===])
 end

--- a/modulefiles/wflow_linux.lua
+++ b/modulefiles/wflow_linux.lua
@@ -1,11 +1,11 @@
 help([[
-This module activates python environement for running the UFS SRW App on Linux
+This module sets a path to activate conda environment needed for running the UFS SRW App on Linux
 ]])
 
-whatis([===[This module activates python environment for running the UFS SRW App on Linux]===])
+whatis([===[This module sets a path for conda environment needed for running the UFS SRW App on Linux]===])
 
 setenv("CMAKE_Platform", "linux")
-setenv("VENV", pathJoin(os.getenv("HOME"), "venv/regional_workflow"))
+setenv("VENV", pathJoin(os.getenv("HOME"), "condaenv/envs/regional_workflow"))
 
 --[[
 local ROCOTOmod="/Users/username/modules"
@@ -14,13 +14,7 @@ load(rocoto)
 --]]
 
 if mode() == "load" then
-   LmodMsgRaw([===[Verify the Python virtual environment path \$VENV shown below is correct,
-set to the correct path otherwise:
-VENV=$env(VENV) "
-Please do the following to activate python virtual environment:
-       > source \$VENV/bin/activate
+     LmodMsgRaw([===[Please do the following to activate conda:
+       > conda activate $VENV
 ]===])
-end
-if mode() == "unload" then
-   execute{cmd="deactivate", modeA={"unload"}}
 end


### PR DESCRIPTION
Updated modulefiles: use srw_common module, conda environment instead of python
Build modulefile now uses srw_common module with list of standard software modules for the release.

The following files have been updated:
**./modulefiles/build_linux_gnu.lua
./modulefiles/wflow_linux.lua**

Type of change
- [x]  Update of a supported feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Similar change needed for develop at ufs-community/ufs-srweather-app

This is similar to the [PR-478](https://github.com/ufs-community/ufs-srweather-app/pull/478) that has been merged into the release/public-v2.1.0 branch