### PR TITLE
[develop] Integrate 'online-cmaq' branch into 'develop' branch: Part 1, jjob and ex- scripts

### DIFF
--- a/jobs/JREGIONAL_AQM_ICS
+++ b/jobs/JREGIONAL_AQM_ICS
@@ -3,9 +3,8 @@
 #
 #-----------------------------------------------------------------------
 #
-# This script generates both the initial conditions (ICs) and the lateral
-# boundary conditions (LBCs) files for the air quality model (AQM) from
-# files stored either in the system directory or on mass storage (HPSS).
+# This script adds extra species for air quality modeling (AQM) to the 
+# initial conditions (ICs).
 #
 #-----------------------------------------------------------------------
 #
@@ -19,7 +18,7 @@
 #
 . $USHdir/source_util_funcs.sh
 source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
-. $USHdir/job_preamble.sh "TRUE"
+. $USHdir/job_preamble.sh
 #
 #-----------------------------------------------------------------------
 #

--- a/jobs/JREGIONAL_AQM_ICS
+++ b/jobs/JREGIONAL_AQM_ICS
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# This script generates both the initial conditions (ICs) and the lateral
+# boundary conditions (LBCs) files for the air quality model (AQM) from
+# files stored either in the system directory or on mass storage (HPSS).
+#
+#-----------------------------------------------------------------------
+#
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+. $USHdir/job_preamble.sh "TRUE"
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the J-job script for the task that copies/fetches to a local 
+directory (either from disk or HPSS) the aqm boundary conditions from 
+which the model needs.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set the name of and create the directory in which the output from this
+# script will be placed (if it doesn't already exist).
+#
+#-----------------------------------------------------------------------
+#
+if [ $RUN_ENVIR = "nco" ]; then
+    export INPUT_DATA="${COMIN}"
+else
+    export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}/INPUT"
+fi
+mkdir_vrfy -p "${INPUT_DATA}"
+#
+#-----------------------------------------------------------------------
+#
+# Set the run directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+mkdir_vrfy -p "${DATA}"
+#
+#-----------------------------------------------------------------------
+#
+# Call the ex-script for this J-job and pass to it the necessary variables.
+#
+#-----------------------------------------------------------------------
+#
+$SCRIPTSdir/exregional_aqm_ics.sh || \
+print_err_msg_exit "\
+Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
+#
+#-----------------------------------------------------------------------
+#
+# Run job postamble.
+#
+#-----------------------------------------------------------------------
+#
+job_postamble
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/jobs/JREGIONAL_AQM_LBCS
+++ b/jobs/JREGIONAL_AQM_LBCS
@@ -3,9 +3,8 @@
 #
 #-----------------------------------------------------------------------
 #
-# This script generates both the initial conditions (ICs) and the lateral
-# boundary conditions (LBCs) files for the air quality model (AQM) from
-# files stored either in the system directory or on mass storage (HPSS).
+# This script adds extra species for air quality modeling (AQM) to the 
+# lateral boundary conditions (LBCs) files.
 #
 #-----------------------------------------------------------------------
 #
@@ -19,7 +18,7 @@
 #
 . $USHdir/source_util_funcs.sh
 source_config_for_task "task_get_extrn_lbcs|task_make_orog|task_make_lbcs|cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
-. $USHdir/job_preamble.sh "TRUE"
+. $USHdir/job_preamble.sh
 #
 #-----------------------------------------------------------------------
 #

--- a/jobs/JREGIONAL_AQM_LBCS
+++ b/jobs/JREGIONAL_AQM_LBCS
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# This script generates both the initial conditions (ICs) and the lateral
+# boundary conditions (LBCs) files for the air quality model (AQM) from
+# files stored either in the system directory or on mass storage (HPSS).
+#
+#-----------------------------------------------------------------------
+#
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "task_get_extrn_lbcs|task_make_orog|task_make_lbcs|cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+. $USHdir/job_preamble.sh "TRUE"
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the J-job script for the task that copies/fetches to a local 
+directory (either from disk or HPSS) the aqm boundary conditions from 
+which the model needs.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set the name of and create the directory in which the output from this
+# script will be placed (if it doesn't already exist).
+#
+#-----------------------------------------------------------------------
+#
+if [ $RUN_ENVIR = "nco" ]; then
+    export INPUT_DATA="${COMIN}"
+else
+    export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}/INPUT"
+fi
+mkdir_vrfy -p "${INPUT_DATA}"
+#
+#-----------------------------------------------------------------------
+#
+# Set the run directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+mkdir_vrfy -p "${DATA}"
+#
+#-----------------------------------------------------------------------
+#
+# Call the ex-script for this J-job and pass to it the necessary variables.
+#
+#-----------------------------------------------------------------------
+#
+$SCRIPTSdir/exregional_aqm_lbcs.sh || \
+print_err_msg_exit "\
+Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
+#
+#-----------------------------------------------------------------------
+#
+# Run job postamble.
+#
+#-----------------------------------------------------------------------
+#
+job_postamble
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/jobs/JREGIONAL_BIAS_CORRECTION_O3
+++ b/jobs/JREGIONAL_BIAS_CORRECTION_O3
@@ -17,7 +17,7 @@
 #
 . $USHdir/source_util_funcs.sh
 source_config_for_task "cpl_aqm_parm|task_run_post" ${GLOBAL_VAR_DEFNS_FP}
-. $USHdir/job_preamble.sh "TRUE"
+. $USHdir/job_preamble.sh
 #
 #-----------------------------------------------------------------------
 #
@@ -62,8 +62,6 @@ This is the J-job script for the task that runs BIAS-CORRECTION-O3.
 #
 DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
 
-export COMIN_PDY="${COMIN_PDY:-${COMIN_BASEDIR}/${RUN}.${PDY}}"
-export COMIN_PDYm1="${COMIN_PDYm1:-${COMIN_BASEDIR}/${RUN}.${PDYm1}}"
 export PARMaqm_utils="${PARMaqm_utils:-${HOMEdir}/sorc/AQM-utils/parm}"
 
 TMP_STDAY=`${NDATE} -8760 ${PDY}${cyc} | cut -c1-8`  # 1 year back

--- a/jobs/JREGIONAL_BIAS_CORRECTION_O3
+++ b/jobs/JREGIONAL_BIAS_CORRECTION_O3
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# This script runs BIAS-CORRECTION-O3.
+#
+#-----------------------------------------------------------------------
+#
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm|task_run_post" ${GLOBAL_VAR_DEFNS_FP}
+. $USHdir/job_preamble.sh "TRUE"
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the J-job script for the task that runs BIAS-CORRECTION-O3.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set the run directory.
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+
+export COMIN_PDY="${COMIN_PDY:-${COMIN_BASEDIR}/${RUN}.${PDY}}"
+export COMIN_PDYm1="${COMIN_PDYm1:-${COMIN_BASEDIR}/${RUN}.${PDYm1}}"
+export PARMaqm_utils="${PARMaqm_utils:-${HOMEdir}/sorc/AQM-utils/parm}"
+
+TMP_STDAY=`${NDATE} -8760 ${PDY}${cyc} | cut -c1-8`  # 1 year back
+# The earliest day of training data is August 1 2020
+if [ ${TMP_STDAY} -le 20220810 ]; then 
+  TMP_STDAY=20220810 
+fi
+export BC_STDAY=${BC_STDAY:-${TMP_STDAY}}
+#
+#-----------------------------------------------------------------------
+#
+# Call the ex-script for this J-job and pass to it the necessary varia-
+# bles.
+#
+#-----------------------------------------------------------------------
+#
+$SCRIPTSdir/exregional_bias_correction_o3.sh || \
+print_err_msg_exit "\
+Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
+#
+#-----------------------------------------------------------------------
+#
+# Run job postamble.
+#
+#-----------------------------------------------------------------------
+#
+job_postamble
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/func-
+# tion.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/jobs/JREGIONAL_BIAS_CORRECTION_PM25
+++ b/jobs/JREGIONAL_BIAS_CORRECTION_PM25
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# This script runs BIAS-CORRECTION-PM25.
+#
+#-----------------------------------------------------------------------
+#
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm|task_run_post" ${GLOBAL_VAR_DEFNS_FP}
+. $USHdir/job_preamble.sh "TRUE"
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the J-job script for the task that runs BIAS-CORRECTION-PM25.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set the run directory.
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+
+export COMIN_PDY="${COMIN_PDY:-${COMIN_BASEDIR}/${RUN}.${PDY}}"
+export COMIN_PDYm1="${COMIN_PDYm1:-${COMIN_BASEDIR}/${RUN}.${PDYm1}}"
+export PARMaqm_utils="${PARMaqm_utils:-${HOMEdir}/sorc/AQM-utils/parm}"
+
+TMP_STDAY=`${NDATE} -8760 ${PDY}${cyc} | cut -c1-8`  # 1 year back
+# The earliest day of training data is August 1 2020
+if [ ${TMP_STDAY} -le 20220810 ]; then 
+  TMP_STDAY=20220810 
+fi
+export BC_STDAY=${BC_STDAY:-${TMP_STDAY}}
+#
+#-----------------------------------------------------------------------
+#
+# Call the ex-script for this J-job and pass to it the necessary varia-
+# bles.
+#
+#-----------------------------------------------------------------------
+#
+$SCRIPTSdir/exregional_bias_correction_pm25.sh || \
+print_err_msg_exit "\
+Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
+#
+#-----------------------------------------------------------------------
+#
+# Run job postamble.
+#
+#-----------------------------------------------------------------------
+#
+job_postamble
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/func-
+# tion.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/jobs/JREGIONAL_BIAS_CORRECTION_PM25
+++ b/jobs/JREGIONAL_BIAS_CORRECTION_PM25
@@ -17,7 +17,7 @@
 #
 . $USHdir/source_util_funcs.sh
 source_config_for_task "cpl_aqm_parm|task_run_post" ${GLOBAL_VAR_DEFNS_FP}
-. $USHdir/job_preamble.sh "TRUE"
+. $USHdir/job_preamble.sh
 #
 #-----------------------------------------------------------------------
 #
@@ -62,8 +62,6 @@ This is the J-job script for the task that runs BIAS-CORRECTION-PM25.
 #
 DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
 
-export COMIN_PDY="${COMIN_PDY:-${COMIN_BASEDIR}/${RUN}.${PDY}}"
-export COMIN_PDYm1="${COMIN_PDYm1:-${COMIN_BASEDIR}/${RUN}.${PDYm1}}"
 export PARMaqm_utils="${PARMaqm_utils:-${HOMEdir}/sorc/AQM-utils/parm}"
 
 TMP_STDAY=`${NDATE} -8760 ${PDY}${cyc} | cut -c1-8`  # 1 year back

--- a/jobs/JREGIONAL_FIRE_EMISSION
+++ b/jobs/JREGIONAL_FIRE_EMISSION
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# This script gets fire emission data files from disk or HPSS
+#
+#-----------------------------------------------------------------------
+#
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+. $USHdir/job_preamble.sh
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the J-job script for the task that copies or fetches RAVE fire
+emission data files from disk, or HPSS.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set the external model start time
+#
+#-----------------------------------------------------------------------
+#
+export TIME_OFFSET_HRS=${AQM_FIRE_FILE_OFFSET_HRS:-0}
+yyyymmdd=${PDY}
+hh=${cyc}
+export FIRE_FILE_CDATE=$( $DATE_UTIL --utc --date "${yyyymmdd} ${hh} UTC - ${TIME_OFFSET_HRS} hours" "+%Y%m%d%H" )
+
+#
+#-----------------------------------------------------------------------
+#
+# Check whether FIRE EMISSION data files are available on the specified 
+# cycle date and time on HPSS (FIRE_FILE_CDATE).
+#
+#-----------------------------------------------------------------------
+#
+CDATE_min="2022101500"
+if [ "$FIRE_FILE_CDATE" -lt "$CDATE_min" ]; then
+  print_info_msg "
+========================================================================  
+RAVE fire emission data are not available on HPSS for this date.
+CDATE:  \"${FIRE_FILE_CDATE}\"
+CDATE_min:    \"${CDATE_min}\"
+========================================================================"
+fi
+#
+#-----------------------------------------------------------------------
+#
+# Create the directory where the RAVE fire emission files should be stored
+#
+#-----------------------------------------------------------------------
+#
+export FIRE_EMISSION_STAGING_DIR="${COMINext}/FIRE_EMISSION"
+mkdir_vrfy -p "${FIRE_EMISSION_STAGING_DIR}"
+cd_vrfy ${FIRE_EMISSION_STAGING_DIR}
+#
+#-----------------------------------------------------------------------
+#
+# Call the ex-script for this J-job and pass to it the necessary variables.
+#
+#-----------------------------------------------------------------------
+#
+$SCRIPTSdir/exregional_fire_emission.sh || \
+print_err_msg_exit "\
+Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
+#
+#-----------------------------------------------------------------------
+#
+# Run job postamble.
+#
+#-----------------------------------------------------------------------
+#
+job_postamble
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/jobs/JREGIONAL_NEXUS_EMISSION
+++ b/jobs/JREGIONAL_NEXUS_EMISSION
@@ -84,7 +84,7 @@ mkdir_vrfy -p "${DATA}"
 #
 #-----------------------------------------------------------------------
 #
-time $SCRIPTSdir/exregional_nexus_emission.sh || \
+$SCRIPTSdir/exregional_nexus_emission.sh || \
 print_err_msg_exit "\
 Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
 #

--- a/jobs/JREGIONAL_NEXUS_EMISSION
+++ b/jobs/JREGIONAL_NEXUS_EMISSION
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# This script generate NEXUS emission netcdf file.
+#
+#-----------------------------------------------------------------------
+#
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "task_run_fcst|cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+. $USHdir/job_preamble.sh
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the J-job script for the task that generates the emission files 
+using NEXUS which will output for FV3 (in NetCDF format).
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set the name of and create the directory in which the output from this
+# script will be placed (if it doesn't already exist).
+#
+#-----------------------------------------------------------------------
+#
+if [ $RUN_ENVIR = "nco" ]; then
+    export INPUT_DATA="${COMIN}/NEXUS"
+else
+    export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}/NEXUS"
+fi
+mkdir_vrfy -p "${INPUT_DATA}"
+#
+#-----------------------------------------------------------------------
+#
+# Set the run directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+mkdir_vrfy -p "${DATA}"
+#
+#-----------------------------------------------------------------------
+#
+# Call the ex-script for this J-job.
+#
+#-----------------------------------------------------------------------
+#
+time $SCRIPTSdir/exregional_nexus_emission.sh || \
+print_err_msg_exit "\
+Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
+#
+#-----------------------------------------------------------------------
+#
+# Run job postamble.
+#
+#-----------------------------------------------------------------------
+#
+job_postamble
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/func-
+# tion.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/jobs/JREGIONAL_NEXUS_GFS_SFC
+++ b/jobs/JREGIONAL_NEXUS_GFS_SFC
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# This script gets fire emission data files from disk or HPSS
+#
+#-----------------------------------------------------------------------
+#
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+. $USHdir/job_preamble.sh "TRUE"
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the J-job script for the task that copies or fetches RAVE fire
+emission data files from disk, or HPSS.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set the external model start time
+#
+#-----------------------------------------------------------------------
+#
+export TIME_OFFSET_HRS=${NEXUS_GFS_SFC_OFFSET_HRS:-0}
+yyyymmdd=${PDY}
+hh=${cyc}
+export GFS_SFC_CDATE=$( $DATE_UTIL --utc --date "${yyyymmdd} ${hh} UTC - ${TIME_OFFSET_HRS} hours" "+%Y%m%d%H" )
+
+#
+#-----------------------------------------------------------------------
+#
+# Check whether GFS_SFC_CDATE data files are available on the specified 
+# cycle date and time on HPSS.
+#
+#-----------------------------------------------------------------------
+#
+CDATE_min="2021032100"
+if [ "$GFS_SFC_CDATE" -lt "$CDATE_min" ]; then
+  print_info_msg "
+========================================================================  
+GFS surface data (NetCDF) are not available on HPSS for this date.
+CDATE:     \"${GFS_SFC_CDATE}\"
+CDATE_min: \"${CDATE_min}\"
+
+Therefore, this task will be skipped and MERRA2 data will be used for
+NEXUS_EMISSION.
+========================================================================"
+
+  exit 0
+fi
+#
+#-----------------------------------------------------------------------
+#
+# Create the directory where the RAVE fire emission files should be stored
+#
+#-----------------------------------------------------------------------
+#
+export GFS_SFC_STAGING_DIR="${COMINext}/GFS_SFC"
+mkdir_vrfy -p "${GFS_SFC_STAGING_DIR}"
+#
+#-----------------------------------------------------------------------
+#
+# Set the run directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+mkdir_vrfy -p "${DATA}"
+#
+#-----------------------------------------------------------------------
+#
+# Call the ex-script for this J-job and pass to it the necessary variables.
+#
+#-----------------------------------------------------------------------
+#
+$SCRIPTSdir/exregional_nexus_gfs_sfc.sh || \
+print_err_msg_exit "\
+Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
+#
+#-----------------------------------------------------------------------
+#
+# Run job postamble.
+#
+#-----------------------------------------------------------------------
+#
+job_postamble
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/jobs/JREGIONAL_NEXUS_GFS_SFC
+++ b/jobs/JREGIONAL_NEXUS_GFS_SFC
@@ -17,7 +17,7 @@
 #
 . $USHdir/source_util_funcs.sh
 source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
-. $USHdir/job_preamble.sh "TRUE"
+. $USHdir/job_preamble.sh
 #
 #-----------------------------------------------------------------------
 #
@@ -51,8 +51,8 @@ print_info_msg "
 Entering script:  \"${scrfunc_fn}\"
 In directory:     \"${scrfunc_dir}\"
 
-This is the J-job script for the task that copies or fetches RAVE fire
-emission data files from disk, or HPSS.
+This is the J-job script for the task that copies or fetches GFS surface
+data files from disk, or HPSS.
 ========================================================================"
 #
 #-----------------------------------------------------------------------

--- a/jobs/JREGIONAL_NEXUS_POST_SPLIT
+++ b/jobs/JREGIONAL_NEXUS_POST_SPLIT
@@ -9,7 +9,7 @@
 #
 . $USHdir/source_util_funcs.sh
 source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
-. $USHdir/job_preamble.sh "TRUE"
+. $USHdir/job_preamble.sh
 #
 #-----------------------------------------------------------------------
 #
@@ -76,7 +76,7 @@ mkdir_vrfy -p "${DATA}"
 #
 #-----------------------------------------------------------------------
 #
-time $SCRIPTSdir/exregional_nexus_post_split.sh || \
+$SCRIPTSdir/exregional_nexus_post_split.sh || \
 print_err_msg_exit "\
 Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
 #

--- a/jobs/JREGIONAL_NEXUS_POST_SPLIT
+++ b/jobs/JREGIONAL_NEXUS_POST_SPLIT
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+. $USHdir/job_preamble.sh "TRUE"
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the J-job script for the task that generates the emission files 
+using NEXUS which will output for FV3 (in NetCDF format).
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set the name of and create the directory in which the output from this
+# script will be placed (if it doesn't already exist).
+#
+#-----------------------------------------------------------------------
+#
+if [ $RUN_ENVIR = "nco" ]; then
+    export INPUT_DATA="${COMIN}"
+else
+    export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}/INPUT"
+fi
+mkdir_vrfy -p "${INPUT_DATA}"
+#
+#-----------------------------------------------------------------------
+#
+# Set the run directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+mkdir_vrfy -p "${DATA}"
+#
+#-----------------------------------------------------------------------
+#
+# Call the ex-script for this J-job.
+#
+#-----------------------------------------------------------------------
+#
+time $SCRIPTSdir/exregional_nexus_post_split.sh || \
+print_err_msg_exit "\
+Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
+#
+#-----------------------------------------------------------------------
+#
+# Run job postamble.
+#
+#-----------------------------------------------------------------------
+#
+job_postamble
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/func-
+# tion.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/jobs/JREGIONAL_POINT_SOURCE
+++ b/jobs/JREGIONAL_POINT_SOURCE
@@ -9,7 +9,7 @@
 #
 . $USHdir/source_util_funcs.sh
 source_config_for_task "task_make_grid|task_run_fcst|cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
-. $USHdir/job_preamble.sh "TRUE"
+. $USHdir/job_preamble.sh
 #
 #-----------------------------------------------------------------------
 #

--- a/jobs/JREGIONAL_POINT_SOURCE
+++ b/jobs/JREGIONAL_POINT_SOURCE
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "task_make_grid|task_run_fcst|cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+. $USHdir/job_preamble.sh "TRUE"
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the J-job script for the task that generates the emission files 
+using NEXUS which will output for FV3 (in NetCDF format).
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set the name of and create the directory in which the output from this
+# script will be placed (if it doesn't already exist).
+#
+#-----------------------------------------------------------------------
+#
+if [ $RUN_ENVIR = "nco" ]; then
+    export INPUT_DATA="${COMIN}"
+else
+    export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}"
+fi
+mkdir_vrfy -p "${INPUT_DATA}"
+#
+#-----------------------------------------------------------------------
+#
+# Set the run directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+mkdir_vrfy -p "${DATA}"
+#
+#
+#-----------------------------------------------------------------------
+#
+# Call the ex-script for this J-job.
+#
+#-----------------------------------------------------------------------
+#
+time $SCRIPTSdir/exregional_point_source.sh || \
+print_err_msg_exit "\
+Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
+#
+#-----------------------------------------------------------------------
+#
+# Run job postamble.
+#
+#-----------------------------------------------------------------------
+#
+job_postamble
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/func-
+# tion.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/jobs/JREGIONAL_POST_STAT_O3
+++ b/jobs/JREGIONAL_POST_STAT_O3
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# This script runs POST-STAT-O3.
+#
+#-----------------------------------------------------------------------
+#
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm|task_run_post" ${GLOBAL_VAR_DEFNS_FP}
+. $USHdir/job_preamble.sh "TRUE"
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the J-job script for the task that runs POST-STAT-O3.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set the run directory.
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+
+export COMIN_PDY="${COMIN_PDY:-${COMIN_BASEDIR}/${RUN}.${PDY}}"
+export COMIN_PDYm1="${COMIN_PDYm1:-${COMIN_BASEDIR}/${RUN}.${PDYm1}}"
+export PARMaqm_utils="${PARMaqm_utils:-${HOMEdir}/sorc/AQM-utils/parm}"
+#
+#-----------------------------------------------------------------------
+#
+# Call the ex-script for this J-job and pass to it the necessary varia-
+# bles.
+#
+#-----------------------------------------------------------------------
+#
+$SCRIPTSdir/exregional_post_stat_o3.sh || \
+print_err_msg_exit "\
+Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
+#
+#-----------------------------------------------------------------------
+#
+# Run job postamble.
+#
+#-----------------------------------------------------------------------
+#
+job_postamble
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/func-
+# tion.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/jobs/JREGIONAL_POST_STAT_O3
+++ b/jobs/JREGIONAL_POST_STAT_O3
@@ -17,7 +17,7 @@
 #
 . $USHdir/source_util_funcs.sh
 source_config_for_task "cpl_aqm_parm|task_run_post" ${GLOBAL_VAR_DEFNS_FP}
-. $USHdir/job_preamble.sh "TRUE"
+. $USHdir/job_preamble.sh
 #
 #-----------------------------------------------------------------------
 #
@@ -62,8 +62,6 @@ This is the J-job script for the task that runs POST-STAT-O3.
 #
 DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
 
-export COMIN_PDY="${COMIN_PDY:-${COMIN_BASEDIR}/${RUN}.${PDY}}"
-export COMIN_PDYm1="${COMIN_PDYm1:-${COMIN_BASEDIR}/${RUN}.${PDYm1}}"
 export PARMaqm_utils="${PARMaqm_utils:-${HOMEdir}/sorc/AQM-utils/parm}"
 #
 #-----------------------------------------------------------------------

--- a/jobs/JREGIONAL_POST_STAT_PM25
+++ b/jobs/JREGIONAL_POST_STAT_PM25
@@ -17,7 +17,7 @@
 #
 . $USHdir/source_util_funcs.sh
 source_config_for_task "cpl_aqm_parm|task_run_post" ${GLOBAL_VAR_DEFNS_FP}
-. $USHdir/job_preamble.sh "TRUE"
+. $USHdir/job_preamble.sh
 #
 #-----------------------------------------------------------------------
 #
@@ -62,8 +62,6 @@ This is the J-job script for the task that runs POST-UPP-STAT.
 #
 DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
 
-export COMIN_PDY="${COMIN_PDY:-${COMIN_BASEDIR}/${RUN}.${PDY}}"
-export COMIN_PDYm1="${COMIN_PDYm1:-${COMIN_BASEDIR}/${RUN}.${PDYm1}}"
 export PARMaqm_utils="${PARMaqm_utils:-${HOMEdir}/sorc/AQM-utils/parm}"
 #
 #-----------------------------------------------------------------------

--- a/jobs/JREGIONAL_POST_STAT_PM25
+++ b/jobs/JREGIONAL_POST_STAT_PM25
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# This script runs POST-STAT-PM25.
+#
+#-----------------------------------------------------------------------
+#
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm|task_run_post" ${GLOBAL_VAR_DEFNS_FP}
+. $USHdir/job_preamble.sh "TRUE"
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the J-job script for the task that runs POST-UPP-STAT.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set the run directory.
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+
+export COMIN_PDY="${COMIN_PDY:-${COMIN_BASEDIR}/${RUN}.${PDY}}"
+export COMIN_PDYm1="${COMIN_PDYm1:-${COMIN_BASEDIR}/${RUN}.${PDYm1}}"
+export PARMaqm_utils="${PARMaqm_utils:-${HOMEdir}/sorc/AQM-utils/parm}"
+#
+#-----------------------------------------------------------------------
+#
+# Call the ex-script for this J-job and pass to it the necessary varia-
+# bles.
+#
+#-----------------------------------------------------------------------
+#
+$SCRIPTSdir/exregional_post_stat_pm25.sh || \
+print_err_msg_exit "\
+Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
+#
+#-----------------------------------------------------------------------
+#
+# Run job postamble.
+#
+#-----------------------------------------------------------------------
+#
+job_postamble
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/func-
+# tion.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/jobs/JREGIONAL_PRE_POST_STAT
+++ b/jobs/JREGIONAL_PRE_POST_STAT
@@ -17,7 +17,7 @@
 #
 . $USHdir/source_util_funcs.sh
 source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
-. $USHdir/job_preamble.sh "TRUE"
+. $USHdir/job_preamble.sh
 #
 #-----------------------------------------------------------------------
 #

--- a/jobs/JREGIONAL_PRE_POST_STAT
+++ b/jobs/JREGIONAL_PRE_POST_STAT
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# This script runs PRE-POST-STAT.
+#
+#-----------------------------------------------------------------------
+#
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+. $USHdir/job_preamble.sh "TRUE"
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the J-job script for the task that runs POST-UPP-STAT.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set the run directory.
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+#
+#-----------------------------------------------------------------------
+#
+# Call the ex-script for this J-job and pass to it the necessary varia-
+# bles.
+#
+#-----------------------------------------------------------------------
+#
+$SCRIPTSdir/exregional_pre_post_stat.sh || \
+print_err_msg_exit "\
+Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
+#
+#-----------------------------------------------------------------------
+#
+# Run job postamble.
+#
+#-----------------------------------------------------------------------
+#
+job_postamble
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/func-
+# tion.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/scripts/exregional_aqm_ics.sh
+++ b/scripts/exregional_aqm_ics.sh
@@ -111,9 +111,7 @@ print_info_msg "
     FV3 IC file: \"${gfs_ic_file}\""
 
 cp_vrfy ${gfs_ic_file} ${wrk_ic_file}
-cp_vrfy ${HOMEdir}/sorc/AQM-utils/python_utils/add_aqm_ics.py add_aqm_ics.py
-
-python3 add_aqm_ics.py --fv_tracer_file "${fv_tracer_file}" --wrk_ic_file "${wrk_ic_file}"
+python3 ${HOMEdir}/sorc/AQM-utils/python_utils/add_aqm_ics.py --fv_tracer_file "${fv_tracer_file}" --wrk_ic_file "${wrk_ic_file}"
 
 ncatted -a checksum,,d,s, tmp1.nc  || print_err_msg_exit "\
 Call to NCATTED returned with nonzero exit code."

--- a/scripts/exregional_aqm_ics.sh
+++ b/scripts/exregional_aqm_ics.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the ex-script for the task that copies/fetches to a local direc-
+tory (either from disk or HPSS) the external model files from which ini-
+tial or boundary condition files for the FV3 will be generated.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Check if restart file exists
+#
+#-----------------------------------------------------------------------
+#
+rst_dir=${PREV_CYCLE_DIR}/RESTART
+rst_file=fv_tracer.res.tile1.nc
+fv_tracer_file=${rst_dir}/${PDY}.${cyc}0000.${rst_file}
+print_info_msg "
+  Looking for tracer restart file: \"${fv_tracer_file}\""
+if [ ! -r ${fv_tracer_file} ]; then
+  if [ -r ${rst_dir}/coupler.res ]; then
+    rst_info=( $( tail -n 1 ${rst_dir}/coupler.res ) )
+    rst_date=$( printf "%04d%02d%02d%02d" ${rst_info[@]:0:4} )
+    print_info_msg "
+  Tracer file not found. Checking available restart date:
+    requested date: \"${PDY}${cyc}\"
+    available date: \"${rst_date}\""
+    if [ "${rst_date}" = "${PDY}${cyc}" ] ; then
+      fv_tracer_file=${rst_dir}/${rst_file}
+      if [ -r ${fv_tracer_file} ]; then
+        print_info_msg "
+  Tracer file found: \"${fv_tracer_file}\""
+      else
+        print_err_msg_exit "\
+  No suitable tracer restart file found."
+      fi
+    fi
+  fi
+fi
+#
+#-----------------------------------------------------------------------
+#
+# Move to work directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA}/tmp_AQM_ICS"
+mkdir_vrfy -p "$DATA"
+cd_vrfy $DATA
+#
+#-----------------------------------------------------------------------
+#
+# Add air quality tracer variables from previous cycle's restart output
+# to atmosphere's initial condition file according to the steps below:
+#
+# a. Python script to manipulate the files (see comments inside for
+#    details)
+# b. Remove checksum attribute to prevent overflow
+#
+# c. Rename reulting file as the expected atmospheric IC file
+#
+#-----------------------------------------------------------------------
+#
+gfs_ic_file=${INPUT_DATA}/${NET}.${cycle}${dot_ensmem}.gfs_data.tile${TILE_RGNL}.halo${NH0}.nc
+wrk_ic_file=${DATA}/gfs.nc
+
+print_info_msg "
+  Adding air quality tracers to atmospheric initial condition file:
+    tracer file: \"${fv_tracer_file}\"
+    FV3 IC file: \"${gfs_ic_file}\""
+
+cp_vrfy ${gfs_ic_file} ${wrk_ic_file}
+cp_vrfy ${HOMEdir}/sorc/AQM-utils/python_utils/add_aqm_ics.py add_aqm_ics.py
+
+python3 add_aqm_ics.py --fv_tracer_file "${fv_tracer_file}" --wrk_ic_file "${wrk_ic_file}"
+
+ncatted -a checksum,,d,s, tmp1.nc  || print_err_msg_exit "\
+Call to NCATTED returned with nonzero exit code."
+
+mv_vrfy tmp1.nc ${gfs_ic_file}
+
+rm_vrfy gfs.nc
+
+unset fv_tracer_file
+unset wrk_ic_file
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating successful completion of script.
+#
+#-----------------------------------------------------------------------
+#
+    print_info_msg "
+========================================================================
+Successfully added air quality tracers to atmospheric initial condition
+file!!!
+
+Exiting script:  \"${scrfunc_fn}\"
+In directory:    \"${scrfunc_dir}\"
+========================================================================"
+
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/func-
+# tion.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/scripts/exregional_aqm_lbcs.sh
+++ b/scripts/exregional_aqm_lbcs.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "task_get_extrn_lbcs|task_make_orog|task_make_lbcs|cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the ex-script for the task that generates chemical and GEFS
+lateral boundary conditions.
+========================================================================"
+#
+# Set OpenMP variables.
+#
+#-----------------------------------------------------------------------
+#
+export KMP_AFFINITY=${KMP_AFFINITY_MAKE_LBCS}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_MAKE_LBCS}
+export OMP_STACKSIZE=${OMP_STACKSIZE_MAKE_LBCS}
+#
+#-----------------------------------------------------------------------
+#
+# Set run command.
+#
+#-----------------------------------------------------------------------
+#
+eval ${PRE_TASK_CMDS}
+
+nprocs=$(( NNODES_AQM_LBCS*PPN_AQM_LBCS ))
+
+if [ -z "${RUN_CMD_UTILS:-}" ] ; then
+  print_err_msg_exit "\
+  Run command was not set in machine file. \
+  Please set RUN_CMD_UTILS for your platform"
+else
+  print_info_msg "$VERBOSE" "
+  All executables will be submitted with command \'${RUN_CMD_UTILS}\'."
+fi
+
+#
+#-----------------------------------------------------------------------
+#
+# Move to working directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA}/tmp_AQM_LBCS"
+mkdir_vrfy -p "$DATA"
+cd_vrfy $DATA
+#
+#-----------------------------------------------------------------------
+#
+# Add chemical LBCS
+#
+#-----------------------------------------------------------------------
+#
+yyyymmdd="${PDY}"
+mm="${PDY:4:2}"
+
+if [ "${FCST_LEN_HRS}" = "-1" ]; then
+  for i_cdate in "${!ALL_CDATES[@]}"; do
+    if [ "${ALL_CDATES[$i_cdate]}" = "${PDY}${cyc}" ]; then
+      FCST_LEN_HRS="${FCST_LEN_CYCL[$i_cdate]}"
+      break
+    fi
+  done
+fi
+LBC_SPEC_FCST_HRS=()
+for i_lbc in $(seq ${LBC_SPEC_INTVL_HRS} ${LBC_SPEC_INTVL_HRS} $(( ${FCST_LEN_HRS}+${LBC_SPEC_INTVL_HRS} )) ); do
+  LBC_SPEC_FCST_HRS+=("$i_lbc")
+done
+
+if [ ${DO_AQM_CHEM_LBCS} = "TRUE" ]; then
+
+  ext_lbcs_file=${AQM_LBCS_FILES}
+  chem_lbcs_fn=${ext_lbcs_file//<MM>/${mm}}
+
+  chem_lbcs_fp=${AQM_LBCS_DIR}/${chem_lbcs_fn}
+  if [ -f ${chem_lbcs_fp} ]; then
+    #Copy the boundary condition file to the current location
+    cp_vrfy ${chem_lbcs_fp} .
+  else
+    print_err_msg_exit "\
+The chemical LBC files do not exist:
+  CHEM_BOUNDARY_CONDITION_FILE = \"${chem_lbcs_fp}\""
+  fi
+
+  for hr in 0 ${LBC_SPEC_FCST_HRS[@]}; do
+    fhr=$( printf "%03d" "${hr}" )
+    if [ -r ${INPUT_DATA}/${NET}.${cycle}${dot_ensmem}.gfs_bndy.tile7.f${fhr}.nc ]; then
+        ncks -A ${chem_lbcs_fn} ${INPUT_DATA}/${NET}.${cycle}${dot_ensmem}.gfs_bndy.tile7.f${fhr}.nc
+    fi
+  done
+
+  print_info_msg "
+========================================================================
+Successfully added chemical LBCs !!!
+========================================================================"
+fi
+#
+#-----------------------------------------------------------------------
+#
+# Add GEFS-LBCS
+#
+#-----------------------------------------------------------------------
+#
+if [ ${DO_AQM_GEFS_LBCS} = "TRUE" ]; then
+
+  RUN_CYC="${cyc}"
+
+  if [ ${DO_REAL_TIME} = "TRUE" ]; then
+    CDATE_MOD=$( $DATE_UTIL --utc --date "${PDY} ${cyc} UTC - ${EXTRN_MDL_LBCS_OFFSET_HRS} hours" "+%Y%m%d%H" )
+    PDY_MOD=${CDATE_MOD:0:8}
+    AQM_GEFS_CYC=$( printf "%02d" ${CDATE_MOD:8:2} )
+    AQM_MOFILE_FN="${AQM_GEFS_DIR}/gefs.${PDY_MOD}/${AQM_GEFS_CYC}/chem/sfcsig/geaer.t${AQM_GEFS_CYC}z.atmf"
+  else
+    AQM_GEFS_CYC=$( printf "%02d" "${AQM_GEFS_CYC}" )
+    AQM_MOFILE_FN="${AQM_GEFS_DIR}/${PDY}/${AQM_GEFS_CYC}/gfs.t00z.atmf"
+  fi  
+
+  GEFS_CYC_DIFF=$( printf "%02d" "$(( RUN_CYC - AQM_GEFS_CYC ))" )
+  NUMTS="$(( FCST_LEN_HRS / LBC_SPEC_INTVL_HRS + 1 ))"
+
+cat > gefs2lbc-nemsio.ini <<EOF
+&control
+ tstepdiff=${GEFS_CYC_DIFF}
+ dtstep=${LBC_SPEC_INTVL_HRS}
+ bndname='aothrj','aecj','aorgcj','asoil','numacc','numcor'
+ mofile='${AQM_MOFILE_FN}','.nemsio'
+ lbcfile='${INPUT_DATA}/${NET}.${cycle}${dot_ensmem}.gfs_bndy.tile7.f','.nc'
+ topofile='${OROG_DIR}/${CRES}_oro_data.tile7.halo4.nc'
+&end
+
+Species converting Factor
+# Gocart ug/m3 to regional ug/m3
+'dust1'    2  ## 0.2-2um diameter: assuming mean diameter is 0.3 um (volume= 0.01414x10^-18 m3) and density is 2.6x10^3 kg/m3 or 2.6x10^12 ug/m3.so 1 particle = 0.036x10^-6 ug
+'aothrj'  1.0   'numacc' 27205909.
+'dust2'    4  ## 2-4um
+'aothrj'  0.45    'numacc'  330882.  'asoil'  0.55   'numcor'  50607.
+'dust3'    2  ## 4-6um
+'asoil'   1.0   'numcor' 11501.
+'dust4'    2   ## 6-12um
+'asoil'  0.7586   'numcor' 1437.
+'bc1'      2     # kg/kg
+'aecj'     1.0   'numacc' 6775815.
+'bc2'  2     # kg/kg
+'aecj'     1.0   'numacc' 6775815.
+'oc1'  2     # kg/kg OC -> organic matter
+'aorgcj'    1.0   'numacc' 6775815.
+'oc2'  2
+'aorgcj'  1.0   'numacc' 6775815.
+EOF
+
+  exec_fn="gefs2lbc_para"
+  exec_fp="$EXECdir/${exec_fn}"
+  if [ ! -f "${exec_fp}" ]; then
+    print_err_msg_exit "\
+The executable (exec_fp) for GEFS LBCs does not exist:
+  exec_fp = \"${exec_fp}\"
+Please ensure that you've built this executable."
+  fi
+#
+#----------------------------------------------------------------------
+#
+# Run the executable
+#
+#----------------------------------------------------------------------
+#
+  PREP_STEP
+  eval ${RUN_CMD_UTILS} -n ${NUMTS} ${exec_fp} ${REDIRECT_OUT_ERR} || \
+    print_err_msg_exit "\
+Call to executable (exec_fp) to generate chemical and GEFS LBCs
+file for RRFS-CMAQ failed:
+  exec_fp = \"${exec_fp}\""
+  POST_STEP
+
+  print_info_msg "
+========================================================================
+Successfully added GEFS aerosol LBCs !!!
+========================================================================"
+#
+fi
+#
+print_info_msg "
+========================================================================
+Exiting script:  \"${scrfunc_fn}\"
+In directory:    \"${scrfunc_dir}\"
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/func-
+# tion.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1
+

--- a/scripts/exregional_aqm_lbcs.sh
+++ b/scripts/exregional_aqm_lbcs.sh
@@ -102,7 +102,7 @@ if [ "${FCST_LEN_HRS}" = "-1" ]; then
   done
 fi
 LBC_SPEC_FCST_HRS=()
-for i_lbc in $(seq ${LBC_SPEC_INTVL_HRS} ${LBC_SPEC_INTVL_HRS} $(( ${FCST_LEN_HRS}+${LBC_SPEC_INTVL_HRS} )) ); do
+for i_lbc in $(seq ${LBC_SPEC_INTVL_HRS} ${LBC_SPEC_INTVL_HRS} $(( FCST_LEN_HRS+LBC_SPEC_INTVL_HRS )) ); do
   LBC_SPEC_FCST_HRS+=("$i_lbc")
 done
 

--- a/scripts/exregional_bias_correction_o3.sh
+++ b/scripts/exregional_bias_correction_o3.sh
@@ -1,0 +1,461 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+This is the ex-script for the task that runs BIAS-CORRECTION-O3.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set OpenMP variables.
+#
+#-----------------------------------------------------------------------
+#
+export KMP_AFFINITY=${KMP_AFFINITY_BIAS_CORRECTION_O3}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_BIAS_CORRECTION_O3}
+export OMP_STACKSIZE=${OMP_STACKSIZE_BIAS_CORRECTION_O3}
+#
+#-----------------------------------------------------------------------
+#
+# Set run command.
+#
+#-----------------------------------------------------------------------
+#
+eval ${PRE_TASK_CMDS}
+
+if [ -z "${RUN_CMD_SERIAL:-}" ] ; then
+  print_err_msg_exit "\
+  Run command was not set in machine file. \
+  Please set RUN_CMD_SERIAL for your platform"
+else
+  RUN_CMD_SERIAL=$(eval echo ${RUN_CMD_SERIAL})
+  print_info_msg "$VERBOSE" "
+  All executables will be submitted with command \'${RUN_CMD_SERIAL}\'."
+fi
+
+#
+#-----------------------------------------------------------------------
+#
+# Move to the working directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA}/tmp_BIAS_CORRECTION_O3"
+rm_vrfy -rf "$DATA"
+mkdir_vrfy -p "$DATA"
+cd_vrfy $DATA
+
+set -x
+
+yyyy=${PDY:0:4}
+yyyymm=${PDY:0:6}
+yyyy_m1=${PDYm1:0:4}
+yyyymm_m1=${PDYm1:0:6}
+yyyy_m2=${PDYm2:0:4}
+yyyymm_m2=${PDYm2:0:6}
+yyyy_m3=${PDYm3:0:4}
+yyyymm_m3=${PDYm3:0:6}
+
+#
+#-----------------------------------------------------------------------
+#
+# Bias correction: O3
+#
+#-----------------------------------------------------------------------
+#
+if [ "${PREDEF_GRID_NAME}" = "AQM_NA_13km" ]; then
+  id_domain=793
+fi
+
+#-----------------------------------------------------------------------------
+# STEP 1: Retrieve AIRNOW observation data
+#-----------------------------------------------------------------------------
+
+# Link the historical airnow data
+mkdir_vrfy -p "${DATA}/data"
+ln_vrfy -sf ${AQM_AIRNOW_HIST_DIR}/bcdata* "${DATA}/data"
+if [ -d "${DATA}/data/bcdata.${yyyymm}" ]; then
+  rm_vrfy -rf "${DATA}/data/bcdata.${yyyymm}"
+  mkdir_vrfy -p "${DATA}/data/bcdata.${yyyymm}"
+  cp_vrfy -rL "${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/airnow" "${DATA}/data/bcdata.${yyyymm}"
+  cp_vrfy -rL "${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/interpolated" "${DATA}/data/bcdata.${yyyymm}" 
+fi
+
+# Retrieve real-time airnow data for the last three days
+if [ "${DO_REAL_TIME}" = "TRUE" ]; then
+  mkdir -p ${DATA}/data/bcdata.${yyyymm_m1}/airnow/${yyyy_m1}/${PDYm1}/b008
+  mkdir -p ${DATA}/data/bcdata.${yyyymm_m2}/airnow/${yyyy_m2}/${PDYm2}/b008
+  mkdir -p ${DATA}/data/bcdata.${yyyymm_m3}/airnow/${yyyy_m3}/${PDYm3}/b008
+
+  cp_vrfy ${COMINairnow}/${yyyy_m1}/${PDYm1}/b008/xx021 ${DATA}/data/bcdata.${yyyymm_m1}/airnow/${yyyy_m1}/${PDYm1}/b008
+  cp_vrfy ${COMINairnow}/${yyyy_m2}/${PDYm2}/b008/xx021 ${DATA}/data/bcdata.${yyyymm_m2}/airnow/${yyyy_m2}/${PDYm2}/b008
+  cp_vrfy ${COMINairnow}/${yyyy_m3}/${PDYm3}/b008/xx021 ${DATA}/data/bcdata.${yyyymm_m3}/airnow/${yyyy_m3}/${PDYm3}/b008
+fi
+
+#-----------------------------------------------------------------------------
+# STEP 2:  Extracting PM2.5, O3, and met variables from CMAQ input and outputs
+#-----------------------------------------------------------------------------
+
+case $cyc in
+  00) bc_interp_hr=06;;
+  06) bc_interp_hr=72;;
+  12) bc_interp_hr=72;;
+  18) bc_interp_hr=06;;
+esac
+
+ic=1
+while [ $ic -lt 120 ]; do
+  if [ -s ${COMIN}/${NET}.${cycle}.chem_sfc.f0${bc_interp_hr}.nc ]; then
+    echo "cycle ${cyc} post1 is done!"
+    break
+  else
+    (( ic=ic+1 ))
+  fi
+done
+
+if [ $ic -ge 120 ]; then
+  print_err_msg_exit "FATAL ERROR - COULD NOT LOCATE:${NET}.${cycle}.chem_sfc.f0${bc_interp_hr}.nc"
+fi
+
+# remove any pre-exit ${NET}.${cycle}.chem_sfc/met_sfc.nc for 2-stage post processing
+DATA_grid="${DATA}/data/bcdata.${yyyymm}/grid"
+if [ -d "${DATA_grid}/${cyc}z/${PDY}" ]; then
+  rm_vrfy -rf "${DATA_grid}/${cyc}z/${PDY}"
+fi
+
+mkdir_vrfy -p "${DATA_grid}/${cyc}z/${PDY}"
+ln_vrfy -sf ${COMIN}/${NET}.${cycle}.chem_sfc.*.nc ${DATA_grid}/${cyc}z/${PDY}
+ln_vrfy -sf ${COMIN}/${NET}.${cycle}.met_sfc.*.nc ${DATA_grid}/${cyc}z/${PDY}
+
+#-----------------------------------------------------------------------------
+# STEP 3:  Intepolating CMAQ O3 into AIRNow sites
+#-----------------------------------------------------------------------------
+
+mkdir_vrfy -p ${DATA}/data/coords 
+mkdir_vrfy -p ${DATA}/data/site-lists.interp 
+mkdir_vrfy -p ${DATA}/out/ozone/${yyyy}
+mkdir_vrfy -p ${DATA}/data/bcdata.${yyyymm}/interpolated/ozone/${yyyy} 
+
+cp_vrfy ${PARMaqm_utils}/bias_correction/sites.valid.ozone.20220724.12z.list ${DATA}/data/site-lists.interp
+cp_vrfy ${PARMaqm_utils}/bias_correction/aqm.t12z.chem_sfc.f000.nc ${DATA}/data/coords
+cp_vrfy ${PARMaqm_utils}/bias_correction/config.interp.ozone.7-vars_${id_domain}.${cyc}z ${DATA}
+
+PREP_STEP
+${EXECdir}/aqm_bias_interpolate config.interp.ozone.7-vars_${id_domain}.${cyc}z ${cyc}z ${PDY} ${PDY} || print_err_msg_exit "Call to executable to run AQM_BIAS_INTERPOLATE returned with nonzero exit code."
+POST_STEP
+
+cp_vrfy ${DATA}/out/ozone/${yyyy}/*nc ${DATA}/data/bcdata.${yyyymm}/interpolated/ozone/${yyyy}
+
+#-----------------------------------------------------------------------------
+# STEP 4:  Performing Bias Correction for Ozone
+#-----------------------------------------------------------------------------
+
+mkdir_vrfy -p ${DATA}/data/sites
+cp_vrfy ${PARMaqm_utils}/bias_correction/config.ozone.bias_corr_${id_domain}.${cyc}z ${DATA}
+ 
+PREP_STEP
+${EXECdir}/aqm_bias_correct config.ozone.bias_corr_${id_domain}.${cyc}z ${cyc}z ${BC_STDAY} ${PDY} || print_err_msg_exit "Call to executable to run AQM_BIAS_CORRECT returned with nonzero exit code."
+POST_STEP
+
+cp_vrfy ${DATA}/out/ozone.corrected* ${COMIN}
+
+if [ "${cyc}" = "12" ]; then
+  cp_vrfy ${DATA}/sites/sites.valid.ozone.${PDY}.${cyc}z.list ${DATA}
+fi
+
+#-----------------------------------------------------------------------------
+# STEP 5:  converting netcdf to grib format
+#-----------------------------------------------------------------------------
+
+ln_vrfy -sf ${COMIN}/ozone.corrected.${PDY}.${cyc}z.nc .
+
+#
+cat >bias_cor.ini <<EOF1
+&control
+varlist='o3','O3_8hr'
+infile='ozone.corrected.${PDY}.${cyc}z.nc'
+outfile='${NET}.${cycle}.awpozcon_bc'
+id_gribdomain=${id_domain}
+/
+EOF1
+
+# convert from netcdf to grib2 format
+PREP_STEP
+${EXECdir}/aqm_post_bias_cor_grib2 ${PDY} ${cyc} || print_err_msg_exit "\
+Call to executable to run AQM_POST_BIAS_COR_GRIB2 returned with nonzero exit code."
+POST_STEP
+
+cp_vrfy ${DATA}/${NET}.${cycle}.awpozcon*bc*.grib2 ${COMOUT}
+
+#-----------------------------------------------------------------------------
+# STEP 6: calculating 24-hr ave PM2.5
+#-----------------------------------------------------------------------------
+
+if [ "${cyc}" = "06" ] || [ "${cyc}" = "12" ]; then
+  ln_vrfy -sf ${COMOUT}/ozone.corrected.${PDY}.${cyc}z.nc a.nc 
+
+  chk=1 
+  chk1=1 
+  # today 00z file exists otherwise chk=0
+cat >bias_cor_max.ini <<EOF1
+&control
+varlist='O3_1h_max','O3_8h_max'
+outfile='aqm-maxi_bc'
+id_gribdomain=${id_domain}
+max_proc=72
+/
+EOF1
+
+  flag_run_bicor_max=yes
+  # 06z needs b.nc to find current day output from 04Z to 06Z
+  if [ "${cyc}" = "06" ]; then
+    if [ -s ${COMIN_PDY}/00/ozone.corrected.${PDY}.00z.nc ]; then
+      ln_vrfy -sf ${COMIN_PDY}/00/ozone.corrected.${PDY}.00z.nc b.nc
+    elif [ -s ${COMIN_PDYm1}/12/ozone.corrected.${PDYm1}.12z.nc ]; then
+      ln_vrfy -sf ${COMIN_PDYm1}/12/ozone.corrected.${PDYm1}.12z.nc b.nc
+      chk=0
+    else
+      flag_run_bicor_max=no
+    fi
+  fi
+
+  if [ "${cyc}" = "12" ]; then
+    # 12z needs b.nc to find current day output from 04Z to 06Z
+    if [ -s ${COMIN_PDY}/00/ozone.corrected.${PDY}.00z.nc ]; then
+      ln_vrfy -sf ${COMIN_PDY}/00/ozone.corrected.${PDY}.00z.nc b.nc
+    elif [ -s ${COMIN_PDYm1}/12/ozone.corrected.${PDYm1}.12z.nc ]; then
+      ln_vrfy -sf ${COMIN_PDYm1}/12/ozone.corrected.${PDYm1}.12z.nc b.nc
+      chk=0
+    else
+      flag_run_bicor_max=no
+    fi
+
+    # 12z needs c.nc to find current day output from 07Z to 12z
+    if [ -s ${COMIN_PDY}/06/ozone.corrected.${PDY}.06z.nc ]; then
+      ln_vrfy -sf ${COMIN_PDY}/06/ozone.corrected.${PDY}.06z.nc c.nc
+    elif [ -s ${COMIN_PDYm1}/12/ozone.corrected.${PDYm1}.12z.nc ]; then
+      ln_vrfy -sf ${COMIN_PDYm1}/12/ozone.corrected.${PDYm1}.12z.nc c.nc
+      chk1=0
+    else
+      flag_run_bicor_max=no
+    fi
+  fi
+
+  if [ "${flag_run_bicor_max}" = "yes" ]; then
+    #-------------------------------------------------
+    # write out grib2 format 
+    #-------------------------------------------------
+    PREP_STEP
+    ${EXECdir}/aqm_post_maxi_bias_cor_grib2  ${PDY} ${cyc} ${chk} ${chk1} || print_err_msg_exit "\
+    Call to executable to run AQM_POST_MAXI_BIAS_COR_GRIB2 returned with nonzero exit code."
+    POST_STEP
+
+    # split into max_1h and max_8h files and copy to grib227
+    wgrib2 aqm-maxi_bc.${id_domain}.grib2 |grep "OZMAX1" | wgrib2 -i aqm-maxi_bc.${id_domain}.grib2 -grib  ${NET}.${cycle}.max_1hr_o3_bc.${id_domain}.grib2
+    wgrib2 aqm-maxi_bc.${id_domain}.grib2 |grep "OZMAX8" | wgrib2 -i aqm-maxi_bc.${id_domain}.grib2 -grib  ${NET}.${cycle}.max_8hr_o3_bc.${id_domain}.grib2
+
+    grid227="lambert:265.0000:25.0000:25.0000 226.5410:1473:5079.000 12.1900:1025:5079.000"
+   
+    wgrib2 ${NET}.${cycle}.max_8hr_o3_bc.${id_domain}.grib2 -set_grib_type same -new_grid_winds earth -new_grid ${grid227} ${NET}.${cycle}.max_8hr_o3_bc.227.grib2
+    wgrib2 ${NET}.${cycle}.max_1hr_o3_bc.${id_domain}.grib2 -set_grib_type same -new_grid_winds earth -new_grid ${grid227} ${NET}.${cycle}.max_1hr_o3_bc.227.grib2
+
+    cp_vrfy ${DATA}/${NET}.${cycle}.max_*hr_o3_bc.*.grib2 ${COMOUT}
+   
+    if [ "$SENDDBN" = "YES" ]; then
+      ${DBNROOT}/bin/dbn_alert MODEL AQM_MAX ${job} ${COMOUT}/${NET}.${cycle}.max_1hr_o3_bc.227.grib2
+      ${DBNROOT}/bin/dbn_alert MODEL AQM_MAX ${job} ${COMOUT}/${NET}.${cycle}.max_8hr_o3_bc.227.grib2
+    fi
+   
+    # Add WMO header for daily 1h and 8h max O3 
+    for hr in 1 8; do
+      echo 0 > filesize
+      export XLFRTEOPTS="unit_vars=yes"
+      export FORT11=${NET}.${cycle}.max_${hr}hr_o3_bc.227.grib2
+      export FORT12="filesize"
+      export FORT31=
+      export FORT51=${NET}-${hr}hro3-maxi.227.grib2.temp
+      tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm-${hr}hro3-maxi.${cycle}.227
+   
+      echo `ls -l ${NET}-${hr}hro3-maxi.227.grib2.temp | awk '{print $5} '` > filesize
+      export XLFRTEOPTS="unit_vars=yes"
+      export FORT11=${NET}-${hr}hro3-maxi.227.grib2.temp
+      export FORT12="filesize"
+      export FORT31=
+      export FORT51=awpaqm.${cycle}.${hr}ho3-max-bc.227.grib2
+      tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm-${hr}hro3-maxi.${cycle}.227
+    done
+   
+    # Post Files to COMOUT
+    cp_vrfy awpaqm.${cycle}.*o3-max-bc.227.grib2 ${COMOUT}
+
+    # Distribute Data
+    if [ "${SENDDBN_NTC}" = "YES" ] ; then
+      ${DBNROOT}/bin/dbn_alert ${DBNALERT_TYPE} ${NET} ${job} ${COMOUT}/awpaqm.${cycle}.1ho3-max-bc.227.grib2
+      ${DBNROOT}/bin/dbn_alert ${DBNALERT_TYPE} ${NET} ${job} ${COMOUT}/awpaqm.${cycle}.8ho3-max-bc.227.grib2
+    fi
+  fi
+fi
+
+#-------------------------------------
+fhr=01
+case $cyc in
+  00) endfhr=06;;
+  06) endfhr=72;;
+  12) endfhr=72;;
+  18) endfhr=06;;
+esac
+
+rm_vrfy -rf tmpfile
+
+while [ "${fhr}" -le "${endfhr}" ]; do
+  fhr2d=$( printf "%02d" "${fhr}" )
+  
+  cp_vrfy ${DATA}/${NET}.${cycle}.awpozcon_bc.f${fhr2d}.${id_domain}.grib2 ${COMOUT}
+
+  # create GRIB file to convert to grid 227 then to GRIB2 for NDFD
+  cat ${DATA}/${NET}.${cycle}.awpozcon_bc.f${fhr2d}.${id_domain}.grib2 >> tmpfile
+  if [ "${fhr}" -le "07" ]; then
+    cat ${DATA}/${NET}.${cycle}.awpozcon_bc.f${fhr2d}.${id_domain}.grib2 >> tmpfile.1hr
+  else
+    wgrib2 ${DATA}/${NET}.${cycle}.awpozcon_bc.f${fhr2d}.${id_domain}.grib2 -d 1 -append -grib tmpfile.1hr
+    wgrib2 ${DATA}/${NET}.${cycle}.awpozcon_bc.f${fhr2d}.${id_domain}.grib2 -d 2 -append -grib tmpfile.8hr
+  fi
+  (( fhr=fhr+1 ))
+done
+
+###############
+# Convert ozone Concentration to grid 227 in GRIB2 format
+###############
+echo ' &NLCOPYGB IDS(180)=1, /' > ozcon_scale
+
+newgrib2file1=${NET}.${cycle}.ave_1hr_o3_bc.227.grib2
+newgrib2file2=${NET}.${cycle}.ave_8hr_o3_bc.227.grib2
+
+grid227="lambert:265.0000:25.0000:25.0000 226.5410:1473:5079.000 12.1900:1025:5079.000"
+
+wgrib2 tmpfile.1hr -set_grib_type same -new_grid_winds earth -new_grid ${grid227} ${newgrib2file1} 
+cp_vrfy tmpfile.1hr ${COMOUT}/${NET}.${cycle}.ave_1hr_o3_bc.${id_domain}.grib2
+cp_vrfy ${NET}.${cycle}.ave_1hr_o3_bc.227.grib2 ${COMOUT}
+
+if [ "${cyc}" = "06" ] || [ "${cyc}" = "12" ]; then
+  wgrib2 tmpfile.8hr -set_grib_type same -new_grid_winds earth -new_grid ${grid227} ${newgrib2file2} 
+  cp_vrfy tmpfile.8hr ${COMOUT}/${NET}.${cycle}.ave_8hr_o3_bc.${id_domain}.grib2
+  cp_vrfy ${NET}.${cycle}.ave_8hr_o3_bc.227.grib2 ${COMOUT}
+fi
+
+if [ "${SENDDBN}" = "YES" ] ; then
+   ${DBNROOT}/bin/dbn_alert MODEL AQM_CONC ${job} ${COMOUT}/${NET}.${cycle}.ave_1hr_o3_bc.227.grib2
+  if [ "${cyc}" = "06" ] || [ "${cyc}" = "12" ]; then
+   ${DBNROOT}/bin/dbn_alert MODEL AQM_CONC ${job} ${COMOUT}/${NET}.${cycle}.ave_8hr_o3_bc.227.grib2
+  fi
+fi
+
+#################################################
+#    Part III:  Insert WMO header to GRIB files
+#################################################
+
+if [ "${cyc}" = "06" ] || [ "${cyc}" = "12" ]; then
+  # Create AWIPS GRIB data for 1hr and 8hr ave ozone
+  for hr in 1 8; do
+    echo 0 > filesize
+    export XLFRTEOPTS="unit_vars=yes"
+    export FORT11=${NET}.${cycle}.ave_${hr}hr_o3_bc.227.grib2
+    export FORT12="filesize"
+    export FORT31=
+    export FORT51=grib2.${cycle}.awpcsozcon_aqm_${hr}-bc.temp
+    tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_ave_${hr}hr_o3_bc-awpozcon.${cycle}.227
+
+    echo `ls -l grib2.${cycle}.awpcsozcon_aqm_${hr}-bc.temp  | awk '{print $5} '` > filesize
+    export XLFRTEOPTS="unit_vars=yes"
+    export FORT11=grib2.${cycle}.awpcsozcon_aqm_${hr}-bc.temp
+    export FORT12="filesize"
+    export FORT31=
+    export FORT51=awpaqm.${cycle}.${hr}ho3-bc.227.grib2
+    tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_ave_${hr}hr_o3_bc-awpozcon.${cycle}.227
+
+    # Create AWIPS GRIB data for dailly 1-hr and 8hr max ozone
+    echo 0 > filesize
+    export XLFRTEOPTS="unit_vars=yes"
+    export FORT11=${NET}.${cycle}.max_${hr}hr_o3_bc.227.grib2
+    export FORT12="filesize"
+    export FORT31=
+    export FORT51=${NET}.${cycle}.max_${hr}hr_o3-bc.227.grib2.temp
+    tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm-${hr}hro3_bc-maxi.${cycle}.227
+
+    echo `ls -l  ${NET}.${cycle}.max_${hr}hr_o3-bc.227.grib2.temp | awk '{print $5} '` > filesize
+    export XLFRTEOPTS="unit_vars=yes"
+    export FORT11=${NET}.${cycle}.max_${hr}hr_o3-bc.227.grib2.temp
+    export FORT12="filesize"
+    export FORT31=
+    export FORT51=awpaqm.${cycle}.${hr}ho3-max-bc.227.grib2
+    tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm-${hr}hro3_bc-maxi.${cycle}.227
+
+    # Post Files to COMOUT
+    cp_vrfy awpaqm.${cycle}.${hr}ho3-bc.227.grib2 ${COMOUT}
+    cp_vrfy awpaqm.${cycle}.${hr}ho3-max-bc.227.grib2 ${COMOUT}
+
+    # Distribute Data
+    if [ "${SENDDBN}" = "YES" ]; then
+      ${DBNROOT}/bin/dbn_alert ${DBNALERT_TYPE} ${NET} ${job} ${COMOUT}/awpaqm.${cycle}.${hr}ho3-bc.227.grib2
+      ${DBNROOT}/bin/dbn_alert ${DBNALERT_TYPE} ${NET} ${job} ${COMOUT}/awpaqm.${cycle}.${hr}ho3-max-bc.227.grib2
+    fi
+  done
+fi
+
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating successful completion of script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+BIAS-CORRECTION-O3 completed successfully.
+
+Exiting script:  \"${scrfunc_fn}\"
+In directory:    \"${scrfunc_dir}\"
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1

--- a/scripts/exregional_bias_correction_o3.sh
+++ b/scripts/exregional_bias_correction_o3.sh
@@ -94,7 +94,7 @@ yyyy_m2=${PDYm2:0:4}
 yyyymm_m2=${PDYm2:0:6}
 yyyy_m3=${PDYm3:0:4}
 yyyymm_m3=${PDYm3:0:6}
-
+ 
 #
 #-----------------------------------------------------------------------
 #
@@ -104,6 +104,15 @@ yyyymm_m3=${PDYm3:0:6}
 #
 if [ "${PREDEF_GRID_NAME}" = "AQM_NA_13km" ]; then
   id_domain=793
+fi
+
+if [ "${FCST_LEN_HRS}" = "-1" ]; then
+  for i_cdate in "${!ALL_CDATES[@]}"; do
+    if [ "${ALL_CDATES[$i_cdate]}" = "${PDY}${cyc}" ]; then
+      FCST_LEN_HRS="${FCST_LEN_CYCL[$i_cdate]}"
+      break
+    fi
+  done
 fi
 
 #-----------------------------------------------------------------------------
@@ -135,16 +144,10 @@ fi
 # STEP 2:  Extracting PM2.5, O3, and met variables from CMAQ input and outputs
 #-----------------------------------------------------------------------------
 
-case $cyc in
-  00) bc_interp_hr=06;;
-  06) bc_interp_hr=72;;
-  12) bc_interp_hr=72;;
-  18) bc_interp_hr=06;;
-esac
-
+FCST_LEN_HRS=$( printf "%03d" ${FCST_LEN_HRS} )
 ic=1
 while [ $ic -lt 120 ]; do
-  if [ -s ${COMIN}/${NET}.${cycle}.chem_sfc.f0${bc_interp_hr}.nc ]; then
+  if [ -s ${COMIN}/${NET}.${cycle}.chem_sfc.f${FCST_LEN_HRS}.nc ]; then
     echo "cycle ${cyc} post1 is done!"
     break
   else
@@ -153,7 +156,7 @@ while [ $ic -lt 120 ]; do
 done
 
 if [ $ic -ge 120 ]; then
-  print_err_msg_exit "FATAL ERROR - COULD NOT LOCATE:${NET}.${cycle}.chem_sfc.f0${bc_interp_hr}.nc"
+  print_err_msg_exit "FATAL ERROR - COULD NOT LOCATE:${NET}.${cycle}.chem_sfc.f${FCST_LEN_HRS}.nc"
 fi
 
 # remove any pre-exit ${NET}.${cycle}.chem_sfc/met_sfc.nc for 2-stage post processing
@@ -180,7 +183,7 @@ cp_vrfy ${PARMaqm_utils}/bias_correction/aqm.t12z.chem_sfc.f000.nc ${DATA}/data/
 cp_vrfy ${PARMaqm_utils}/bias_correction/config.interp.ozone.7-vars_${id_domain}.${cyc}z ${DATA}
 
 PREP_STEP
-${EXECdir}/aqm_bias_interpolate config.interp.ozone.7-vars_${id_domain}.${cyc}z ${cyc}z ${PDY} ${PDY} || print_err_msg_exit "Call to executable to run AQM_BIAS_INTERPOLATE returned with nonzero exit code."
+eval ${RUN_CMD_SERIAL} ${EXECdir}/aqm_bias_interpolate config.interp.ozone.7-vars_${id_domain}.${cyc}z ${cyc}z ${PDY} ${PDY} ${REDIRECT_OUT_ERR} || print_err_msg_exit "Call to executable to run AQM_BIAS_INTERPOLATE returned with nonzero exit code."
 POST_STEP
 
 cp_vrfy ${DATA}/out/ozone/${yyyy}/*nc ${DATA}/data/bcdata.${yyyymm}/interpolated/ozone/${yyyy}
@@ -193,7 +196,7 @@ mkdir_vrfy -p ${DATA}/data/sites
 cp_vrfy ${PARMaqm_utils}/bias_correction/config.ozone.bias_corr_${id_domain}.${cyc}z ${DATA}
  
 PREP_STEP
-${EXECdir}/aqm_bias_correct config.ozone.bias_corr_${id_domain}.${cyc}z ${cyc}z ${BC_STDAY} ${PDY} || print_err_msg_exit "Call to executable to run AQM_BIAS_CORRECT returned with nonzero exit code."
+eval ${RUN_CMD_SERIAL} ${EXECdir}/aqm_bias_correct config.ozone.bias_corr_${id_domain}.${cyc}z ${cyc}z ${BC_STDAY} ${PDY} ${REDIRECT_OUT_ERR} || print_err_msg_exit "Call to executable to run AQM_BIAS_CORRECT returned with nonzero exit code."
 POST_STEP
 
 cp_vrfy ${DATA}/out/ozone.corrected* ${COMIN}
@@ -220,7 +223,7 @@ EOF1
 
 # convert from netcdf to grib2 format
 PREP_STEP
-${EXECdir}/aqm_post_bias_cor_grib2 ${PDY} ${cyc} || print_err_msg_exit "\
+eval ${RUN_CMD_SERIAL} ${EXECdir}/aqm_post_bias_cor_grib2 ${PDY} ${cyc} ${REDIRECT_OUT_ERR} || print_err_msg_exit "\
 Call to executable to run AQM_POST_BIAS_COR_GRIB2 returned with nonzero exit code."
 POST_STEP
 
@@ -285,7 +288,7 @@ EOF1
     # write out grib2 format 
     #-------------------------------------------------
     PREP_STEP
-    ${EXECdir}/aqm_post_maxi_bias_cor_grib2  ${PDY} ${cyc} ${chk} ${chk1} || print_err_msg_exit "\
+    eval ${RUN_CMD_SERIAL} ${EXECdir}/aqm_post_maxi_bias_cor_grib2  ${PDY} ${cyc} ${chk} ${chk1} ${REDIRECT_OUT_ERR} || print_err_msg_exit "\
     Call to executable to run AQM_POST_MAXI_BIAS_COR_GRIB2 returned with nonzero exit code."
     POST_STEP
 
@@ -336,17 +339,10 @@ EOF1
 fi
 
 #-------------------------------------
-fhr=01
-case $cyc in
-  00) endfhr=06;;
-  06) endfhr=72;;
-  12) endfhr=72;;
-  18) endfhr=06;;
-esac
-
 rm_vrfy -rf tmpfile
 
-while [ "${fhr}" -le "${endfhr}" ]; do
+fhr=01
+while [ "${fhr}" -le "${FCST_LEN_HRS}" ]; do
   fhr2d=$( printf "%02d" "${fhr}" )
   
   cp_vrfy ${DATA}/${NET}.${cycle}.awpozcon_bc.f${fhr2d}.${id_domain}.grib2 ${COMOUT}

--- a/scripts/exregional_bias_correction_pm25.sh
+++ b/scripts/exregional_bias_correction_pm25.sh
@@ -1,0 +1,437 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+This is the ex-script for the task that runs BIAS-CORRECTION-PM25.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set OpenMP variables.
+#
+#-----------------------------------------------------------------------
+#
+export KMP_AFFINITY=${KMP_AFFINITY_BIAS_CORRECTION_PM25}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_BIAS_CORRECTION_PM25}
+export OMP_STACKSIZE=${OMP_STACKSIZE_BIAS_CORRECTION_PM25}
+#
+#-----------------------------------------------------------------------
+#
+# Set run command.
+#
+#-----------------------------------------------------------------------
+#
+eval ${PRE_TASK_CMDS}
+
+if [ -z "${RUN_CMD_SERIAL:-}" ] ; then
+  print_err_msg_exit "\
+  Run command was not set in machine file. \
+  Please set RUN_CMD_SERIAL for your platform"
+else
+  RUN_CMD_SERIAL=$(eval echo ${RUN_CMD_SERIAL})
+  print_info_msg "$VERBOSE" "
+  All executables will be submitted with command \'${RUN_CMD_SERIAL}\'."
+fi
+
+#
+#-----------------------------------------------------------------------
+#
+# Move to the working directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA}/tmp_BIAS_CORRECTION_PM25"
+rm_vrfy -rf $DATA
+mkdir_vrfy -p "$DATA"
+cd_vrfy $DATA
+
+set -x
+
+yyyy=${PDY:0:4}
+yyyymm=${PDY:0:6}
+yyyy_m1=${PDYm1:0:4}
+yyyymm_m1=${PDYm1:0:6}
+yyyy_m2=${PDYm2:0:4}
+yyyymm_m2=${PDYm2:0:6}
+yyyy_m3=${PDYm3:0:4}
+yyyymm_m3=${PDYm3:0:6}
+
+#
+#-----------------------------------------------------------------------
+#
+# Bias correction: PM25
+#
+#-----------------------------------------------------------------------
+#
+if [ "${PREDEF_GRID_NAME}" = "AQM_NA_13km" ]; then
+  id_domain=793
+fi
+
+#-----------------------------------------------------------------------------
+# STEP 1: Retrieve AIRNOW observation data
+#-----------------------------------------------------------------------------
+
+# Link the historical airnow data
+mkdir_vrfy -p "${DATA}/data"
+ln_vrfy -sf ${AQM_AIRNOW_HIST_DIR}/bcdata* "${DATA}/data"
+if [ -d "${DATA}/data/bcdata.${yyyymm}" ]; then
+  rm_vrfy -rf "${DATA}/data/bcdata.${yyyymm}"
+  mkdir_vrfy -p "${DATA}/data/bcdata.${yyyymm}"
+  cp_vrfy -rL "${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/airnow" "${DATA}/data/bcdata.${yyyymm}"
+  cp_vrfy -rL "${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/interpolated" "${DATA}/data/bcdata.${yyyymm}"
+fi
+
+# Retrieve real-time airnow data for the last three days
+if [ "${DO_REAL_TIME}" = "TRUE" ]; then
+  mkdir -p ${DATA}/data/bcdata.${yyyymm_m1}/airnow/${yyyy_m1}/${PDYm1}/b008
+  mkdir -p ${DATA}/data/bcdata.${yyyymm_m2}/airnow/${yyyy_m2}/${PDYm2}/b008
+  mkdir -p ${DATA}/data/bcdata.${yyyymm_m3}/airnow/${yyyy_m3}/${PDYm3}/b008
+
+  cp_vrfy ${COMINairnow}/${yyyy_m1}/${PDYm1}/b008/xx031 ${DATA}/data/bcdata.${yyyymm_m1}/airnow/${yyyy_m1}/${PDYm1}/b008
+  cp_vrfy ${COMINairnow}/${yyyy_m2}/${PDYm2}/b008/xx031 ${DATA}/data/bcdata.${yyyymm_m2}/airnow/${yyyy_m2}/${PDYm2}/b008
+  cp_vrfy ${COMINairnow}/${yyyy_m3}/${PDYm3}/b008/xx031 ${DATA}/data/bcdata.${yyyymm_m3}/airnow/${yyyy_m3}/${PDYm3}/b008
+fi
+
+#-----------------------------------------------------------------------------
+# STEP 2:  Extracting PM2.5, O3, and met variables from CMAQ input and outputs
+#-----------------------------------------------------------------------------
+
+case $cyc in
+  00) bc_interp_hr=06;;
+  06) bc_interp_hr=72;;
+  12) bc_interp_hr=72;;
+  18) bc_interp_hr=06;;
+esac
+
+ic=1
+while [ $ic -lt 120 ]; do
+  if [ -s ${COMIN}/${NET}.${cycle}.chem_sfc.f0${bc_interp_hr}.nc ]; then
+    echo "cycle ${cyc} post1 is done!"
+    break
+  else  
+    (( ic=ic+1 ))
+  fi    
+done    
+
+if [ $ic -ge 120 ]; then 
+  print_err_msg_exit "FATAL ERROR - COULD NOT LOCATE:${NET}.${cycle}.chem_sfc.f0${bc_interp_hr}.nc"
+fi      
+
+# remove any pre-exit ${NET}.${cycle}.chem_sfc/met_sfc.nc for 2-stage post processing
+DATA_grid="${DATA}/data/bcdata.${yyyymm}/grid"
+if [ -d "${DATA_grid}/${cyc}z/${PDY}" ]; then
+  rm_vrfy -rf "${DATA_grid}/${cyc}z/${PDY}"
+fi
+
+mkdir_vrfy -p "${DATA_grid}/${cyc}z/${PDY}"
+ln_vrfy -sf ${COMIN}/${NET}.${cycle}.chem_sfc.*.nc ${DATA_grid}/${cyc}z/${PDY}
+ln_vrfy -sf ${COMIN}/${NET}.${cycle}.met_sfc.*.nc ${DATA_grid}/${cyc}z/${PDY}
+
+#-----------------------------------------------------------------------
+# STEP 3:  Intepolating CMAQ PM2.5 into AIRNow sites
+#-----------------------------------------------------------------------
+
+mkdir_vrfy -p ${DATA}/data/coords 
+mkdir_vrfy -p ${DATA}/data/site-lists.interp 
+mkdir_vrfy -p ${DATA}/out/pm25/${yyyy}
+mkdir_vrfy -p ${DATA}/data/bcdata.${yyyymm}/interpolated/pm25/${yyyy}
+
+cp_vrfy ${PARMaqm_utils}/bias_correction/sites.valid.pm25.20220724.12z.list ${DATA}/data/site-lists.interp
+cp_vrfy ${PARMaqm_utils}/bias_correction/aqm.t12z.chem_sfc.f000.nc ${DATA}/data/coords
+cp_vrfy ${PARMaqm_utils}/bias_correction/config.interp.pm2.5.5-vars_${id_domain}.${cyc}z ${DATA}
+
+PREP_STEP
+${EXECdir}/aqm_bias_interpolate config.interp.pm2.5.5-vars_${id_domain}.${cyc}z ${cyc}z ${PDY} ${PDY}  || print_err_msg_exit "Call to executable to run AQM_BIAS_INTERPOLATE returned with nonzero exit code."
+POST_STEP
+
+cp_vrfy ${DATA}/out/pm25/${yyyy}/*nc ${DATA}/data/bcdata.${yyyymm}/interpolated/pm25/${yyyy}
+
+#-----------------------------------------------------------------------
+# STEP 4:  Performing Bias Correction for PM2.5 
+#-----------------------------------------------------------------------
+
+mkdir_vrfy -p ${DATA}/data/sites
+
+cp_vrfy ${PARMaqm_utils}/bias_correction/config.pm2.5.bias_corr_${id_domain}.${cyc}z ${DATA}
+cp_vrfy ${PARMaqm_utils}/bias_correction/site_blocking.pm2.5.2021.0427.2-sites.txt ${DATA}
+cp_vrfy ${PARMaqm_utils}/bias_correction/bias_thresholds.pm2.5.2015.1030.32-sites.txt ${DATA}
+
+PREP_STEP
+${EXECdir}/aqm_bias_correct config.pm2.5.bias_corr_${id_domain}.${cyc}z ${cyc}z ${BC_STDAY} ${PDY} || print_err_msg_exit "Call to executable to run AQM_BIAS_CORRECT returned with nonzero exit code."
+POST_STEP
+
+cp_vrfy $DATA/out/pm2.5.corrected* ${COMIN}
+
+if [ "${cyc}" = "12" ]; then
+  cp_vrfy ${DATA}/sites/sites.valid.pm25.${PDY}.${cyc}z.list ${DATA}
+fi
+
+#------------------------------------------------------------------------
+# STEP 5:  converting netcdf to grib format
+#------------------------------------------------------------------------
+
+ln_vrfy -sf ${COMIN}/pm2.5.corrected.${PDY}.${cyc}z.nc .
+
+# convert from netcdf to grib2 format
+cat >bias_cor.ini <<EOF1
+&control
+varlist='PM25_TOT'
+infile='pm2.5.corrected.${PDY}.${cyc}z.nc'
+outfile='${NET}.${cycle}.pm25_bc'
+id_gribdomain=${id_domain}
+/
+EOF1
+
+PREP_STEP
+${EXECdir}/aqm_post_bias_cor_grib2 ${PDY} ${cyc} || print_err_msg_exit "\
+Call to executable to run AQM_POST_BIAS_COR_GRIB2 returned with nonzero exit code."
+POST_STEP
+
+cp_vrfy ${DATA}/${NET}.${cycle}.pm25*bc*.grib2 ${COMOUT}
+if [ "$SENDDBN" = "YES" ]; then
+  $DBNROOT/bin/dbn_alert MODEL AQM_PM ${job} ${COMOUT}
+fi
+
+#-----------------------------------------------------------------------
+# STEP 6: calculating 24-hr ave PM2.5
+#------------------------------------------------------------------------
+
+if [ "${cyc}" = "06" ] || [ "${cyc}" = "12" ]; then
+  ln_vrfy -sf ${COMOUT}/pm2.5.corrected.${PDY}.${cyc}z.nc  a.nc 
+
+  chk=1 
+  chk1=1 
+  # today 00z file exists otherwise chk=0
+cat >bias_cor_max.ini <<EOF1
+&control
+varlist='pm25_24h_ave','pm25_1h_max'
+outfile='aqm-pm25_bc'
+id_gribdomain=${id_domain}
+max_proc=72
+/
+EOF1
+
+  flag_run_bicor_max=yes
+  # 06z needs b.nc to find current day output from 04Z to 06Z
+  if [ "${cyc}" = "06" ]; then
+    if [ -s ${COMIN_PDY}/00/pm2.5.corrected.${PDY}.00z.nc ]; then
+      ln_vrfy -sf ${COMIN_PDY}/00/pm2.5.corrected.${PDY}.00z.nc  b.nc 
+    elif [ -s ${COMIN_PDYm1}/12/pm2.5.corrected.${PDYm1}.12z.nc ]; then
+      ln_vrfy -sf ${COMIN_PDYm1}/12/pm2.5.corrected.${PDYm1}.12z.nc  b.nc
+      chk=0
+    else 
+      flag_run_bicor_max=no
+    fi
+  fi
+
+  if [ "${cyc}" = "12" ]; then
+    # 12z needs b.nc to find current day output from 04Z to 06Z
+    if [ -s ${COMIN_PDY}/00/pm2.5.corrected.${PDY}.00z.nc ]; then
+      ln_vrfy -sf ${COMIN_PDY}/00/pm2.5.corrected.${PDY}.00z.nc  b.nc
+    elif [ -s ${COMIN_PDYm1}/12/pm2.5.corrected.${PDYm1}.12z.nc ]; then
+      ln_vrfy -sf ${COMIN_PDYm1}/12/pm2.5.corrected.${PDYm1}.12z.nc  b.nc
+      chk=0
+    else
+      flag_run_bicor_max=no
+    fi
+
+    # 12z needs c.nc to find current day output from 07Z to 12z
+    if [ -s ${COMIN_PDY}/06/pm2.5.corrected.${PDY}.06z.nc ]; then
+      ln_vrfy -sf ${COMIN_PDY}/06/pm2.5.corrected.${PDY}.06z.nc c.nc
+    elif [ -s ${COMIN_PDYm1}/12/pm2.5.corrected.${PDYm1}.12z.nc ]; then
+      ln_vrfy -sf ${COMIN_PDYm1}/12/pm2.5.corrected.${PDYm1}.12z.nc  c.nc
+      chk1=0
+    else
+      flag_run_bicor_max=no
+    fi
+  fi
+  if [ "${flag_run_bicor_max}" = "yes" ]; then
+    #-------------------------------------------------
+    # write out grib2 format 
+    #-------------------------------------------------
+    PREP_STEP
+    ${EXECdir}/aqm_post_maxi_bias_cor_grib2  ${PDY} ${cyc} ${chk} ${chk1} || print_err_msg_exit "\
+    Call to executable to run AQM_POST_MAXI_BIAS_COR_GRIB2 returned with nonzero exit code."
+    POST_STEP
+
+    # split into two files: one for 24hr_ave and one for 1h_max
+    wgrib2 aqm-pm25_bc.${id_domain}.grib2  |grep  "PMTF"   | ${WGRIB2} -i  aqm-pm25_bc.${id_domain}.grib2  -grib aqm.t${cyc}z.ave_24hr_pm25_bc.793.grib2 
+    wgrib2 aqm-pm25_bc.${id_domain}.grib2  |grep  "PDMAX1" | ${WGRIB2} -i  aqm-pm25_bc.${id_domain}.grib2  -grib aqm.t${cyc}z.max_1hr_pm25_bc.793.grib2 
+   
+    cp_vrfy ${DATA}/${NET}.${cycle}.ave_24hr_pm25_bc.${id_domain}.grib2 ${COMOUT}
+    cp_vrfy ${DATA}/${NET}.${cycle}.max_1hr_pm25_bc.${id_domain}.grib2 ${COMOUT}
+  fi
+
+  # interpolate to grid 227
+  oldgrib2file1=${NET}.${cycle}.ave_24hr_pm25_bc.${id_domain}.grib2
+  newgrib2file1=${NET}.${cycle}.ave_24hr_pm25_bc.227.grib2
+
+  grid227="lambert:265.0000:25.0000:25.0000 226.5410:1473:5079.000 12.1900:1025:5079.000"
+  wgrib2 ${oldgrib2file1} -set_grib_type same -new_grid_winds earth -new_grid ${grid227}  ${newgrib2file1} 
+
+  oldgrib2file2=${NET}.${cycle}.max_1hr_pm25_bc.${id_domain}.grib2
+  newgrib2file2=${NET}.${cycle}.max_1hr_pm25_bc.227.grib2
+  wgrib2 ${oldgrib2file2} -set_grib_type same -new_grid_winds earth -new_grid ${grid227}  ${newgrib2file2}
+
+  cp_vrfy ${NET}.${cycle}.max_1hr_pm25_bc.${id_domain}.grib2   ${COMOUT}
+  cp_vrfy ${NET}.${cycle}.ave_24hr_pm25_bc.${id_domain}.grib2  ${COMOUT}
+  cp_vrfy ${NET}.${cycle}.max_1hr_pm25_bc.227.grib2   ${COMOUT}
+  cp_vrfy ${NET}.${cycle}.ave_24hr_pm25_bc.227.grib2  ${COMOUT}
+
+  if [ "${SENDDBN}" = "YES" ]; then
+    ${DBNROOT}/bin/dbn_alert MODEL AQM_MAX ${job} ${COMOUT}/${NET}.${cycle}.max_1hr_pm25_bc.227.grib2
+    ${DBNROOT}/bin/dbn_alert MODEL AQM_PM ${job} ${COMOUT}/${NET}.${cycle}.ave_24hr_pm25_bc.227.grib2
+  fi
+fi
+
+fhr=01
+case ${cyc} in
+  00) endfhr=06;;
+  06) endfhr=72;;
+  12) endfhr=72;;
+  18) endfhr=06;;
+esac
+
+while [ "${fhr}" -le "${endfhr}" ]; do
+  fhr2d=$( printf "%02d" "${fhr}" )
+  cat ${DATA}/${NET}.${cycle}.pm25_bc.f${fhr2d}.${id_domain}.grib2 >> tmpfile_pm25_bc
+  (( fhr=fhr+1 ))
+done
+
+grid227="lambert:265.0000:25.0000:25.0000 226.5410:1473:5079.000 12.1900:1025:5079.000"
+wgrib2 tmpfile_pm25_bc -set_grib_type same -new_grid_winds earth -new_grid ${grid227} ${NET}.${cycle}.grib2_pm25_bc.227
+
+cp_vrfy tmpfile_pm25_bc ${COMOUT}/${NET}.${cycle}.ave_1hr_pm25_bc.${id_domain}.grib2
+cp_vrfy ${NET}.${cycle}.grib2_pm25_bc.227 ${COMOUT}/${NET}.${cycle}.ave_1hr_pm25_bc.227.grib2
+if [ "${SENDDBN}" = "YES" ]; then
+  ${DBNROOT}/bin/dbn_alert MODEL AQM_PM ${job} ${COMOUT}/${NET}.${cycle}.ave_1hr_pm25_bc.227.grib2
+fi
+
+#--------------------------------------------------------------
+# STEP 7: adding WMO header  
+#--------------------------------------------------------------
+
+# Create AWIPS GRIB2 data for Bias-Corrected PM2.5
+if [ "${cyc}" = "06" ] || [ "${cyc}" = "12" ]; then
+  echo 0 > filesize
+  export XLFRTEOPTS="unit_vars=yes"
+  export FORT11=${NET}.${cycle}.grib2_pm25_bc.227
+  export FORT12="filesize"
+  export FORT31=
+  export FORT51=${NET}.${cycle}.grib2_pm25_bc.227.temp
+  tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_pm25_bc.${cycle}.227
+
+  echo `ls -l ${NET}.${cycle}.grib2_pm25_bc.227.temp  | awk '{print $5} '` > filesize
+  export XLFRTEOPTS="unit_vars=yes"
+  export FORT11=${NET}.${cycle}.grib2_pm25_bc.227.temp
+  export FORT12="filesize"
+  export FORT31=
+  export FORT51=awpaqm.${cycle}.1hpm25-bc.227.grib2
+  tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_pm25_bc.${cycle}.227
+
+  ####################################################
+  rm_vrfy -f filesize
+  echo 0 > filesize
+  export XLFRTEOPTS="unit_vars=yes"
+  export FORT11=${NET}.${cycle}.max_1hr_pm25_bc.227.grib2
+  export FORT12="filesize"
+  export FORT31=
+  export FORT51=${NET}.${cycle}.max_1hr_pm25_bc.227.grib2.temp
+  tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_max_1hr_pm25_bc.${cycle}.227
+
+  echo `ls -l  ${NET}.${cycle}.max_1hr_pm25_bc.227.grib2.temp | awk '{print $5} '` > filesize
+  export XLFRTEOPTS="unit_vars=yes"
+  export FORT11=${NET}.${cycle}.max_1hr_pm25_bc.227.grib2.temp
+  export FORT12="filesize"
+  export FORT31=
+  export FORT51=awpaqm.${cycle}.daily-1hr-pm25-max-bc.227.grib2
+  tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_max_1hr_pm25_bc.${cycle}.227
+
+  rm_vrfy -f filesize
+  # daily_24hr_ave_PM2.5
+  echo 0 > filesize
+  export XLFRTEOPTS="unit_vars=yes"
+  export FORT11=${NET}.${cycle}.ave_24hr_pm25_bc.227.grib2
+  export FORT12="filesize"
+  export FORT31=
+  export FORT51=${NET}.${cycle}.ave_24hr_pm25_bc.227.grib2.temp
+  tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_ave_24hrpm25_bc_awp.${cycle}.227
+
+  echo `ls -l  ${NET}.${cycle}.ave_24hr_pm25_bc.227.grib2.temp | awk '{print $5} '` > filesize
+  export XLFRTEOPTS="unit_vars=yes"
+  export FORT11=${NET}.${cycle}.ave_24hr_pm25_bc.227.grib2.temp
+  export FORT12="filesize"
+  export FORT31=
+  export FORT51=awpaqm.${cycle}.24hr-pm25-ave-bc.227.grib2
+  tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_ave_24hrpm25_bc_awp.${cycle}.227
+
+  # Post Files to COMOUT
+  cp_vrfy awpaqm.${cycle}.1hpm25-bc.227.grib2             ${COMOUT}
+  cp_vrfy awpaqm.${cycle}.daily-1hr-pm25-max-bc.227.grib2 ${COMOUT}
+  cp_vrfy awpaqm.${cycle}.24hr-pm25-ave-bc.227.grib2      ${COMOUT}
+
+  # Distribute Data
+  if [ "${SENDDBN_NTC}" = "YES" ] ; then
+    ${DBNROOT}/bin/dbn_alert ${DBNALERT_TYPE} ${NET} ${job} ${COMOUT}/awpaqm.${cycle}.1hpm25-bc.227.grib2
+    ${DBNROOT}/bin/dbn_alert ${DBNALERT_TYPE} ${NET} ${job} ${COMOUT}/awpaqm.${cycle}.daily-1hr-pm25-max-bc.227.grib2
+    ${DBNROOT}/bin/dbn_alert ${DBNALERT_TYPE} ${NET} ${job} ${COMOUT}/awpaqm.${cycle}.24hr-pm25-ave-bc.227.grib2
+  fi
+fi
+
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating successful completion of script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+BIAS-CORRECTION-PM25 completed successfully.
+
+Exiting script:  \"${scrfunc_fn}\"
+In directory:    \"${scrfunc_dir}\"
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1

--- a/scripts/exregional_bias_correction_pm25.sh
+++ b/scripts/exregional_bias_correction_pm25.sh
@@ -106,6 +106,15 @@ if [ "${PREDEF_GRID_NAME}" = "AQM_NA_13km" ]; then
   id_domain=793
 fi
 
+if [ "${FCST_LEN_HRS}" = "-1" ]; then
+  for i_cdate in "${!ALL_CDATES[@]}"; do
+    if [ "${ALL_CDATES[$i_cdate]}" = "${PDY}${cyc}" ]; then
+      FCST_LEN_HRS="${FCST_LEN_CYCL[$i_cdate]}"
+      break
+    fi
+  done
+fi
+
 #-----------------------------------------------------------------------------
 # STEP 1: Retrieve AIRNOW observation data
 #-----------------------------------------------------------------------------
@@ -135,16 +144,10 @@ fi
 # STEP 2:  Extracting PM2.5, O3, and met variables from CMAQ input and outputs
 #-----------------------------------------------------------------------------
 
-case $cyc in
-  00) bc_interp_hr=06;;
-  06) bc_interp_hr=72;;
-  12) bc_interp_hr=72;;
-  18) bc_interp_hr=06;;
-esac
-
+FCST_LEN_HRS=$( printf "%03d" ${FCST_LEN_HRS} )
 ic=1
 while [ $ic -lt 120 ]; do
-  if [ -s ${COMIN}/${NET}.${cycle}.chem_sfc.f0${bc_interp_hr}.nc ]; then
+  if [ -s ${COMIN}/${NET}.${cycle}.chem_sfc.f${FCST_LEN_HRS}.nc ]; then
     echo "cycle ${cyc} post1 is done!"
     break
   else  
@@ -153,7 +156,7 @@ while [ $ic -lt 120 ]; do
 done    
 
 if [ $ic -ge 120 ]; then 
-  print_err_msg_exit "FATAL ERROR - COULD NOT LOCATE:${NET}.${cycle}.chem_sfc.f0${bc_interp_hr}.nc"
+  print_err_msg_exit "FATAL ERROR - COULD NOT LOCATE:${NET}.${cycle}.chem_sfc.f${FCST_LEN_HRS}.nc"
 fi      
 
 # remove any pre-exit ${NET}.${cycle}.chem_sfc/met_sfc.nc for 2-stage post processing
@@ -180,7 +183,7 @@ cp_vrfy ${PARMaqm_utils}/bias_correction/aqm.t12z.chem_sfc.f000.nc ${DATA}/data/
 cp_vrfy ${PARMaqm_utils}/bias_correction/config.interp.pm2.5.5-vars_${id_domain}.${cyc}z ${DATA}
 
 PREP_STEP
-${EXECdir}/aqm_bias_interpolate config.interp.pm2.5.5-vars_${id_domain}.${cyc}z ${cyc}z ${PDY} ${PDY}  || print_err_msg_exit "Call to executable to run AQM_BIAS_INTERPOLATE returned with nonzero exit code."
+eval ${RUN_CMD_SERIAL} ${EXECdir}/aqm_bias_interpolate config.interp.pm2.5.5-vars_${id_domain}.${cyc}z ${cyc}z ${PDY} ${PDY} ${REDIRECT_OUT_ERR} || print_err_msg_exit "Call to executable to run AQM_BIAS_INTERPOLATE returned with nonzero exit code."
 POST_STEP
 
 cp_vrfy ${DATA}/out/pm25/${yyyy}/*nc ${DATA}/data/bcdata.${yyyymm}/interpolated/pm25/${yyyy}
@@ -196,7 +199,7 @@ cp_vrfy ${PARMaqm_utils}/bias_correction/site_blocking.pm2.5.2021.0427.2-sites.t
 cp_vrfy ${PARMaqm_utils}/bias_correction/bias_thresholds.pm2.5.2015.1030.32-sites.txt ${DATA}
 
 PREP_STEP
-${EXECdir}/aqm_bias_correct config.pm2.5.bias_corr_${id_domain}.${cyc}z ${cyc}z ${BC_STDAY} ${PDY} || print_err_msg_exit "Call to executable to run AQM_BIAS_CORRECT returned with nonzero exit code."
+eval ${RUN_CMD_SERIAL} ${EXECdir}/aqm_bias_correct config.pm2.5.bias_corr_${id_domain}.${cyc}z ${cyc}z ${BC_STDAY} ${PDY} ${REDIRECT_OUT_ERR} || print_err_msg_exit "Call to executable to run AQM_BIAS_CORRECT returned with nonzero exit code."
 POST_STEP
 
 cp_vrfy $DATA/out/pm2.5.corrected* ${COMIN}
@@ -222,7 +225,7 @@ id_gribdomain=${id_domain}
 EOF1
 
 PREP_STEP
-${EXECdir}/aqm_post_bias_cor_grib2 ${PDY} ${cyc} || print_err_msg_exit "\
+eval ${RUN_CMD_SERIAL} ${EXECdir}/aqm_post_bias_cor_grib2 ${PDY} ${cyc} ${REDIRECT_OUT_ERR} || print_err_msg_exit "\
 Call to executable to run AQM_POST_BIAS_COR_GRIB2 returned with nonzero exit code."
 POST_STEP
 
@@ -289,7 +292,7 @@ EOF1
     # write out grib2 format 
     #-------------------------------------------------
     PREP_STEP
-    ${EXECdir}/aqm_post_maxi_bias_cor_grib2  ${PDY} ${cyc} ${chk} ${chk1} || print_err_msg_exit "\
+    eval ${RUN_CMD_SERIAL} ${EXECdir}/aqm_post_maxi_bias_cor_grib2  ${PDY} ${cyc} ${chk} ${chk1} ${REDIRECT_OUT_ERR} || print_err_msg_exit "\
     Call to executable to run AQM_POST_MAXI_BIAS_COR_GRIB2 returned with nonzero exit code."
     POST_STEP
 
@@ -324,14 +327,7 @@ EOF1
 fi
 
 fhr=01
-case ${cyc} in
-  00) endfhr=06;;
-  06) endfhr=72;;
-  12) endfhr=72;;
-  18) endfhr=06;;
-esac
-
-while [ "${fhr}" -le "${endfhr}" ]; do
+while [ "${fhr}" -le "${FCST_LEN_HRS}" ]; do
   fhr2d=$( printf "%02d" "${fhr}" )
   cat ${DATA}/${NET}.${cycle}.pm25_bc.f${fhr2d}.${id_domain}.grib2 >> tmpfile_pm25_bc
   (( fhr=fhr+1 ))

--- a/scripts/exregional_fire_emission.sh
+++ b/scripts/exregional_fire_emission.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the ex-script for the task that copies or fetches fire emission
+data files from disk or HPSS.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set up variables for call to retrieve_data.py
+#
+#-----------------------------------------------------------------------
+#
+yyyymmdd=${FIRE_FILE_CDATE:0:8}
+hh=${FIRE_FILE_CDATE:8:2}
+#
+#-----------------------------------------------------------------------
+#
+# Retrieve fire files to FIRE_EMISSION_STAGING_DIR
+#
+#-----------------------------------------------------------------------
+#
+aqm_fire_file_fn="${AQM_FIRE_FILE_PREFIX}_${yyyymmdd}_t${hh}z${AQM_FIRE_FILE_SUFFIX}"
+
+# Check if the file exists in the designated directory
+if [ -e "${AQM_FIRE_DIR}/${yyyymmdd}/${aqm_fire_file_fn}" ]; then
+  cp_vrfy "${AQM_FIRE_DIR}/${yyyymmdd}/${aqm_fire_file_fn}" "${FIRE_EMISSION_STAGING_DIR}"
+else
+  # Retrieve files from HPSS
+  arcv_dir="/NCEPDEV/emc-naqfc/2year/Kai.Wang/RAVE_fire/RAVE_NA"
+  arcv_fp="${arcv_dir}/${aqm_fire_file_fn}"
+
+  hsi_log_fn="log.hsi_get.${yyyymmdd}_${hh}"
+  hsi get ${arcv_fp} >& ${hsi_log_fn} || \
+  print_err_msg_exit "\
+htar file reading operation (\"hsi get ...\") failed.  Check the log 
+file hsi_log_fn in the staging directory (fire_emission_staging_dir) for 
+details:
+  fire_emission_staging_dir = \"${FIRE_EMISSION_STAGING_DIR}\"
+  hsi_log_fn = \"${hsi_log_fn}\""
+fi
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1

--- a/scripts/exregional_nexus_emission.sh
+++ b/scripts/exregional_nexus_emission.sh
@@ -61,6 +61,7 @@ export OMP_STACKSIZE=${OMP_STACKSIZE_NEXUS_EMISSION}
 #
 #-----------------------------------------------------------------------
 #
+set -x
 eval ${PRE_TASK_CMDS}
 
 nprocs=$(( NNODES_NEXUS_EMISSION*PPN_NEXUS_EMISSION ))
@@ -191,94 +192,86 @@ NEXUS_INPUT_BASE_DIR=${NEXUS_INPUT_DIR}
 # 
 # modify time configuration file
 #
-cp_vrfy ${ARL_NEXUS_DIR}/utils/python/nexus_time_parser.py .
-echo ${start_date} ${end_date} # ${cyc}
-./nexus_time_parser.py -f ${DATA}/HEMCO_sa_Time.rc -s $start_date -e $end_date
+python3 ${ARL_NEXUS_DIR}/utils/python/nexus_time_parser.py -f ${DATA}/HEMCO_sa_Time.rc -s $start_date -e $end_date
 
 #
 #---------------------------------------------------------------------
 #
 # set the root directory to the temporary directory
 #
-cp_vrfy ${ARL_NEXUS_DIR}/utils/python/nexus_root_parser.py .
-./nexus_root_parser.py -f ${DATA}/NEXUS_Config.rc -d ${DATAinput}
+python3 ${ARL_NEXUS_DIR}/utils/python/nexus_root_parser.py -f ${DATA}/NEXUS_Config.rc -d ${DATAinput}
 
 #
 #----------------------------------------------------------------------
 # Get all the files needed (TEMPORARILY JUST COPY FROM THE DIRECTORY)
 #
 if [ "${NEI2016}" = "TRUE" ]; then #NEI2016
-    cp_vrfy ${ARL_NEXUS_DIR}/utils/python/nexus_nei2016_linker.py .
-    cp_vrfy ${ARL_NEXUS_DIR}/utils/python/nexus_nei2016_control_tilefix.py .
-    mkdir_vrfy -p ${DATAinput}/NEI2016v1
-    mkdir_vrfy -p ${DATAinput}/NEI2016v1/v2022-07
-    mkdir_vrfy -p ${DATAinput}/NEI2016v1/v2022-07/${mm}
-    ./nexus_nei2016_linker.py --src_dir ${NEXUS_INPUT_BASE_DIR} --date ${yyyymmdd} --work_dir ${DATAinput} -v "v2022-07"
-    ./nexus_nei2016_control_tilefix.py -f NEXUS_Config.rc -t HEMCO_sa_Time.rc # -d ${yyyymmdd}
+  mkdir_vrfy -p ${DATAinput}/NEI2016v1
+  mkdir_vrfy -p ${DATAinput}/NEI2016v1/v2022-07
+  mkdir_vrfy -p ${DATAinput}/NEI2016v1/v2022-07/${mm}
+  python3 ${ARL_NEXUS_DIR}/utils/python/nexus_nei2016_linker.py --src_dir ${NEXUS_INPUT_BASE_DIR} --date ${yyyymmdd} --work_dir ${DATAinput} -v "v2022-07"
+  python3 ${ARL_NEXUS_DIR}/utils/python/nexus_nei2016_control_tilefix.py -f ${DATA}/NEXUS_Config.rc -t ${DATA}/HEMCO_sa_Time.rc # -d ${yyyymmdd}
 fi
 
-
-
 if [ "${TIMEZONES}" = "TRUE" ]; then # TIME ZONES
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/TIMEZONES ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/TIMEZONES ${DATAinput}/
 fi
 
 if [ "${MASKS}" = "TRUE" ]; then # MASKS
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/MASKS ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/MASKS ${DATAinput}/
 fi
 
 if [ "${CEDS}" = "TRUE" ]; then #CEDS
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/CEDS ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/CEDS ${DATAinput}/
 fi
 
 if [ "${HTAP2010}" = "TRUE" ]; then #CEDS2014
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/HTAP ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/HTAP ${DATAinput}/
 fi
 
 if [ "${OMIHTAP}" = "TRUE" ]; then #CEDS2014
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/OMI-HTAP_2019 ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/OMI-HTAP_2019 ${DATAinput}/
 fi
 
 if [ "${NOAAGMD}" = "TRUE" ]; then #NOAA_GMD
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/NOAA_GMD ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/NOAA_GMD ${DATAinput}/
 fi
 
 if [ "${SOA}" = "TRUE" ]; then #SOA
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/SOA ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/SOA ${DATAinput}/
 fi
 
 if [ "${EDGAR}" = "TRUE" ]; then #EDGARv42
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/EDGARv42 ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/EDGARv42 ${DATAinput}/
 fi
 
 if [ "${MEGAN}" = "TRUE" ]; then #MEGAN
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/MEGAN ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/MEGAN ${DATAinput}/
 fi
 
 if [ "${OLSON_MAP}" = "TRUE" ]; then #OLSON_MAP
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/OLSON_MAP ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/OLSON_MAP ${DATAinput}/
 fi
 
 if [ "${Yuan_XLAI}" = "TRUE" ]; then #Yuan_XLAI
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/Yuan_XLAI ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/Yuan_XLAI ${DATAinput}/
 fi
 
 if [ "${GEOS}" = "TRUE" ]; then #GEOS
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/GEOS_0.5x0.625 ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/GEOS_0.5x0.625 ${DATAinput}/
 fi
 
 if [ "${AnnualScalar}" = "TRUE" ]; then #ANNUAL_SCALAR
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/AnnualScalar ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/AnnualScalar ${DATAinput}/
 fi
 
 if [ "${MODIS_XLAI}" = "TRUE" ]; then #MODIS_XLAI
-    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/MODIS_XLAI ${DATAinput}/
+  ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/MODIS_XLAI ${DATAinput}/
 fi
 
 if [ "${USE_GFS_SFC}" = "TRUE" ]; then # GFS INPUT
-    cp_vrfy ${ARL_NEXUS_DIR}/utils/python/nexus_gfs_bio.py .
-    mkdir_vrfy -p $${DATAinput}/GFS_SFC
-    ./nexus_gfs_bio.py -i GFS_SFC/gfs.t??z.sfcf???.nc -o GFS_SFC_MEGAN_INPUT.nc
+  mkdir_vrfy -p ${DATAinput}/GFS_SFC
+  python3 ${ARL_NEXUS_DIR}/utils/python/nexus_gfs_bio.py -i ${DATA}/GFS_SFC/gfs.t??z.sfcf???.nc -o ${DATA}/GFS_SFC_MEGAN_INPUT.nc
 fi
 
 #

--- a/scripts/exregional_nexus_emission.sh
+++ b/scripts/exregional_nexus_emission.sh
@@ -1,0 +1,323 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the ex-script for the task that runs NEXUS.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set OpenMP variables.
+#
+#-----------------------------------------------------------------------
+#
+export KMP_AFFINITY=${KMP_AFFINITY_NEXUS_EMISSION}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_NEXUS_EMISSION}
+export OMP_STACKSIZE=${OMP_STACKSIZE_NEXUS_EMISSION}
+#
+#-----------------------------------------------------------------------
+#
+# Set run command.
+#
+#-----------------------------------------------------------------------
+#
+eval ${PRE_TASK_CMDS}
+
+nprocs=$(( NNODES_NEXUS_EMISSION*PPN_NEXUS_EMISSION ))
+ppn_run_aqm="${PPN_NEXUS_EMISSION}"
+omp_num_threads_run_aqm="${OMP_NUM_THREADS_NEXUS_EMISSION}"
+
+if [ -z "${RUN_CMD_AQM:-}" ] ; then
+  print_err_msg_exit "\
+  Run command was not set in machine file. \
+  Please set RUN_CMD_AQM for your platform"
+else
+  RUN_CMD_AQM=$(eval echo ${RUN_CMD_AQM})
+  print_info_msg "$VERBOSE" "
+  All executables will be submitted with command \'${RUN_CMD_AQM}\'."
+fi
+#
+#-----------------------------------------------------------------------
+#
+# Move to the NEXUS working directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA}/tmp_NEXUS/${nspt}"
+mkdir_vrfy -p "$DATA"
+
+DATAinput="${DATA}/input"
+mkdir_vrfy -p "$DATAinput"
+
+cd_vrfy $DATA
+#
+#-----------------------------------------------------------------------
+#
+# Link GFS surface data files to the tmp directory if they exist
+#
+#-----------------------------------------------------------------------
+#
+USE_GFS_SFC="FALSE"
+if [ -d "${COMINext}/GFS_SFC" ]; then
+  if [ "$(ls -A ${COMINext}/GFS_SFC)" ]; then
+    ln_vrfy -sf "${COMINext}/GFS_SFC" .
+    USE_GFS_SFC="TRUE"
+  fi
+fi
+
+#
+#-----------------------------------------------------------------------
+#
+# Copy the NEXUS config files to the tmp directory  
+#
+#-----------------------------------------------------------------------
+#
+cp_vrfy ${EXECdir}/nexus ${DATA}
+cp_vrfy ${NEXUS_FIX_DIR}/${NEXUS_GRID_FN} ${DATA}/grid_spec.nc
+
+
+if [ "${USE_GFS_SFC}" = "TRUE" ]; then
+    cp_vrfy ${ARL_NEXUS_DIR}/config/cmaq_gfs_megan/*.rc ${DATA}
+else
+    cp_vrfy ${ARL_NEXUS_DIR}/config/cmaq/*.rc ${DATA}
+fi
+#
+#-----------------------------------------------------------------------
+#
+# Get the starting and ending year, month, day, and hour of the emission
+# time series.
+#
+#-----------------------------------------------------------------------
+#
+mm="${PDY:4:2}"
+dd="${PDY:6:2}"
+hh="${cyc}"
+yyyymmdd="${PDY}"
+
+NUM_SPLIT_NEXUS=$( printf "%02d" ${NUM_SPLIT_NEXUS} )
+if [ "${FCST_LEN_HRS}" = "-1" ]; then
+  for i_cdate in "${!ALL_CDATES[@]}"; do
+    if [ "${ALL_CDATES[$i_cdate]}" = "${PDY}${cyc}" ]; then
+      FCST_LEN_HRS="${FCST_LEN_CYCL[$i_cdate]}"
+      break
+    fi      
+  done
+fi
+
+if [ "${NUM_SPLIT_NEXUS}" = "01" ]; then
+  start_date=$( $DATE_UTIL --utc --date "${yyyymmdd} ${hh} UTC" "+%Y%m%d%H" )
+  end_date=$( $DATE_UTIL --utc --date "${yyyymmdd} ${hh} UTC + ${FCST_LEN_HRS} hours" "+%Y%m%d%H" )
+else
+  len_per_split=$(( FCST_LEN_HRS / NUM_SPLIT_NEXUS  ))
+  nsptp=$(( nspt+1 ))
+
+  # Compute start and end dates for nexus split option
+  start_del_hr=$(( len_per_split * nspt ))
+  start_date=$( $DATE_UTIL --utc --date "${yyyymmdd} ${hh} UTC + ${start_del_hr} hours " "+%Y%m%d%H" )
+  if [ "${nsptp}" = "${NUM_SPLIT_NEXUS}" ];then
+    end_date=$( $DATE_UTIL --utc --date "${yyyymmdd} ${hh} UTC + ${FCST_LEN_HRS} hours" "+%Y%m%d%H" )
+  else
+    end_del_hr=$(( len_per_split * nsptp ))
+    end_date=$( $DATE_UTIL --utc --date "${yyyymmdd} ${hh} UTC + ${end_del_hr} hours" "+%Y%m%d%H" )
+  fi
+fi
+#
+#######################################################################
+# This will be the section to set the datasets used in $workdir/NEXUS_Config.rc 
+# All Datasets in that file need to be placed here as it will link the files 
+# necessary to that folder.  In the future this will be done by a get_nexus_input 
+# script
+NEI2016="TRUE"
+TIMEZONES="TRUE"
+CEDS="TRUE"
+HTAP2010="TRUE"
+OMIHTAP="TRUE"
+MASKS="TRUE"
+NOAAGMD="TRUE"
+SOA="TRUE"
+EDGAR="TRUE"
+MEGAN="TRUE"
+MODIS_XLAI="TRUE"
+OLSON_MAP="TRUE"
+Yuan_XLAI="TRUE"
+GEOS="TRUE"
+AnnualScalar="TRUE"
+
+NEXUS_INPUT_BASE_DIR=${NEXUS_INPUT_DIR}
+########################################################################
+
+#
+#----------------------------------------------------------------------
+# 
+# modify time configuration file
+#
+cp_vrfy ${ARL_NEXUS_DIR}/utils/python/nexus_time_parser.py .
+echo ${start_date} ${end_date} # ${cyc}
+./nexus_time_parser.py -f ${DATA}/HEMCO_sa_Time.rc -s $start_date -e $end_date
+
+#
+#---------------------------------------------------------------------
+#
+# set the root directory to the temporary directory
+#
+cp_vrfy ${ARL_NEXUS_DIR}/utils/python/nexus_root_parser.py .
+./nexus_root_parser.py -f ${DATA}/NEXUS_Config.rc -d ${DATAinput}
+
+#
+#----------------------------------------------------------------------
+# Get all the files needed (TEMPORARILY JUST COPY FROM THE DIRECTORY)
+#
+if [ "${NEI2016}" = "TRUE" ]; then #NEI2016
+    cp_vrfy ${ARL_NEXUS_DIR}/utils/python/nexus_nei2016_linker.py .
+    cp_vrfy ${ARL_NEXUS_DIR}/utils/python/nexus_nei2016_control_tilefix.py .
+    mkdir_vrfy -p ${DATAinput}/NEI2016v1
+    mkdir_vrfy -p ${DATAinput}/NEI2016v1/v2022-07
+    mkdir_vrfy -p ${DATAinput}/NEI2016v1/v2022-07/${mm}
+    ./nexus_nei2016_linker.py --src_dir ${NEXUS_INPUT_BASE_DIR} --date ${yyyymmdd} --work_dir ${DATAinput} -v "v2022-07"
+    ./nexus_nei2016_control_tilefix.py -f NEXUS_Config.rc -t HEMCO_sa_Time.rc # -d ${yyyymmdd}
+fi
+
+
+
+if [ "${TIMEZONES}" = "TRUE" ]; then # TIME ZONES
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/TIMEZONES ${DATAinput}/
+fi
+
+if [ "${MASKS}" = "TRUE" ]; then # MASKS
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/MASKS ${DATAinput}/
+fi
+
+if [ "${CEDS}" = "TRUE" ]; then #CEDS
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/CEDS ${DATAinput}/
+fi
+
+if [ "${HTAP2010}" = "TRUE" ]; then #CEDS2014
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/HTAP ${DATAinput}/
+fi
+
+if [ "${OMIHTAP}" = "TRUE" ]; then #CEDS2014
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/OMI-HTAP_2019 ${DATAinput}/
+fi
+
+if [ "${NOAAGMD}" = "TRUE" ]; then #NOAA_GMD
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/NOAA_GMD ${DATAinput}/
+fi
+
+if [ "${SOA}" = "TRUE" ]; then #SOA
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/SOA ${DATAinput}/
+fi
+
+if [ "${EDGAR}" = "TRUE" ]; then #EDGARv42
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/EDGARv42 ${DATAinput}/
+fi
+
+if [ "${MEGAN}" = "TRUE" ]; then #MEGAN
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/MEGAN ${DATAinput}/
+fi
+
+if [ "${OLSON_MAP}" = "TRUE" ]; then #OLSON_MAP
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/OLSON_MAP ${DATAinput}/
+fi
+
+if [ "${Yuan_XLAI}" = "TRUE" ]; then #Yuan_XLAI
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/Yuan_XLAI ${DATAinput}/
+fi
+
+if [ "${GEOS}" = "TRUE" ]; then #GEOS
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/GEOS_0.5x0.625 ${DATAinput}/
+fi
+
+if [ "${AnnualScalar}" = "TRUE" ]; then #ANNUAL_SCALAR
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/AnnualScalar ${DATAinput}/
+fi
+
+if [ "${MODIS_XLAI}" = "TRUE" ]; then #MODIS_XLAI
+    ln_vrfy -sf ${NEXUS_INPUT_BASE_DIR}/MODIS_XLAI ${DATAinput}/
+fi
+
+if [ "${USE_GFS_SFC}" = "TRUE" ]; then # GFS INPUT
+    cp_vrfy ${ARL_NEXUS_DIR}/utils/python/nexus_gfs_bio.py .
+    mkdir_vrfy -p $${DATAinput}/GFS_SFC
+    ./nexus_gfs_bio.py -i GFS_SFC/gfs.t??z.sfcf???.nc -o GFS_SFC_MEGAN_INPUT.nc
+fi
+
+#
+#----------------------------------------------------------------------
+#
+# Execute NEXUS
+#
+#-----------------------------------------------------------------------
+#
+PREP_STEP
+eval ${RUN_CMD_AQM} ${EXECdir}/nexus -c NEXUS_Config.rc -r grid_spec.nc -o NEXUS_Expt_split.nc ${REDIRECT_OUT_ERR} || \
+print_err_msg_exit "\
+Call to execute nexus standalone for the FV3LAM failed."
+POST_STEP
+
+#
+#-----------------------------------------------------------------------
+#
+# Move NEXUS output to INPUT_DATA directory.
+#
+#-----------------------------------------------------------------------
+#
+mv_vrfy ${DATA}/NEXUS_Expt_split.nc ${INPUT_DATA}/${NET}.${cycle}${dot_ensmem}.NEXUS_Expt_split.${nspt}.nc
+
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating successful completion of script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+NEXUS has successfully generated emissions files in netcdf format!!!!
+
+Exiting script:  \"${scrfunc_fn}\"
+In directory:    \"${scrfunc_dir}\"
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1

--- a/scripts/exregional_nexus_gfs_sfc.sh
+++ b/scripts/exregional_nexus_gfs_sfc.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the ex-script for the task that copies or fetches GFS surface
+data files from disk or HPSS.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA}/tmp_GFS_SFC"
+mkdir_vrfy -p "$DATA"
+cd_vrfy $DATA
+#
+#-----------------------------------------------------------------------
+#
+# Set up variables for call to retrieve_data.py
+#
+#-----------------------------------------------------------------------
+#
+yyyymmdd=${GFS_SFC_CDATE:0:8}
+yyyymm=${GFS_SFC_CDATE:0:6}
+yyyy=${GFS_SFC_CDATE:0:4}
+hh=${GFS_SFC_CDATE:8:2}
+if [ "${FCST_LEN_HRS}" = "-1" ]; then
+  for i_cdate in "${!ALL_CDATES[@]}"; do
+    if [ "${ALL_CDATES[$i_cdate]}" = "${PDY}${cyc}" ]; then
+      FCST_LEN_HRS="${FCST_LEN_CYCL[$i_cdate]}"
+      break
+    fi
+  done
+fi
+#
+#-----------------------------------------------------------------------
+#
+# Retrieve GFS surface files to GFS_SFC_STAGING_DIR
+#
+#-----------------------------------------------------------------------
+#
+GFS_SFC_TAR_DIR="${NEXUS_GFS_SFC_ARCHV_DIR}/rh${yyyy}/${yyyymm}/${yyyymmdd}"
+GFS_SFC_TAR_SUB_DIR="gfs.${yyyymmdd}/${hh}/atmos"
+
+GFS_SFC_LOCAL_DIR="${COMINgfs_BASEDIR}/${GFS_SFC_TAR_SUB_DIR}"
+GFS_SFC_DATA_INTVL="3"
+
+# copy files from local directory
+if [ -d ${GFS_SFC_LOCAL_DIR} ]; then
+  gfs_sfc_fn="gfs.t${hh}z.sfcanl.nc"
+  cp_vrfy "${GFS_SFC_LOCAL_DIR}/${gfs_sfc_fn}" ${GFS_SFC_STAGING_DIR}
+
+  for fhr in $(seq -f "%03g" 0 ${GFS_SFC_DATA_INTVL} ${FCST_LEN_HRS}); do
+    gfs_sfc_fn="gfs.t${hh}z.sfcf${fhr}.nc"
+    if [ -e "${GFS_SFC_LOCAL_DIR}/${gfs_sfc_fn}" ]; then
+      cp_vrfy "${GFS_SFC_LOCAL_DIR}/${gfs_sfc_fn}" ${GFS_SFC_STAGING_DIR}
+    else
+    print_err_msg_exit "\
+sfc file does not exist in the directory:
+  GFS_SFC_LOCAL_DIR = \"${GFS_SFC_LOCAL_DIR}\"
+  gfs_sfc_fn = \"${gfs_sfc_fn}\""
+    fi	    
+  done
+ 
+# retrieve files from HPSS
+else
+  if [ "${yyyymmdd}" -lt "20220627" ]; then
+    GFS_SFC_TAR_FN_VER="prod"
+  elif [ "${yyyymmdd}" -lt "20221129" ]; then
+    GFS_SFC_TAR_FN_VER="v16.2"
+  else
+    GFS_SFC_TAR_FN_VER="v16.3"
+  fi
+  GFS_SFC_TAR_FN_PREFIX="com_gfs_${GFS_SFC_TAR_FN_VER}_gfs"
+  GFS_SFC_TAR_FN_SUFFIX_A="gfs_nca.tar"
+  GFS_SFC_TAR_FN_SUFFIX_B="gfs_ncb.tar"
+
+  # Check if the sfcanl file exists in the staging directory
+  gfs_sfc_tar_fn="${GFS_SFC_TAR_FN_PREFIX}.${yyyymmdd}_${hh}.${GFS_SFC_TAR_FN_SUFFIX_A}"
+  gfs_sfc_tar_fp="${GFS_SFC_TAR_DIR}/${gfs_sfc_tar_fn}"
+  gfs_sfc_fns=("gfs.t${hh}z.sfcanl.nc")
+  gfs_sfc_fps="./${GFS_SFC_TAR_SUB_DIR}/gfs.t${hh}z.sfcanl.nc"
+  if [ "${FCST_LEN_HRS}" -lt "40" ]; then
+    ARCHV_LEN_HRS="${FCST_LEN_HRS}"
+  else
+    ARCHV_LEN_HRS="39"
+  fi
+  for fhr in $(seq -f "%03g" 0 ${GFS_SFC_DATA_INTVL} ${ARCHV_LEN_HRS}); do
+    gfs_sfc_fns+="gfs.t${hh}z.sfcf${fhr}.nc"
+    gfs_sfc_fps+=" ./${GFS_SFC_TAR_SUB_DIR}/gfs.t${hh}z.sfcf${fhr}.nc"
+  done
+
+  # Retrieve data from A file up to FCST_LEN_HRS=39
+  htar_log_fn="log.htar_a_get.${yyyymmdd}_${hh}"
+  htar -tvf ${gfs_sfc_tar_fp}
+  htar -xvf ${gfs_sfc_tar_fp} ${gfs_sfc_fps} >& ${htar_log_fn} || \
+    print_err_msg_exit "\
+htar file reading operation (\"htar -xvf ...\") failed.  Check the log 
+file htar_log_fn in the staging directory (gfs_sfc_staging_dir) for 
+details:
+  gfs_sfc_staging_dir = \"${GFS_SFC_STAGING_DIR}\"
+  htar_log_fn = \"${htar_log_fn}\""
+
+  # Retireve data from B file when FCST_LEN_HRS>=40
+  if [ "${FCST_LEN_HRS}" -ge "40" ]; then
+    gfs_sfc_tar_fn="${GFS_SFC_TAR_FN_PREFIX}.${yyyymmdd}_${hh}.${GFS_SFC_TAR_FN_SUFFIX_B}"
+    gfs_sfc_tar_fp="${GFS_SFC_TAR_DIR}/${gfs_sfc_tar_fn}"
+    gfs_sfc_fns=()
+    gfs_sfc_fps=""
+    for fhr in $(seq -f "%03g" 42 ${GFS_SFC_DATA_INTVL} ${FCST_LEN_HRS}); do
+      gfs_sfc_fns+="gfs.t${hh}z.sfcf${fhr}.nc"
+      gfs_sfc_fps+=" ./${GFS_SFC_TAR_SUB_DIR}/gfs.t${hh}z.sfcf${fhr}.nc"  
+    done
+
+    htar_log_fn="log.htar_b_get.${yyyymmdd}_${hh}"
+    htar -tvf ${gfs_sfc_tar_fp}
+    htar -xvf ${gfs_sfc_tar_fp} ${gfs_sfc_fps} >& ${htar_log_fn} || \
+    print_err_msg_exit "\
+htar file reading operation (\"htar -xvf ...\") failed.  Check the log 
+file htar_log_fn in the staging directory (gfs_sfc_staging_dir) for 
+details:
+  gfs_sfc_staging_dir = \"${GFS_SFC_STAGING_DIR}\"
+  htar_log_fn = \"${htar_log_fn}\""
+
+  fi
+  # Move retrieved files to staging directory
+  mv_vrfy ${DATA}/${GFS_SFC_TAR_SUB_DIR}/gfs.*.nc ${GFS_SFC_STAGING_DIR}
+
+fi  
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1

--- a/scripts/exregional_nexus_gfs_sfc.sh
+++ b/scripts/exregional_nexus_gfs_sfc.sh
@@ -133,11 +133,7 @@ else
   htar -tvf ${gfs_sfc_tar_fp}
   PREP_STEP
   htar -xvf ${gfs_sfc_tar_fp} ${gfs_sfc_fps} ${REDIRECT_OUT_ERR} || \
-    print_err_msg_exit "\
-htar file reading operation (\"htar -xvf ...\") failed.  Check the log 
-file htar_log_fn in the staging directory (gfs_sfc_staging_dir) for 
-details:
-  gfs_sfc_staging_dir = \"${GFS_SFC_STAGING_DIR}\""
+    print_err_msg_exit "htar file reading operation (\"htar -xvf ...\") failed."
   POST_STEP
 
   # Retireve data from B file when FCST_LEN_HRS>=40
@@ -153,11 +149,7 @@ details:
     htar -tvf ${gfs_sfc_tar_fp}
     PREP_STEP
     htar -xvf ${gfs_sfc_tar_fp} ${gfs_sfc_fps} ${REDIRECT_OUT_ERR} || \
-    print_err_msg_exit "\
-htar file reading operation (\"htar -xvf ...\") failed.  Check the log 
-file htar_log_fn in the staging directory (gfs_sfc_staging_dir) for 
-details:
-  gfs_sfc_staging_dir = \"${GFS_SFC_STAGING_DIR}\""
+    print_err_msg_exit "htar file reading operation (\"htar -xvf ...\") failed."
     POST_STEP
   fi
   # Move retrieved files to staging directory

--- a/scripts/exregional_nexus_gfs_sfc.sh
+++ b/scripts/exregional_nexus_gfs_sfc.sh
@@ -48,6 +48,7 @@ data files from disk or HPSS.
 #
 #-----------------------------------------------------------------------
 #
+set -x
 DATA="${DATA}/tmp_GFS_SFC"
 mkdir_vrfy -p "$DATA"
 cd_vrfy $DATA
@@ -129,15 +130,15 @@ else
   done
 
   # Retrieve data from A file up to FCST_LEN_HRS=39
-  htar_log_fn="log.htar_a_get.${yyyymmdd}_${hh}"
   htar -tvf ${gfs_sfc_tar_fp}
-  htar -xvf ${gfs_sfc_tar_fp} ${gfs_sfc_fps} >& ${htar_log_fn} || \
+  PREP_STEP
+  htar -xvf ${gfs_sfc_tar_fp} ${gfs_sfc_fps} ${REDIRECT_OUT_ERR} || \
     print_err_msg_exit "\
 htar file reading operation (\"htar -xvf ...\") failed.  Check the log 
 file htar_log_fn in the staging directory (gfs_sfc_staging_dir) for 
 details:
-  gfs_sfc_staging_dir = \"${GFS_SFC_STAGING_DIR}\"
-  htar_log_fn = \"${htar_log_fn}\""
+  gfs_sfc_staging_dir = \"${GFS_SFC_STAGING_DIR}\""
+  POST_STEP
 
   # Retireve data from B file when FCST_LEN_HRS>=40
   if [ "${FCST_LEN_HRS}" -ge "40" ]; then
@@ -149,17 +150,15 @@ details:
       gfs_sfc_fns+="gfs.t${hh}z.sfcf${fhr}.nc"
       gfs_sfc_fps+=" ./${GFS_SFC_TAR_SUB_DIR}/gfs.t${hh}z.sfcf${fhr}.nc"  
     done
-
-    htar_log_fn="log.htar_b_get.${yyyymmdd}_${hh}"
     htar -tvf ${gfs_sfc_tar_fp}
-    htar -xvf ${gfs_sfc_tar_fp} ${gfs_sfc_fps} >& ${htar_log_fn} || \
+    PREP_STEP
+    htar -xvf ${gfs_sfc_tar_fp} ${gfs_sfc_fps} ${REDIRECT_OUT_ERR} || \
     print_err_msg_exit "\
 htar file reading operation (\"htar -xvf ...\") failed.  Check the log 
 file htar_log_fn in the staging directory (gfs_sfc_staging_dir) for 
 details:
-  gfs_sfc_staging_dir = \"${GFS_SFC_STAGING_DIR}\"
-  htar_log_fn = \"${htar_log_fn}\""
-
+  gfs_sfc_staging_dir = \"${GFS_SFC_STAGING_DIR}\""
+    POST_STEP
   fi
   # Move retrieved files to staging directory
   mv_vrfy ${DATA}/${GFS_SFC_TAR_SUB_DIR}/gfs.*.nc ${GFS_SFC_STAGING_DIR}

--- a/scripts/exregional_nexus_post_split.sh
+++ b/scripts/exregional_nexus_post_split.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the ex-script for the task that runs NEXUS.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set OpenMP variables.
+#
+#-----------------------------------------------------------------------
+#
+export KMP_AFFINITY=${KMP_AFFINITY_NEXUS_POST_SPLIT}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_NEXUS_POST_SPLIT}
+export OMP_STACKSIZE=${OMP_STACKSIZE_NEXUS_POST_SPLIT}
+#
+#-----------------------------------------------------------------------
+#
+# Set run command.
+#
+#-----------------------------------------------------------------------
+#
+eval ${PRE_TASK_CMDS}
+
+if [ -z "${RUN_CMD_SERIAL:-}" ] ; then
+  print_err_msg_exit "\
+  Run command was not set in machine file. \
+  Please set RUN_CMD_SERIAL for your platform"
+else
+  print_info_msg "$VERBOSE" "
+  All executables will be submitted with command \'${RUN_CMD_SERIAL}\'."
+fi
+
+set -x
+#
+#-----------------------------------------------------------------------
+#
+# Move to the NEXUS working directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA}/tmp_NEXUS_POST_SPLIT"
+mkdir_vrfy -p "$DATA"
+
+cd_vrfy $DATA
+
+mm="${PDY:4:2}"
+dd="${PDY:6:2}"
+hh="${cyc}"
+yyyymmdd="${PDY}"
+
+NUM_SPLIT_NEXUS=$( printf "%02d" ${NUM_SPLIT_NEXUS} )
+if [ "${FCST_LEN_HRS}" = "-1" ]; then
+  for i_cdate in "${!ALL_CDATES[@]}"; do
+    if [ "${ALL_CDATES[$i_cdate]}" = "${PDY}${cyc}" ]; then
+      FCST_LEN_HRS="${FCST_LEN_CYCL[$i_cdate]}"
+      break
+    fi
+  done
+fi
+start_date=$( $DATE_UTIL --utc --date "${yyyymmdd} ${hh} UTC" "+%Y%m%d%H" )
+end_date=$( $DATE_UTIL --utc --date "${yyyymmdd} ${hh} UTC + ${FCST_LEN_HRS} hours" "+%Y%m%d%H" )
+
+#
+#-----------------------------------------------------------------------
+#
+# Copy the NEXUS config files to the tmp directory  
+#
+#-----------------------------------------------------------------------
+#
+cp_vrfy ${ARL_NEXUS_DIR}/config/cmaq/HEMCO_sa_Time.rc ${DATA}/HEMCO_sa_Time.rc
+
+cp_vrfy ${NEXUS_FIX_DIR}/${NEXUS_GRID_FN} ${DATA}/grid_spec.nc
+if [ "${NUM_SPLIT_NEXUS}" = "01" ]; then
+  nspt="00"
+  cp_vrfy ${COMIN}/NEXUS/${NET}.${cycle}${dot_ensmem}.NEXUS_Expt_split.${nspt}.nc ${DATA}/NEXUS_Expt_combined.nc
+else
+  cp_vrfy ${ARL_NEXUS_DIR}/utils/python/concatenate_nexus_post_split.py .
+  ./concatenate_nexus_post_split.py "${COMIN}/NEXUS/${NET}.${cycle}${dot_ensmem}.NEXUS_Expt_split.*.nc" "${DATA}/NEXUS_Expt_combined.nc"
+fi
+    
+#
+#-----------------------------------------------------------------------
+#
+# make nexus output pretty
+#
+#-----------------------------------------------------------------------
+#
+cp_vrfy ${ARL_NEXUS_DIR}/utils/python/nexus_time_parser.py .
+./nexus_time_parser.py -f ${DATA}/HEMCO_sa_Time.rc -s $start_date -e $end_date
+
+cp_vrfy ${ARL_NEXUS_DIR}/utils/python/make_nexus_output_pretty.py .
+./make_nexus_output_pretty.py --src ${DATA}/NEXUS_Expt_combined.nc --grid ${DATA}/grid_spec.nc -o ${DATA}/NEXUS_Expt_pretty.nc -t ${DATA}/HEMCO_sa_Time.rc
+
+#
+#-----------------------------------------------------------------------
+#
+# run MEGAN NCO script
+#
+#-----------------------------------------------------------------------
+#
+cp_vrfy ${ARL_NEXUS_DIR}/utils/combine_ant_bio.py .
+./combine_ant_bio.py NEXUS_Expt_pretty.nc NEXUS_Expt.nc
+
+#
+#-----------------------------------------------------------------------
+#
+# Move NEXUS output to INPUT_DATA directory.
+#
+#-----------------------------------------------------------------------
+#
+mv_vrfy ${DATA}/NEXUS_Expt.nc ${INPUT_DATA}/${NET}.${cycle}${dot_ensmem}.NEXUS_Expt.nc
+#
+# Print message indicating successful completion of script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+NEXUS NetCDF file has been generated successfully!!!!
+
+Exiting script:  \"${scrfunc_fn}\"
+In directory:    \"${scrfunc_dir}\"
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1

--- a/scripts/exregional_nexus_post_split.sh
+++ b/scripts/exregional_nexus_post_split.sh
@@ -62,17 +62,6 @@ export OMP_STACKSIZE=${OMP_STACKSIZE_NEXUS_POST_SPLIT}
 #-----------------------------------------------------------------------
 #
 eval ${PRE_TASK_CMDS}
-
-if [ -z "${RUN_CMD_SERIAL:-}" ] ; then
-  print_err_msg_exit "\
-  Run command was not set in machine file. \
-  Please set RUN_CMD_SERIAL for your platform"
-else
-  print_info_msg "$VERBOSE" "
-  All executables will be submitted with command \'${RUN_CMD_SERIAL}\'."
-fi
-
-set -x
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exregional_nexus_post_split.sh
+++ b/scripts/exregional_nexus_post_split.sh
@@ -116,8 +116,7 @@ if [ "${NUM_SPLIT_NEXUS}" = "01" ]; then
   nspt="00"
   cp_vrfy ${COMIN}/NEXUS/${NET}.${cycle}${dot_ensmem}.NEXUS_Expt_split.${nspt}.nc ${DATA}/NEXUS_Expt_combined.nc
 else
-  cp_vrfy ${ARL_NEXUS_DIR}/utils/python/concatenate_nexus_post_split.py .
-  ./concatenate_nexus_post_split.py "${COMIN}/NEXUS/${NET}.${cycle}${dot_ensmem}.NEXUS_Expt_split.*.nc" "${DATA}/NEXUS_Expt_combined.nc"
+  python3 ${ARL_NEXUS_DIR}/utils/python/concatenate_nexus_post_split.py "${COMIN}/NEXUS/${NET}.${cycle}${dot_ensmem}.NEXUS_Expt_split.*.nc" "${DATA}/NEXUS_Expt_combined.nc"
 fi
     
 #
@@ -127,11 +126,9 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-cp_vrfy ${ARL_NEXUS_DIR}/utils/python/nexus_time_parser.py .
-./nexus_time_parser.py -f ${DATA}/HEMCO_sa_Time.rc -s $start_date -e $end_date
+python3 ${ARL_NEXUS_DIR}/utils/python/nexus_time_parser.py -f ${DATA}/HEMCO_sa_Time.rc -s $start_date -e $end_date
 
-cp_vrfy ${ARL_NEXUS_DIR}/utils/python/make_nexus_output_pretty.py .
-./make_nexus_output_pretty.py --src ${DATA}/NEXUS_Expt_combined.nc --grid ${DATA}/grid_spec.nc -o ${DATA}/NEXUS_Expt_pretty.nc -t ${DATA}/HEMCO_sa_Time.rc
+python3 ${ARL_NEXUS_DIR}/utils/python/make_nexus_output_pretty.py --src ${DATA}/NEXUS_Expt_combined.nc --grid ${DATA}/grid_spec.nc -o ${DATA}/NEXUS_Expt_pretty.nc -t ${DATA}/HEMCO_sa_Time.rc
 
 #
 #-----------------------------------------------------------------------
@@ -140,8 +137,7 @@ cp_vrfy ${ARL_NEXUS_DIR}/utils/python/make_nexus_output_pretty.py .
 #
 #-----------------------------------------------------------------------
 #
-cp_vrfy ${ARL_NEXUS_DIR}/utils/combine_ant_bio.py .
-./combine_ant_bio.py NEXUS_Expt_pretty.nc NEXUS_Expt.nc
+python3 ${ARL_NEXUS_DIR}/utils/combine_ant_bio.py ${DATA}/NEXUS_Expt_pretty.nc ${DATA}/NEXUS_Expt.nc
 
 #
 #-----------------------------------------------------------------------

--- a/scripts/exregional_point_source.sh
+++ b/scripts/exregional_point_source.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "task_make_grid|task_run_fcst|cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the ex-script for the task that runs PT_SOURCE.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set OpenMP variables.
+#
+#-----------------------------------------------------------------------
+#
+export KMP_AFFINITY=${KMP_AFFINITY_POINT_SOURCE}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_POINT_SOURCE}
+export OMP_STACKSIZE=${OMP_STACKSIZE_POINT_SOURCE}
+#
+#-----------------------------------------------------------------------
+#
+# Set run command.
+#
+#-----------------------------------------------------------------------
+#
+eval ${PRE_TASK_CMDS}
+
+nprocs=$(( LAYOUT_X*LAYOUT_Y ))
+ppn_run_aqm="${PPN_POINT_SOURCE}"
+omp_num_threads_run_aqm="${OMP_NUM_THREADS_POINT_SOURCE}"
+if [ "${FCST_LEN_HRS}" = "-1" ]; then
+  for i_cdate in "${!ALL_CDATES[@]}"; do
+    if [ "${ALL_CDATES[$i_cdate]}" = "${PDY}${cyc}" ]; then
+      FCST_LEN_HRS="${FCST_LEN_CYCL[$i_cdate]}"
+      break
+    fi
+  done
+fi
+nstep=$(( FCST_LEN_HRS+1 ))
+yyyymmddhh="${PDY}${cyc}"
+
+if [ -z "${RUN_CMD_AQM:-}" ] ; then
+  print_err_msg_exit "\
+  Run command was not set in machine file. \
+  Please set RUN_CMD_AQM for your platform"
+else
+  RUN_CMD_AQM=$(eval echo ${RUN_CMD_AQM})
+  print_info_msg "$VERBOSE" "
+  All executables will be submitted with command \'${RUN_CMD_AQM}\'."
+fi
+
+#
+#-----------------------------------------------------------------------
+#
+# Move to the working directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA}/tmp_PT_SOURCE"
+mkdir_vrfy -p "$DATA"
+cd_vrfy $DATA
+#
+#-----------------------------------------------------------------------
+#
+# Set the directories for CONUS/HI/AK
+#
+#-----------------------------------------------------------------------
+#
+PT_SRC_CONUS="${PT_SRC_BASEDIR}/12US1"
+PT_SRC_HI="${PT_SRC_BASEDIR}/3HI1"
+PT_SRC_AK="${PT_SRC_BASEDIR}/9AK1"
+#
+#-----------------------------------------------------------------------
+#
+# Run stack-pt-mergy.py if file does not exist.
+#
+#-----------------------------------------------------------------------
+#
+if [ ! -s "${DATA}/pt-${yyyymmddhh}.nc" ]; then 
+  cp_vrfy ${HOMEdir}/sorc/AQM-utils/python_utils/stack-pt-merge.py stack-pt-merge.py
+  python3 stack-pt-merge.py -s ${yyyymmddhh} -n ${nstep} -conus ${PT_SRC_CONUS} -hi ${PT_SRC_HI} -ak ${PT_SRC_AK}
+
+  # bail if error 
+  if [ ! -s "${DATA}/pt-${yyyymmddhh}.nc" ]; then
+    print_err_msg_exit "\
+The point source file \"pt-${yyyymmddhh}.nc\" was not generated."
+  else
+    print_info_msg "The intermediate file \"pt-${yyyymmddhh}.nc\" exists."
+  fi
+fi
+
+#
+#----------------------------------------------------------------------
+#
+# Export input parameters of PT_SOURCE executable
+#
+#-----------------------------------------------------------------------
+#
+export NX=${ESGgrid_NX}
+export NY=${ESGgrid_NY}
+export LAYOUT_X
+export LAYOUT_Y
+export TOPO="${NEXUS_FIX_DIR}/${NEXUS_GRID_FN}"
+export PT_IN="${DATA}/pt-${yyyymmddhh}.nc"
+
+#
+#----------------------------------------------------------------------
+#
+# Temporary output directory for PT_SOURCE executable
+#
+#-----------------------------------------------------------------------
+#
+mkdir_vrfy -p "${DATA}/PT"
+
+#
+#----------------------------------------------------------------------
+#
+# Execute PT_SOURCE
+#
+#-----------------------------------------------------------------------
+#
+PREP_STEP
+eval ${RUN_CMD_AQM} ${EXECdir}/decomp-ptemis-mpi ${REDIRECT_OUT_ERR} || \
+print_err_msg_exit "\
+Call to execute PT_SOURCE for Online-CMAQ failed."
+POST_STEP
+
+#
+#-----------------------------------------------------------------------
+#
+# Move output to INPUT_DATA directory.
+#
+#-----------------------------------------------------------------------
+#
+mv_vrfy "${DATA}/PT" ${INPUT_DATA}
+
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating successful completion of script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+PT_SOURCE has successfully generated output files !!!!
+
+Exiting script:  \"${scrfunc_fn}\"
+In directory:    \"${scrfunc_dir}\"
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1

--- a/scripts/exregional_point_source.sh
+++ b/scripts/exregional_point_source.sh
@@ -115,8 +115,7 @@ PT_SRC_AK="${PT_SRC_BASEDIR}/9AK1"
 #-----------------------------------------------------------------------
 #
 if [ ! -s "${DATA}/pt-${yyyymmddhh}.nc" ]; then 
-  cp_vrfy ${HOMEdir}/sorc/AQM-utils/python_utils/stack-pt-merge.py stack-pt-merge.py
-  python3 stack-pt-merge.py -s ${yyyymmddhh} -n ${nstep} -conus ${PT_SRC_CONUS} -hi ${PT_SRC_HI} -ak ${PT_SRC_AK}
+  python3 ${HOMEdir}/sorc/AQM-utils/python_utils/stack-pt-merge.py -s ${yyyymmddhh} -n ${nstep} -conus ${PT_SRC_CONUS} -hi ${PT_SRC_HI} -ak ${PT_SRC_AK}
 
   # bail if error 
   if [ ! -s "${DATA}/pt-${yyyymmddhh}.nc" ]; then

--- a/scripts/exregional_post_stat_o3.sh
+++ b/scripts/exregional_post_stat_o3.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm|task_run_post" ${GLOBAL_VAR_DEFNS_FP}
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the ex-script for the task that runs POST-STAT-O3.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set OpenMP variables.
+#
+#-----------------------------------------------------------------------
+#
+export KMP_AFFINITY=${KMP_AFFINITY_POST_STAT_O3}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_POST_STAT_O3}
+export OMP_STACKSIZE=${OMP_STACKSIZE_POST_STAT_O3}
+#
+#-----------------------------------------------------------------------
+#
+# Set run command.
+#
+#-----------------------------------------------------------------------
+#
+eval ${PRE_TASK_CMDS}
+
+if [ -z "${RUN_CMD_SERIAL:-}" ] ; then
+  print_err_msg_exit "\
+  Run command was not set in machine file. \
+  Please set RUN_CMD_SERIAL for your platform"
+else
+  RUN_CMD_SERIAL=$(eval echo ${RUN_CMD_SERIAL})
+  print_info_msg "$VERBOSE" "
+  All executables will be submitted with command \'${RUN_CMD_SERIAL}\'."
+fi
+
+#
+#-----------------------------------------------------------------------
+#
+# Move to the working directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA}/tmp_POST_STAT_O3"
+mkdir_vrfy -p "$DATA"
+cd_vrfy $DATA
+
+set -x
+#
+#-----------------------------------------------------------------------
+#
+# POST-STAT: O3
+#
+#-----------------------------------------------------------------------
+#
+if [ "${PREDEF_GRID_NAME}" = "AQM_NA_13km" ]; then
+  id_domain=793
+fi
+
+ln_vrfy -sf ${COMIN}/${NET}.${cycle}.chem_sfc.nc .
+
+#
+cat >aqm_post.ini <<EOF1
+&control
+varlist='o3','O3_8hr'
+infile='${NET}.${cycle}.chem_sfc.nc'
+outfile='${NET}.${cycle}.awpozcon'
+id_gribdomain=${id_domain}
+/
+EOF1
+
+# convert from netcdf to grib2 format
+PREP_STEP
+${EXECdir}/aqm_post_grib2 ${PDY} ${cyc} || print_err_msg_exit "\
+Call to executable to run AQM_POST_GRIB2 returned with nonzero exit code."
+POST_STEP
+
+if [ "${FCST_LEN_HRS}" = "-1" ]; then
+  for i_cdate in "${!ALL_CDATES[@]}"; do
+    if [ "${ALL_CDATES[$i_cdate]}" = "${PDY}${cyc}" ]; then
+      FCST_LEN_HRS="${FCST_LEN_CYCL[$i_cdate]}"
+      break
+    fi
+  done
+fi
+
+fhr=01
+while [ ${fhr} -le ${FCST_LEN_HRS} ]; do
+  fhr9=$( printf "%02d" "${fhr}" )
+
+  if [ "${fhr9}" -le "07" ]; then
+    cat ${DATA}/${NET}.${cycle}.awpozcon.f${fhr9}.${id_domain}.grib2 >> ${NET}.${cycle}.1ho3.${id_domain}.grib2
+  else
+    wgrib2 ${DATA}/${NET}.${cycle}.awpozcon.f${fhr9}.${id_domain}.grib2 -d 1 -append -grib ${NET}.${cycle}.1ho3.${id_domain}.grib2
+    wgrib2 ${DATA}/${NET}.${cycle}.awpozcon.f${fhr9}.${id_domain}.grib2 -d 2 -append -grib ${NET}.${cycle}.8ho3.${id_domain}.grib2
+  fi
+  (( fhr=fhr+1 ))
+done
+
+grid227="lambert:265.0000:25.0000:25.0000 226.5410:1473:5079.000 12.1900:1025:5079.000"
+#grid148="lambert:263.0000:33.0000:45.0000 239.3720:442:12000.000 21.8210:265:12000.000"
+grid196="mercator:20.0000 198.4750:321:2500.000:206.1310 18.0730:255:2500.000:23.0880"
+grid198="nps:210.0000:60.0000 181.4290:825:5953.000 40.5300:553:5953.000"
+
+for grid in 227 196 198;do
+  gg="grid${grid}"
+  wgrib2 ${NET}.${cycle}.1ho3.${id_domain}.grib2 -set_grib_type c3b -new_grid_winds earth -new_grid ${!gg} ${NET}.${cycle}.1ho3.${grid}.grib2
+
+  if [ "${cyc}" = "06" ] || [ "${cyc}" = "12" ]; then
+    wgrib2 ${NET}.${cycle}.8ho3.${id_domain}.grib2 -set_grib_type c3b -new_grid_winds earth -new_grid ${!gg} ${NET}.${cycle}.8ho3.${grid}.grib2
+
+    for hr in 1 8; do
+      echo 0 > filesize
+      export XLFRTEOPTS="unit_vars=yes"
+      export FORT11=${NET}.${cycle}.${hr}ho3.${grid}.grib2
+      export FORT12="filesize"
+      export FORT31=
+      export FORT51=grib2.${cycle}.${hr}awpcsozcon.${grid}.temp
+      tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_ave_${hr}hr_o3-awpozcon.${cycle}.${grid}
+
+      echo `ls -l grib2.${cycle}.${hr}awpcsozcon.${grid}.temp  | awk '{print $5} '` > filesize
+      export XLFRTEOPTS="unit_vars=yes"
+      export FORT11=grib2.${cycle}.${hr}awpcsozcon.${grid}.temp
+      export FORT12="filesize"
+      export FORT31=
+      export FORT51=awpaqm.${cycle}.${hr}ho3.${grid}.grib2
+      tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_ave_${hr}hr_o3-awpozcon.${cycle}.${grid}
+    done
+    for var in 1ho3 8ho3 awpozcon;do
+      cp_vrfy ${DATA}/${NET}.${cycle}.${var}*grib2 ${COMOUT}
+      cp_vrfy ${DATA}/awpaqm.${cycle}.${var}*grib2 ${COMOUT}
+    done
+  else
+    for var in 1ho3 awpozcon;do
+      cp_vrfy ${DATA}/${NET}.${cycle}.${var}*grib2 ${COMOUT}
+    done
+  fi
+done
+
+#------------------------------------------------------------
+# o3_post_maxi
+#------------------------------------------------------------
+if [ "${cyc}" = "06" ] || [ "${cyc}" = "12" ]; then
+
+  ln_vrfy -sf ${COMIN}/${NET}.${cycle}.chem_sfc.nc a.nc
+
+  export chk=1
+  export chk1=1
+  # today 00z file exists otherwise chk=0
+
+cat >aqm_max.ini <<EOF1
+&control
+varlist='O3_1h_max','O3_8h_max'
+outfile='aqm-maxi'
+id_gribdomain=${id_domain}
+max_proc=72
+/
+EOF1
+
+  flag_run_bicor_max=yes
+
+  ## 06z needs b.nc to find current day output from 04Z to 06Z
+  if [ "${cyc}" = "06" ]; then
+    if [ -s ${COMIN_PDY}/00/${NET}.t00z.chem_sfc.nc ]; then
+      ln_vrfy -s  ${COMIN_PDY}/00/${NET}.t00z.chem_sfc.nc b.nc
+    elif [ -s ${COMIN_PDYm1}/12/${NET}.t12z.chem_sfc.nc ]; then
+      ln_vrfy -s ${COMIN_PDYm1}/12/${NET}.t12z.chem_sfc.nc b.nc
+      chk=0
+    else
+      flag_run_bicor_max=no
+    fi
+  fi
+
+  if [ "${cyc}" = "12" ]; then
+    ## 12z needs b.nc to find current day output from 04Z to 06Z 
+    if [ -s ${COMIN_PDY}/00/${NET}.t00z.chem_sfc.nc ]; then
+      ln_vrfy -s ${COMIN_PDY}/00/${NET}.t00z.chem_sfc.nc b.nc
+    elif [ -s ${COMIN_PDYm1}/12/${NET}.t12z.chem_sfc.nc ]; then
+      ln_vrfy -s ${COMIN_PDYm1}/12/${NET}.t12z.chem_sfc.nc b.nc
+      chk=0
+    else
+      flag_run_bicor_max=no
+    fi
+
+    ## 12z needs c.nc to find current day output from 07Z to 12z
+    if [ -s ${COMIN_PDY}/06/${NET}.t06z.chem_sfc.nc ]; then
+      ln_vrfy -s ${COMIN_PDY}/06/${NET}.t06z.chem_sfc.nc c.nc
+    elif [ -s ${COMIN_PDYm1}/12/${NET}.t12z.chem_sfc.nc ]; then
+      ln_vrfy -s ${COMIN_PDYm1}/12/${NET}.t12z.chem_sfc.nc c.nc
+      chk1=0
+    else
+      flag_run_bicor_max=no
+    fi
+  fi
+
+  PREP_STEP
+  ${EXECdir}/aqm_post_maxi_grib2 ${PDY} ${cyc} ${chk} ${chk1} || print_err_msg_exit "\
+  Call to executable to run AQM_POST_MAXI_GRIB2 returned with nonzero exit code."
+  POST_STEP
+
+  # split into max_1h and max_8h files and copy to grib227
+  wgrib2 aqm-maxi.${id_domain}.grib2 |grep "OZMAX1" | wgrib2 -i aqm-maxi.${id_domain}.grib2 -grib ${NET}.${cycle}.max_1hr_o3.${id_domain}.grib2
+  wgrib2 aqm-maxi.${id_domain}.grib2 |grep "OZMAX8" | wgrib2 -i aqm-maxi.${id_domain}.grib2 -grib ${NET}.${cycle}.max_8hr_o3.${id_domain}.grib2
+
+  grid227="lambert:265.0000:25.0000:25.0000 226.5410:1473:5079.000 12.1900:1025:5079.000"
+  #export grid148="lambert:263.0000:33.0000:45.0000 239.3720:442:12000.000 21.8210:265:12000.000"
+  grid196="mercator:20.0000 198.4750:321:2500.000:206.1310 18.0730:255:2500.000:23.0880"
+  grid198="nps:210.0000:60.0000 181.4290:825:5953.000 40.5300:553:5953.000"
+
+  for grid in 227 196 198; do
+    gg="grid${grid}"
+    wgrib2 ${NET}.${cycle}.max_8hr_o3.${id_domain}.grib2 -set_grib_type c3b -new_grid_winds earth -new_grid ${!gg} ${NET}.${cycle}.max_8hr_o3.${grid}.grib2
+    wgrib2 ${NET}.${cycle}.max_1hr_o3.${id_domain}.grib2 -set_grib_type c3b -new_grid_winds earth -new_grid ${!gg} ${NET}.${cycle}.max_1hr_o3.${grid}.grib2
+
+    cp_vrfy ${DATA}/${NET}.${cycle}.max_*hr_o3.*.grib2  ${COMOUT}
+    if [ "$SENDDBN" = "YES" ]; then
+      ${DBNROOT}/bin/dbn_alert MODEL AQM_MAX ${job} ${COMOUT}/${NET}.${cycle}.max_1hr_o3.${grid}.grib2
+      ${DBNROOT}/bin/dbn_alert MODEL AQM_MAX ${job} ${COMOUT}/${NET}.${cycle}.max_8hr_o3.${grid}.grib2
+    fi
+
+    # Add WMO header for daily 1h and 8h max O3
+    for hr in 1 8; do
+      echo 0 > filesize
+      export XLFRTEOPTS="unit_vars=yes"
+      export FORT11=${NET}.${cycle}.max_${hr}hr_o3.${grid}.grib2
+      export FORT12="filesize"
+      export FORT31=
+      export FORT51=aqm-${hr}hro3-maxi.${grid}.grib2.temp
+      tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm-${hr}hro3-maxi.${cycle}.${grid}
+      echo `ls -l  aqm-${hr}hro3-maxi.${grid}.grib2.temp | awk '{print $5} '` > filesize
+      export XLFRTEOPTS="unit_vars=yes"
+      export FORT11=aqm-${hr}hro3-maxi.${grid}.grib2.temp
+      export FORT12="filesize"
+      export FORT31=
+      export FORT51=awpaqm.${cycle}.${hr}ho3-max.${grid}.grib2
+      tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm-${hr}hro3-maxi.${cycle}.${grid}
+    done
+
+    cp_vrfy awpaqm.${cycle}.*o3-max.${grid}.grib2 ${COMOUT}
+    if [ "${SENDDBN_NTC}" = "YES" ]; then
+      ${DBNROOT}/bin/dbn_alert ${DBNALERT_TYPE} ${NET} ${job} ${COMOUT}/awpaqm.${cycle}.1ho3-max.${grid}.grib2
+      ${DBNROOT}/bin/dbn_alert ${DBNALERT_TYPE} ${NET} ${job} ${COMOUT}/awpaqm.${cycle}.8ho3-max.${grid}.grib2
+    fi
+  done
+fi
+
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating successful completion of script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+POST-STAT-O3 completed successfully.
+
+Exiting script:  \"${scrfunc_fn}\"
+In directory:    \"${scrfunc_dir}\"
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1

--- a/scripts/exregional_post_stat_o3.sh
+++ b/scripts/exregional_post_stat_o3.sh
@@ -110,7 +110,7 @@ EOF1
 
 # convert from netcdf to grib2 format
 PREP_STEP
-${EXECdir}/aqm_post_grib2 ${PDY} ${cyc} || print_err_msg_exit "\
+eval ${RUN_CMD_SERIAL} ${EXECdir}/aqm_post_grib2 ${PDY} ${cyc} ${REDIRECT_OUT_ERR} || print_err_msg_exit "\
 Call to executable to run AQM_POST_GRIB2 returned with nonzero exit code."
 POST_STEP
 
@@ -233,7 +233,7 @@ EOF1
   fi
 
   PREP_STEP
-  ${EXECdir}/aqm_post_maxi_grib2 ${PDY} ${cyc} ${chk} ${chk1} || print_err_msg_exit "\
+  eval ${RUN_CMD_SERIAL} ${EXECdir}/aqm_post_maxi_grib2 ${PDY} ${cyc} ${chk} ${chk1} ${REDIRECT_OUT_ERR} || print_err_msg_exit "\
   Call to executable to run AQM_POST_MAXI_GRIB2 returned with nonzero exit code."
   POST_STEP
 

--- a/scripts/exregional_post_stat_pm25.sh
+++ b/scripts/exregional_post_stat_pm25.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm|task_run_post" ${GLOBAL_VAR_DEFNS_FP}
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the ex-script for the task that runs POST-STAT-PM25.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set OpenMP variables.
+#
+#-----------------------------------------------------------------------
+#
+export KMP_AFFINITY=${KMP_AFFINITY_POST_STAT_PM25}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_POST_STAT_PM25}
+export OMP_STACKSIZE=${OMP_STACKSIZE_POST_STAT_PM25}
+#
+#-----------------------------------------------------------------------
+#
+# Set run command.
+#
+#-----------------------------------------------------------------------
+#
+eval ${PRE_TASK_CMDS}
+
+if [ -z "${RUN_CMD_SERIAL:-}" ] ; then
+  print_err_msg_exit "\
+  Run command was not set in machine file. \
+  Please set RUN_CMD_SERIAL for your platform"
+else
+  RUN_CMD_SERIAL=$(eval echo ${RUN_CMD_SERIAL})
+  print_info_msg "$VERBOSE" "
+  All executables will be submitted with command \'${RUN_CMD_SERIAL}\'."
+fi
+
+#
+#-----------------------------------------------------------------------
+#
+# Move to the working directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA}/tmp_POST_STAT_PM25"
+mkdir_vrfy -p "$DATA"
+cd_vrfy $DATA
+
+set -x
+
+#
+#-----------------------------------------------------------------------
+#
+# POST-STAT: PM25
+#
+#-----------------------------------------------------------------------
+#
+
+if [ "${PREDEF_GRID_NAME}" = "AQM_NA_13km" ]; then
+  id_domain=793
+fi
+
+#---------------------------------------------------------------
+# aqm_pm25_post
+#---------------------------------------------------------------
+
+ln_vrfy -sf ${COMIN}/${NET}.${cycle}.chem_sfc.nc .
+
+cat >aqm_post.ini <<EOF1
+&control
+varlist='PM25_TOT'
+infile='${NET}.${cycle}.chem_sfc.nc'
+outfile='${NET}.${cycle}.pm25'
+id_gribdomain=${id_domain}
+/
+EOF1
+
+# convert from netcdf to grib2 format
+PREP_STEP
+${EXECdir}/aqm_post_grib2 ${PDY} ${cyc} || print_err_msg_exit "\
+Call to executable to run AQM_POST_GRIB2 returned with nonzero exit code."
+POST_STEP
+
+cat ${NET}.${cycle}.pm25.*.${id_domain}.grib2 >> ${NET}.${cycle}.1hpm25.${id_domain}.grib2
+
+export grid227="lambert:265.0000:25.0000:25.0000 226.5410:1473:5079.000 12.1900:1025:5079.000"
+#export grid148="lambert:263.0000:33.0000:45.0000 239.3720:442:12000.000 21.8210:265:12000.000"
+export grid196="mercator:20.0000 198.4750:321:2500.000:206.1310 18.0730:255:2500.000:23.0880"
+export grid198="nps:210.0000:60.0000 181.4290:825:5953.000 40.5300:553:5953.000"
+
+for grid in 227 196 198; do
+  gg="grid${grid}"
+  wgrib2 ${NET}.${cycle}.1hpm25.${id_domain}.grib2 -set_grib_type c3b -new_grid_winds earth -new_grid ${!gg} ${NET}.${cycle}.1hpm25.${grid}.grib2
+done
+
+cp_vrfy ${DATA}/${NET}.${cycle}*pm25*.grib2 ${COMOUT}
+  
+# Create AWIPS GRIB2 data for Bias-Corrected PM2.5
+if [ "${cyc}" = "06" ] || [ "${cyc}" = "12" ]; then
+  for grid in 227 198 196; do
+    echo 0 > filesize
+    export XLFRTEOPTS="unit_vars=yes"
+    export FORT11=${NET}.${cycle}.1hpm25.${grid}.grib2
+    export FORT12="filesize"
+    export FORT31=
+    export FORT51=${NET}.${cycle}.1hpm25.${grid}.grib2.temp
+    tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_1hpm25.${cycle}.${grid}
+				
+    echo `ls -l ${NET}.${cycle}.grib2_pm25.${grid}.temp  | awk '{print $5} '` > filesize
+    export XLFRTEOPTS="unit_vars=yes"
+    export FORT11=${NET}.${cycle}.1hpm25.${grid}.grib2.temp
+    export FORT12="filesize"
+    export FORT31=
+    export FORT51=awpaqm.${cycle}.1hpm25.${grid}.grib2
+    tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_1hpm25.${cycle}.${grid}
+
+    # Post Files to COMOUT
+    cp_vrfy awpaqm.${cycle}.1hpm25.${grid}.grib2 ${COMOUT}
+
+    # Distribute Data
+    if [ "${SENDDBN_NTC}" = "YES" ] ; then
+      ${DBNROOT}/bin/dbn_alert ${DBNALERT_TYPE} ${NET} ${job} ${COMOUT}/awpaqm.${cycle}.1hpm25.${grid}.grib2 
+      ${DBNROOT}/bin/dbn_alert ${DBNALERT_TYPE} ${NET} ${job} ${COMOUT}/awpaqm.${cycle}.daily-1hr-pm25-max.${grid}.grib2
+    fi
+  done
+fi
+
+#---------------------------------------------------------------
+# aqm_pm25_post_maxi
+#---------------------------------------------------------------
+if [ "${cyc}" = "06" ] || [ "${cyc}" = "12" ]; then
+
+  ln_vrfy -sf ${COMIN}/${NET}.${cycle}.chem_sfc.nc a.nc
+
+  export chk=1
+  export chk1=1
+  # today 00z file exists otherwise chk=0
+
+cat >aqm_max.ini <<EOF1
+&control
+varlist='pm25_24h_ave','pm25_1h_max'
+outfile='aqm_pm25_24h_ave'
+id_gribdomain=${id_domain}
+max_proc=72
+/
+EOF1
+
+  flag_run_bicor_max=yes
+  # 06z needs b.nc to find current day output from 04Z to 06Z
+  if [ "${cyc}" = "06" ]; then
+    if [ -s ${COMIN_PDY}/00/${NET}.t00z.chem_sfc.nc ]; then
+      ln_vrfy -sf  ${COMIN_PDY}/00/${NET}.t00z.chem_sfc.nc b.nc
+    elif [ -s ${COMIN_PDYm1}/12/${NET}.t12z.chem_sfc.nc ]; then
+      ln_vrfy -sf ${COMIN_PDYm1}/12/${NET}.t12z.chem_sfc.nc b.nc
+      chk=0
+    else
+      flag_run_bicor_max=no
+    fi
+  fi
+
+  if [ "${cyc}" = "12" ]; then
+    # 12z needs b.nc to find current day output from 04Z to 06Z
+    if [ -s ${COMIN_PDY}/00/${NET}.t00z.chem_sfc.nc ]; then
+      ln_vrfy -sf ${COMIN_PDY}/00/${NET}.t00z.chem_sfc.nc b.nc
+    elif [ -s ${COMIN_PDYm1}/12/${NET}.t12z.chem_sfc.nc ]; then
+      ln_vrfy -sf ${COMIN_PDYm1}/12/${NET}.${PDYm1}.t12z.chem_sfc.nc b.nc
+      chk=0
+    else
+      flag_run_bicor_max=no
+    fi
+
+    # 12z needs c.nc to find current day output from 07Z to 12z
+    if [ -s ${COMIN_PDY}/06/${NET}.t06z.chem_sfc.nc ]; then
+      ln_vrfy -sf ${COMIN_PDY}/06/${NET}.t06z.chem_sfc.nc c.nc
+    elif [ -s ${COMIN_PDYm1}/12/${NET}.t12z.chem_sfc.nc ]; then
+      ln_vrfy -sf ${COMIN_PDYm1}/12/${NET}.t12z.chem_sfc.nc c.nc
+      chk1=0
+    else
+      flag_run_bicor_max=no
+    fi
+  fi
+
+  PREP_STEP
+  ${EXECdir}/aqm_post_maxi_grib2 ${PDY} ${cyc} ${chk} ${chk1} || print_err_msg_exit "\
+  Call to executable to run AQM_POST_MAXI_GRIB2 returned with nonzero exit code."
+  POST_STEP
+
+  wgrib2 ${NET}_pm25_24h_ave.${id_domain}.grib2 |grep "PMTF" | wgrib2 -i ${NET}_pm25_24h_ave.${id_domain}.grib2 -grib ${NET}.${cycle}.ave_24hr_pm25.${id_domain}.grib2
+  wgrib2 ${NET}_pm25_24h_ave.${id_domain}.grib2 |grep "PDMAX1" | wgrib2 -i ${NET}_pm25_24h_ave.${id_domain}.grib2 -grib ${NET}.${cycle}.max_1hr_pm25.${id_domain}.grib2
+
+  export grid227="lambert:265.0000:25.0000:25.0000 226.5410:1473:5079.000 12.1900:1025:5079.000"
+  #export grid148="lambert:263.0000:33.0000:45.0000 239.3720:442:12000.000 21.8210:265:12000.000"
+  export grid196="mercator:20.0000 198.4750:321:2500.000:206.1310 18.0730:255:2500.000:23.0880"
+  export grid198="nps:210.0000:60.0000 181.4290:825:5953.000 40.5300:553:5953.000"
+
+  for grid in 227 196 198; do
+    gg="grid${grid}"
+    wgrib2 ${NET}.${cycle}.ave_24hr_pm25.${id_domain}.grib2 -set_grib_type c3b -new_grid_winds earth -new_grid ${!gg} ${NET}.${cycle}.24hrpm25-ave.${grid}.grib2
+    wgrib2 ${NET}.${cycle}.max_1hr_pm25.${id_domain}.grib2 -set_grib_type c3b -new_grid_winds earth -new_grid ${!gg} ${NET}.${cycle}.1hpm25-max.${grid}.grib2
+
+    # Add WMO header for daily 1h PM2.5 and 24hr_ave PM2.5
+    rm_vrfy -f filesize
+    echo 0 > filesize
+    export XLFRTEOPTS="unit_vars=yes"
+    export FORT11=${NET}.${cycle}.1hpm25-max.${grid}.grib2
+    export FORT12="filesize"
+    export FORT31=
+    export FORT51=${NET}.${cycle}.max_1hr_pm25.${grid}.grib2.temp
+    tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_max_1hr_pm25.${cycle}.${grid}
+
+    echo `ls -l  ${NET}.${cycle}.max_1hr_pm25.${grid}.grib2.temp | awk '{print $5} '` > filesize
+    export XLFRTEOPTS="unit_vars=yes"
+    export FORT11=${NET}.${cycle}.max_1hr_pm25.${grid}.grib2.temp
+    export FORT12="filesize"
+    export FORT31=
+    export FORT51=awpaqm.${cycle}.daily-1hr-pm25-max.${grid}.grib2
+    tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_max_1hr_pm25.${cycle}.${grid}
+
+    rm_vrfy -f filesize
+    echo 0 > filesize
+    export XLFRTEOPTS="unit_vars=yes"
+    export FORT11=${NET}.${cycle}.24hrpm25-ave.${grid}.grib2
+    export FORT12="filesize"
+    export FORT31=
+    export FORT51=${NET}.${cycle}.24hrpm25-ave.${grid}.grib2.temp
+    tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_ave_24hrpm25_awp.${cycle}.${grid}
+
+    echo `ls -l  ${NET}.${cycle}.24hrpm25-ave.${grid}.grib2.temp | awk '{print $5} '` > filesize
+    export XLFRTEOPTS="unit_vars=yes"
+    export FORT11=${NET}.${cycle}.24hrpm25-ave.${grid}.grib2.temp
+    export FORT12="filesize"
+    export FORT31=
+    export FORT51=awpaqm.${cycle}.24hr-pm25-ave.${grid}.grib2
+    tocgrib2super < ${PARMaqm_utils}/wmo/grib2_aqm_ave_24hrpm25_awp.${cycle}.${grid}
+    
+    cp_vrfy ${DATA}/${NET}.${cycle}.ave_24hr_pm25*.grib2 ${COMOUT}
+    cp_vrfy ${DATA}/${NET}.${cycle}.max_1hr_pm25*.grib2 ${COMOUT}
+    cp_vrfy awpaqm.${cycle}.daily-1hr-pm25-max.${grid}.grib2 ${COMOUT}
+    cp_vrfy awpaqm.${cycle}.24hr-pm25-ave.${grid}.grib2 ${COMOUT}
+
+    if [ "$SENDDBN" = "YES" ]; then
+      ${DBNROOT}/bin/dbn_alert MODEL AQM_MAX ${job} ${COMOUT}/${NET}.${cycle}.ave_24hr_pm25.${grid}.grib2
+      ${DBNROOT}/bin/dbn_alert MODEL AQM_MAX ${job} ${COMOUT}/${NET}.${cycle}.max_1hr_pm25.${grid}.grib2
+    fi
+  done
+fi
+
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating successful completion of script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+POST-STAT-PM25 completed successfully.
+
+Exiting script:  \"${scrfunc_fn}\"
+In directory:    \"${scrfunc_dir}\"
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1

--- a/scripts/exregional_post_stat_pm25.sh
+++ b/scripts/exregional_post_stat_pm25.sh
@@ -115,7 +115,7 @@ EOF1
 
 # convert from netcdf to grib2 format
 PREP_STEP
-${EXECdir}/aqm_post_grib2 ${PDY} ${cyc} || print_err_msg_exit "\
+eval ${RUN_CMD_SERIAL} ${EXECdir}/aqm_post_grib2 ${PDY} ${cyc} ${REDIRECT_OUT_ERR} || print_err_msg_exit "\
 Call to executable to run AQM_POST_GRIB2 returned with nonzero exit code."
 POST_STEP
 
@@ -219,7 +219,7 @@ EOF1
   fi
 
   PREP_STEP
-  ${EXECdir}/aqm_post_maxi_grib2 ${PDY} ${cyc} ${chk} ${chk1} || print_err_msg_exit "\
+  eval ${RUN_CMD_SERIAL} ${EXECdir}/aqm_post_maxi_grib2 ${PDY} ${cyc} ${chk} ${chk1} ${REDIRECT_OUT_ERR} || print_err_msg_exit "\
   Call to executable to run AQM_POST_MAXI_GRIB2 returned with nonzero exit code."
   POST_STEP
 

--- a/scripts/exregional_pre_post_stat.sh
+++ b/scripts/exregional_pre_post_stat.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+#
+#-----------------------------------------------------------------------
+#
+# Source the variable definitions file and the bash utility functions.
+#
+#-----------------------------------------------------------------------
+#
+. $USHdir/source_util_funcs.sh
+source_config_for_task "cpl_aqm_parm" ${GLOBAL_VAR_DEFNS_FP}
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+{ save_shell_opts; . $USHdir/preamble.sh; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
+scrfunc_fn=$( basename "${scrfunc_fp}" )
+scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating entry into script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+Entering script:  \"${scrfunc_fn}\"
+In directory:     \"${scrfunc_dir}\"
+
+This is the ex-script for the task that runs POST-UPP-STAT.
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+# Set OpenMP variables.
+#
+#-----------------------------------------------------------------------
+#
+export KMP_AFFINITY=${KMP_AFFINITY_PRE_POST_STAT}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_PRE_POST_STAT}
+export OMP_STACKSIZE=${OMP_STACKSIZE_PRE_POST_STAT}
+#
+#-----------------------------------------------------------------------
+#
+# Set run command.
+#
+#-----------------------------------------------------------------------
+#
+eval ${PRE_TASK_CMDS}
+
+if [ -z "${RUN_CMD_SERIAL:-}" ] ; then
+  print_err_msg_exit "\
+  Run command was not set in machine file. \
+  Please set RUN_CMD_SERIAL for your platform"
+else
+  RUN_CMD_SERIAL=$(eval echo ${RUN_CMD_SERIAL})
+  print_info_msg "$VERBOSE" "
+  All executables will be submitted with command \'${RUN_CMD_SERIAL}\'."
+fi
+
+#
+#-----------------------------------------------------------------------
+#
+# Move to the working directory
+#
+#-----------------------------------------------------------------------
+#
+DATA="${DATA}/tmp_PRE_POST_STAT"
+rm_vrfy -r $DATA
+mkdir_vrfy -p "$DATA"
+cd_vrfy $DATA
+
+set -x
+
+if [ "${FCST_LEN_HRS}" = "-1" ]; then
+  for i_cdate in "${!ALL_CDATES[@]}"; do
+    if [ "${ALL_CDATES[$i_cdate]}" = "${PDY}${cyc}" ]; then
+      FCST_LEN_HRS="${FCST_LEN_CYCL[$i_cdate]}"
+      break
+    fi
+  done
+fi
+
+ist=1
+while [ "$ist" -le "${FCST_LEN_HRS}" ]; do
+  hst=$( printf "%03d" "${ist}" )
+
+  rm_vrfy -f ${DATA}/tmp*nc
+  rm_vrfy -f ${DATA}/${NET}.${cycle}.chem_sfc_f${hst}*nc
+  rm_vrfy -f ${DATA}/${NET}.${cycle}.met_sfc_f${hst}*nc
+
+  ncks -v lat,lon,o3_ave,no_ave,no2_ave,pm25_ave -d pfull,63,63 ${COMIN}/${NET}.${cycle}.dyn.f${hst}.nc ${DATA}/tmp2a.nc
+
+  ncks -C -O -x -v pfull ${DATA}/tmp2a.nc ${DATA}/tmp2b.nc
+
+  ncwa -a pfull ${DATA}/tmp2b.nc ${DATA}/tmp2c.nc
+
+  ncrename -v o3_ave,o3 -v no_ave,no -v no2_ave,no2 -v pm25_ave,PM25_TOT ${DATA}/tmp2c.nc
+
+  mv_vrfy ${DATA}/tmp2c.nc ${DATA}/${NET}.${cycle}.chem_sfc.f${hst}.nc
+
+  ncks -v dswrf,hpbl,tmp2m,ugrd10m,vgrd10m,spfh2m ${COMIN}/${NET}.${cycle}.phy.f${hst}.nc ${DATA}/${NET}.${cycle}.met_sfc.f${hst}.nc
+
+  (( ist=ist+1 ))
+done
+
+ist=1
+while [ "${ist}" -le "${FCST_LEN_HRS}" ]; do
+  hst=$( printf "%03d" "${ist}" )
+  ic=0
+  while [ $ic -lt 900 ]; do
+    if [ -s ${DATA}/${NET}.${cycle}.chem_sfc.f${hst}.nc ]; then
+      echo "${DATA}/${NET}.${cycle}.chem_sfc.f${hst}.nc" "exist!"
+      break
+    else
+      sleep 10
+      (( ic=ic+1 ))
+    fi
+  done
+  (( ist=ist+1 ))
+done
+
+ncecat ${DATA}/${NET}.${cycle}.chem_sfc.f*.nc  ${DATA}/${NET}.${cycle}.chem_sfc.nc
+
+#
+#-----------------------------------------------------------------------
+#
+# Move output to COMIN directory.
+#
+#-----------------------------------------------------------------------
+#
+mv_vrfy ${DATA}/${NET}.${cycle}.met_sfc.f*.nc ${COMIN}
+mv_vrfy ${DATA}/${NET}.${cycle}.chem_sfc.f*.nc ${COMIN}
+mv_vrfy ${DATA}/${NET}.${cycle}.chem_sfc.nc ${COMIN}
+#
+#-----------------------------------------------------------------------
+#
+# Print message indicating successful completion of script.
+#
+#-----------------------------------------------------------------------
+#
+print_info_msg "
+========================================================================
+PRE-POST-STAT completed successfully.
+
+Exiting script:  \"${scrfunc_fn}\"
+In directory:    \"${scrfunc_dir}\"
+========================================================================"
+#
+#-----------------------------------------------------------------------
+#
+{ restore_shell_opts; } > /dev/null 2>&1

--- a/scripts/exregional_pre_post_stat.sh
+++ b/scripts/exregional_pre_post_stat.sh
@@ -62,17 +62,6 @@ export OMP_STACKSIZE=${OMP_STACKSIZE_PRE_POST_STAT}
 #-----------------------------------------------------------------------
 #
 eval ${PRE_TASK_CMDS}
-
-if [ -z "${RUN_CMD_SERIAL:-}" ] ; then
-  print_err_msg_exit "\
-  Run command was not set in machine file. \
-  Please set RUN_CMD_SERIAL for your platform"
-else
-  RUN_CMD_SERIAL=$(eval echo ${RUN_CMD_SERIAL})
-  print_info_msg "$VERBOSE" "
-  All executables will be submitted with command \'${RUN_CMD_SERIAL}\'."
-fi
-
 #
 #-----------------------------------------------------------------------
 #
@@ -84,8 +73,6 @@ DATA="${DATA}/tmp_PRE_POST_STAT"
 rm_vrfy -r $DATA
 mkdir_vrfy -p "$DATA"
 cd_vrfy $DATA
-
-set -x
 
 if [ "${FCST_LEN_HRS}" = "-1" ]; then
   for i_cdate in "${!ALL_CDATES[@]}"; do


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Currently, the Online-CMAQ for air quality modeling is separately managed in the 'online-cmaq' branch of the authoritative UFS SRW App repository. The main target of the current 'online-cmaq' branch is the implementation of AQM ver.7 and delivery to NCO in late March. Therefore, it has been developed and tested on WCOSS2 and Hera. The Online-CMAQ checks out the same ufs weather model as the 'develop' branch. However, since it couples another component 'AQM', the compile process is different from that of the 'develop' branch.

This 'online-cmaq' branch is integrated into the 'develop' branch with this PR and the following two PRs. For the convenience of the reviewers, we split the 'online-cmaq' branch into three parts as follows:
- Part 1 (this PR): j-job and ex- scripts
- Part 2: build scripts and module files
- Part 3: workflow set-up, generation, run scripts

In Part1, we add extra j-job and ex- scripts only for Online-CMAQ. As these scripts are totally independent from the 'develop' branch, they do not affect any existing configurations and test cases at all.
In part2, we will modify the 'devbuild.sh' script and add 'Externals_AQM.cfg' to compile the coupled ufs weather model and extra external components for AQM. Same as Part 1, Part 2 will not affect any existing configurations and test cases.
In part3, we will update workflow set-up, generation, run scripts for Online-CMAQ as well as FV3-LAM (current 'develop' branch). New test cases should be added in this step. 

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
- WE2E tests:
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_2017_gfdlmp_regional
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_RAP_suite_HRRR
grid_RRFS_CONUScompact_25km_ics_HRRR_lbcs_HRRR_suite_RRFS_v1beta
grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15_thompson_mynn_lam3km
grid_RRFS_CONUScompact_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
grid_RRFS_NA_3km_ics_FV3GFS_lbcs_FV3GFS_suite_RRFS_v1beta
MET_verification
MET_ensemble_verification
community_ensemble_2mems_stoch

- [ ] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [x] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## ISSUE: 
Fixes issue mentioned in #534 

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

