### PR TITLE
[develop]: Correct PDF-generated release version for develop docs

### DIFF
--- a/docs/UsersGuide/source/conf.py
+++ b/docs/UsersGuide/source/conf.py
@@ -25,9 +25,9 @@ copyright = '2020, '
 author = ' '
 
 # The short X.Y version
-version = ''
+version = 'develop'
 # The full version, including alpha/beta/rc tags
-release = 'v1.0'
+release = 'Develop Branch Documentation'
 
 numfig = True
 
@@ -144,6 +144,9 @@ latex_elements = {
         \usepackage[defaultsans]{lato}
         \usepackage{inconsolata}
     ''',
+    # Release name prefix
+      'releasename': ' ',
+
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Currently, when users generate a PDF of the documentation locally off of the develop branch, the PDF says "Release v1.0," but the content is up-to-date for the develop branch. This PR changes the "release" field in the `conf.py` file to reflect that documentation is for the `develop` branch, not v1.0. 

(Note that this problem does not affect the online RTD documentation.)

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
None required. I generated an updated PDF of the docs successfully. 

## DEPENDENCIES:
N/A

## DOCUMENTATION:
N/A

## ISSUE: 
Partially resolved Issue #512 . PRs to the SRW v2.0.0 and v2.1.0 branches will complete the fix. 

## CHECKLIST
- [X] My code follows the style guidelines in the Contributor's Guide
- [X] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas N/A
- [X] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain). N/A
- [X] My changes generate no new warnings
- [ ] New and existing tests pass with my changes N/A
- [ ] Any dependent changes have been merged and published N/A

## CONTRIBUTORS (optional): 
Thanks to @ywangwof for noticing this bug on the v2.1.0 release branch!
