### PR TITLE
[develop]: Fix formatting for RTD User's Guide

### DIFF
--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -4,3 +4,4 @@ docutils==0.17
 Pygments==2.13.0
 sphinx==5.3.0
 importlib-metadata==5.2.0
+pillow==9.3.0

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -2,3 +2,4 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme==1.1.1
 docutils==0.17
 Pygments==2.13.0
+sphinx==5.3.0

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,2 +1,3 @@
 sphinxcontrib-bibtex
 sphinx_rtd_theme==0.5.1
+docutils==0.17

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,7 +1,8 @@
 sphinxcontrib-bibtex
-sphinx_rtd_theme==1.1.1
+sphinx_rtd_theme 
+#==1.1.1
 docutils==0.16
-Pygments==2.13.0
-sphinx==5.3.0
-importlib-metadata==5.2.0
-pillow==9.3.0
+#Pygments==2.13.0
+#sphinx==5.3.0
+#importlib-metadata==5.2.0
+#pillow==9.3.0

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,6 +1,6 @@
 sphinxcontrib-bibtex
 sphinx_rtd_theme==1.1.1
-docutils==0.17
+docutils==0.16
 Pygments==2.13.0
 sphinx==5.3.0
 importlib-metadata==5.2.0

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -3,3 +3,4 @@ sphinx_rtd_theme==1.1.1
 docutils==0.17
 Pygments==2.13.0
 sphinx==5.3.0
+importlib-metadata==5.2.0

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,3 +1,4 @@
 sphinxcontrib-bibtex
 sphinx_rtd_theme==0.5.1
 docutils==0.17
+Pygments==2.13.0

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,4 +1,4 @@
 sphinxcontrib-bibtex
-sphinx_rtd_theme==0.5.1
+sphinx_rtd_theme==1.1.1
 docutils==0.17
 Pygments==2.13.0

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,8 +1,3 @@
 sphinxcontrib-bibtex
-sphinx_rtd_theme 
-#==1.1.1
+sphinx_rtd_theme
 docutils==0.16
-#Pygments==2.13.0
-#sphinx==5.3.0
-#importlib-metadata==5.2.0
-#pillow==9.3.0

--- a/docs/UsersGuide/requirements.txt
+++ b/docs/UsersGuide/requirements.txt
@@ -1,2 +1,2 @@
 sphinxcontrib-bibtex
-sphinx_rtd_theme
+sphinx_rtd_theme==0.5.1

--- a/docs/UsersGuide/source/conf.py
+++ b/docs/UsersGuide/source/conf.py
@@ -41,6 +41,7 @@ numfig = True
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_rtd_theme',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',

--- a/docs/UsersGuide/source/conf.py
+++ b/docs/UsersGuide/source/conf.py
@@ -41,7 +41,6 @@ numfig = True
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx_rtd_theme',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Added the sphinx_rtd_theme extension and pinned docutils==0.16 to resolve RTD formatting issues. 

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue) --> documentation bug
- [X] This change requires a documentation update

## TESTS CONDUCTED: 
None required. I built the docs from my fork, and they now render correctly: https://srw-ug.readthedocs.io/en/bugfix-doc-dependencies/Introduction.html

## DEPENDENCIES:
N/A

## DOCUMENTATION:
N/A

## ISSUE: 
Issue #532 

## CHECKLIST
- [X] My code follows the style guidelines in the Contributor's Guide
- [X] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas N/A
- [X] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain). N/A
- [X] My changes generate no new warnings
- [ ] New and existing tests pass with my changes N/A
- [ ] Any dependent changes have been merged and published N/A
