### PR TITLE
[develop] Ensure arbitrary restart_interval numbers in model_configure

### DIFF
--- a/parm/model_configure
+++ b/parm/model_configure
@@ -15,7 +15,7 @@ cpl:                     {{ cpl }}
 calendar:                'julian'
 memuse_verbose:          .false.
 atmos_nthreads:          {{ atmos_nthreads }}
-restart_interval:        {{ restart_interval }}  -1
+restart_interval:        {{ restart_interval }}
 output_1st_tstep_rst:    .false.
 write_dopost:            {{ write_dopost }}
 ideflate:                0

--- a/tests/WE2E/test_configs/wflow_features/config.specify_RESTART_INTERVAL.yaml
+++ b/tests/WE2E/test_configs/wflow_features/config.specify_RESTART_INTERVAL.yaml
@@ -2,11 +2,11 @@ metadata:
   description: |-
     This test checks the capability of the workflow to have the time
     interval (RESTART_INTERVAL) at which restart files are written by the
-    forecast model be set to a user-specified value.
+    forecast model be set to user-specified values.
 user:
   RUN_ENVIR: community
 workflow:
-  CCPP_PHYS_SUITE: FV3_GFS_v15p2
+  CCPP_PHYS_SUITE: FV3_GFS_v16
   PREDEF_GRID_NAME: RRFS_CONUS_25km
   DATE_FIRST_CYCL: '2019070100'
   DATE_LAST_CYCL: '2019070100'
@@ -17,7 +17,8 @@ task_get_extrn_ics:
   USE_USER_STAGED_EXTRN_FILES: true
 task_get_extrn_lbcs:
   EXTRN_MDL_NAME_LBCS: FV3GFS
-  LBC_SPEC_INTVL_HRS: 3
+  LBC_SPEC_INTVL_HRS: 6
   USE_USER_STAGED_EXTRN_FILES: true
 task_run_fcst:
-  RESTART_INTERVAL: 1
+  WTIME_RUN_FCST: 01:00:00        
+  RESTART_INTERVAL: 1 2 5

--- a/tests/WE2E/test_configs/wflow_features/config.specify_RESTART_INTERVAL.yaml
+++ b/tests/WE2E/test_configs/wflow_features/config.specify_RESTART_INTERVAL.yaml
@@ -20,5 +20,4 @@ task_get_extrn_lbcs:
   LBC_SPEC_INTVL_HRS: 6
   USE_USER_STAGED_EXTRN_FILES: true
 task_run_fcst:
-  WTIME_RUN_FCST: 01:00:00        
   RESTART_INTERVAL: 1 2 5

--- a/ush/config_defaults.yaml
+++ b/ush/config_defaults.yaml
@@ -1490,8 +1490,10 @@ task_run_fcst:
   # RESTART_INTERVAL:
   # frequency of the output restart files (unit:hour). 
   # Default=0: restart files are produced at the end of a forecast run
-  # For example, RESTART_INTERVAL: 1: restart files are produced every hour
-  # with the prefix "YYYYMMDD.HHmmSS." in the RESTART directory
+  # For example, i) RESTART_INTERVAL: 1 -1 => restart files are produced 
+  # every hour with the prefix "YYYYMMDD.HHmmSS." in the RESTART directory
+  # ii) RESTART_INTERVAL: 1 2 5 => restart files are produced only when 
+  # fh = 1, 2, and 5.
   #
   # WRITE_DOPOST:
   # Flag that determines whether or not to use the inline post feature 

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -569,12 +569,6 @@ def setup():
               FCST_MODEL = '{FCST_MODEL}'"""
         )
 
-    # Make sure RESTART_INTERVAL is set to an integer value
-    if not isinstance(RESTART_INTERVAL, int):
-        raise Exception(
-            f"\nRESTART_INTERVAL = {RESTART_INTERVAL}, must be an integer value\n"
-        )
-
     # Check that input dates are in a date format
 
     # get dictionary of all variables


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- To ensure arbitrary numbers for `restart_interval`, the unnecessary parameter value `-1` is removed from the template `parm/model_configure`.
- The WE2E test is updated with `restart_interval: 1 2 5`, which creates the restart files at fhr=1, 2, and 5.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
- WE2E test: specify_RESTART_INTERVAL with the following three cases:
1) RESTART_INTERVAL: 1 2 5
2) RESTART_INTERVAL: 1 -1
3) RESTART_INTERVAL: 0

- [ ] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [x] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## ISSUE: 
Fixes issue mentioned in #502 

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
