### PR TITLE
[develop] Remove Slurm Memory Option for noaacloud

### DIFF
--- a/parm/FV3LAM_wflow.xml
+++ b/parm/FV3LAM_wflow.xml
@@ -303,7 +303,7 @@ MODULES_RUN_TASK_FP script.
     &RSRV_HPSS;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&GET_EXTRN_ICS_TN;" "&JOBSdir;/JREGIONAL_GET_EXTRN_MDL_FILES"</command>
     <nodes>{{ nnodes_get_extrn_ics }}:ppn={{ ppn_get_extrn_ics }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_get_extrn_ics }}</memory>
   {%- endif %}
     <walltime>{{ wtime_get_extrn_ics }}</walltime>
@@ -334,7 +334,7 @@ MODULES_RUN_TASK_FP script.
     &RSRV_HPSS;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&GET_EXTRN_LBCS_TN;" "&JOBSdir;/JREGIONAL_GET_EXTRN_MDL_FILES"</command>
     <nodes>{{ nnodes_get_extrn_lbcs }}:ppn={{ ppn_get_extrn_lbcs }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_get_extrn_lbcs }}</memory>
   {%- endif %}
     <walltime>{{ wtime_get_extrn_lbcs }}</walltime>
@@ -804,7 +804,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_HPSS;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&GET_OBS;" "&JOBSdir;/JREGIONAL_GET_OBS_CCPA"</command>
     <nodes>{{ nnodes_get_obs_ccpa }}:ppn={{ ppn_get_obs_ccpa }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_get_obs_ccpa }}</memory>
   {%- endif %}
     <walltime>{{ wtime_get_obs_ccpa }}</walltime>
@@ -836,7 +836,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_HPSS;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&GET_OBS;" "&JOBSdir;/JREGIONAL_GET_OBS_MRMS"</command>
     <nodes>{{ nnodes_get_obs_mrms }}:ppn={{ ppn_get_obs_mrms }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_get_obs_mrms }}</memory>
   {%- endif %}
     <walltime>{{ wtime_get_obs_mrms }}</walltime>
@@ -869,7 +869,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_HPSS;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&GET_OBS;" "&JOBSdir;/JREGIONAL_GET_OBS_NDAS"</command>
     <nodes>{{ nnodes_get_obs_ndas }}:ppn={{ ppn_get_obs_ndas }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_get_obs_ndas }}</memory>
   {%- endif %}
     <walltime>{{ wtime_get_obs_ndas }}</walltime>
@@ -900,7 +900,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_GRIDSTAT"</command>
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_gridstat }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_gridstat }}</walltime>
@@ -956,7 +956,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_GRIDSTAT"</command>
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_gridstat }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_gridstat }}</walltime>
@@ -1011,7 +1011,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_GRIDSTAT"</command>
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_gridstat }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_gridstat }}</walltime>
@@ -1066,7 +1066,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_GRIDSTAT"</command>
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_gridstat }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_gridstat }}</walltime>
@@ -1107,7 +1107,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_GRIDSTAT"</command>
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_gridstat }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_gridstat }}</walltime>
@@ -1148,7 +1148,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_GRIDSTAT"</command>
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_gridstat }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_gridstat }}</walltime>
@@ -1189,7 +1189,7 @@ the <task> tag to be identical to the ones above for other output times.
 
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_POINTSTAT"</command>
     <nodes>{{ nnodes_vx_pointstat }}:ppn={{ ppn_vx_pointstat }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_pointstat }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_pointstat }}</walltime>
@@ -1247,7 +1247,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID"</command>
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
@@ -1284,7 +1284,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID"</command>
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
@@ -1321,7 +1321,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID"</command>
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
@@ -1358,7 +1358,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID"</command>
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
@@ -1394,7 +1394,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID"</command>
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
@@ -1429,7 +1429,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID"</command>
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
@@ -1463,7 +1463,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID_MEAN"</command>
     <nodes>{{ nnodes_vx_ensgrid_mean }}:ppn={{ ppn_vx_ensgrid_mean }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid_mean }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
@@ -1499,7 +1499,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID_PROB"</command>
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid_prob }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
@@ -1535,7 +1535,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID_MEAN"</command>
     <nodes>{{ nnodes_vx_ensgrid_mean }}:ppn={{ ppn_vx_ensgrid_mean }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid_mean }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
@@ -1571,7 +1571,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID_PROB"</command>
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid_prob }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
@@ -1608,7 +1608,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID_MEAN"</command>
     <nodes>{{ nnodes_vx_ensgrid_mean }}:ppn={{ ppn_vx_ensgrid_mean }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid_mean }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
@@ -1644,7 +1644,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID_PROB"</command>
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid_prob }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
@@ -1681,7 +1681,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID_MEAN"</command>
     <nodes>{{ nnodes_vx_ensgrid_mean }}:ppn={{ ppn_vx_ensgrid_mean }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid_mean }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
@@ -1717,7 +1717,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID_PROB"</command>
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid_prob }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
@@ -1753,7 +1753,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID_PROB"</command>
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid_prob }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
@@ -1788,7 +1788,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSGRID_PROB"</command>
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_ensgrid_prob }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
@@ -1824,7 +1824,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSPOINT"</command>
     <nodes>{{ nnodes_vx_enspoint }}:ppn={{ ppn_vx_enspoint }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_enspoint }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_enspoint }}</walltime>
@@ -1857,7 +1857,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSPOINT_MEAN"</command>
     <nodes>{{ nnodes_vx_enspoint_mean }}:ppn={{ ppn_vx_enspoint_mean }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_enspoint_mean }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_enspoint_mean }}</walltime>
@@ -1890,7 +1890,7 @@ the <task> tag to be identical to the ones above for other output times.
     &RSRV_DEFAULT;
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSdir;/JREGIONAL_RUN_VX_ENSPOINT_PROB"</command>
     <nodes>{{ nnodes_vx_enspoint_prob }}:ppn={{ ppn_vx_enspoint_prob }}</nodes>
-  {%- if machine not in ["GAEA"]  %}
+  {%- if machine not in ["GAEA", "NOAACLOUD"]  %}
     <memory>{{ mem_vx_enspoint_prob }}</memory>
   {%- endif %}
     <walltime>{{ wtime_vx_enspoint_prob }}</walltime>


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Added logic to not include the slurm memory option for our NOAA cloud platforms. Testing the development branch of the SRW App on NOAA cloud platforms revealed this error:
"FV3LAM_wflow.xml :: sbatch: error: Memory specification can not be satisfied"

Slurm on NOAA cloud wasn't setup like the rest of the RDHPCs, so there isn't a good way to configure its memory. Removing the slurm memory option allows for the experiment to complete successfully. 

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [ ] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [X] NOAA Cloud (indicate which platform)
- Azure and GCP
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:

## DOCUMENTATION:

## ISSUE: 
The slurm memory logic was reported in Issue #349 and was addressed in PR #443.

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
Discussed with @danielabdi-noaa the origins of the Issue and PR.
