### PR TITLE
[release/public-v2]: Correct PDF-generated release version for v2.0.0 docs

### DIFF
--- a/docs/UsersGuide/source/Non-ContainerQS.rst
+++ b/docs/UsersGuide/source/Non-ContainerQS.rst
@@ -40,7 +40,7 @@ For a detailed explanation of how to build and run the SRW App on any supported 
             
             ./devbuild.sh --platform=<machine_name>
 
-         where ``<machine_name>`` is replaced with the name of the platform the user's platform/system. Valid values are: ``cheyenne`` | ``gaea`` | ``hera`` | ``jet`` | ``macos`` | ``odin`` | ``orion`` | ``singularity`` | ``wcoss_dell_p3`` | ``noaacloud``
+         where ``<machine_name>`` is replaced with the name of the user's platform/system. Valid values are: ``cheyenne`` | ``gaea`` | ``hera`` | ``jet`` | ``macos`` | ``odin`` | ``orion`` | ``singularity`` | ``wcoss_dell_p3`` | ``noaacloud``
 
       * **Option 2:**
 

--- a/docs/UsersGuide/source/conf.py
+++ b/docs/UsersGuide/source/conf.py
@@ -25,9 +25,9 @@ copyright = '2020, '
 author = ' '
 
 # The short X.Y version
-version = ''
+version = 'v2.0'
 # The full version, including alpha/beta/rc tags
-release = 'v1.0'
+release = 'v2.0.0'
 
 numfig = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Currently, when users generate a PDF of the documentation locally off of the v2.0.0 branch, the PDF says "Release v1.0," but the content is up-to-date for the v2.0.0 branch. This PR changes the "release" field in the `conf.py` file to reflect that documentation is for the v2.0.0 branch, not v1.0. 

(Note that this problem does not affect the online RTD documentation.)

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
None required. I generated an updated PDF of the docs successfully. 

## DEPENDENCIES:
N/A

## DOCUMENTATION:
N/A

## ISSUE: 
Partially resolved Issue #512 . PRs to the SRW develop and v2.1.0 branches will complete the fix. 

## CHECKLIST
- [X] My code follows the style guidelines in the Contributor's Guide
- [X] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas N/A
- [X] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain). N/A
- [X] My changes generate no new warnings
- [ ] New and existing tests pass with my changes N/A
- [ ] Any dependent changes have been merged and published N/A

## CONTRIBUTORS (optional): 
Thanks to @ywangwof for noticing this bug on the v2.1.0 release branch!