### PR TITLE
[online-cmaq] Fix incorrect date in NEXUS emission

### DIFF
--- a/externals/Externals_AQM.cfg
+++ b/externals/Externals_AQM.cfg
@@ -12,7 +12,7 @@ protocol = git
 repo_url = https://github.com/noaa-oar-arl/NEXUS
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 69a7a50
+hash = 3842818
 local_path = sorc/arl_nexus
 required = True
 

--- a/scripts/exregional_nexus_emission.sh
+++ b/scripts/exregional_nexus_emission.sh
@@ -205,7 +205,7 @@ if [ "${NEI2016}" = "TRUE" ]; then #NEI2016
     mkdir_vrfy -p ${DATAinput}/NEI2016v1/v2022-07
     mkdir_vrfy -p ${DATAinput}/NEI2016v1/v2022-07/${mm}
     ./nexus_nei2016_linker.py --src_dir ${NEXUS_INPUT_BASE_DIR} --date ${yyyymmdd} --work_dir ${DATAinput} -v "v2022-07"
-    ./nexus_nei2016_control_tilefix.py -f NEXUS_Config.rc -d ${yyyymmdd}
+    ./nexus_nei2016_control_tilefix.py -f NEXUS_Config.rc -t HEMCO_sa_Time.rc # -d ${yyyymmdd}
 fi
 
 


### PR DESCRIPTION


## DESCRIPTION OF CHANGES: 
<!-- One or more paragraphs describing the problem, solution, and required changes. -->
Updates the nexus hash and nexus_emission job to use the local HEMCO_sa_Time.rc instead of a supplied date.  This correctly handles crossing the new year. 

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [x] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [x] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## ISSUE: 

https://github.com/NOAA-EMC/AQM/issues/39#issuecomment-1371477023

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

