### PR TITLE
[develop] Fix issue 541: correct error message when config.yaml has invalid entries

### DIFF
--- a/ush/python_utils/config_parser.py
+++ b/ush/python_utils/config_parser.py
@@ -465,25 +465,26 @@ def update_dict(dict_o, dict_t, provide_default=False):
 
 def check_structure_dict(dict_o, dict_t):
     """Check if a dictionary's structure follows a template.
-    The invalid entries are printed to the screen.
+    The invalid entries are returned as a list of lists.
+    If all entries are valid, returns an empty dictionary
 
     Args:
         dict_o: target dictionary
         dict_t: template dictionary to compare structure to
     Returns:
-        Boolean
+        inval:  dictionary of invalid key-value pairs
     """
+    inval = {}
     for k, v in dict_o.items():
         if k in dict_t.keys():
             v1 = dict_t[k]
             if isinstance(v, dict) and isinstance(v1, dict):
                 r = check_structure_dict(v, v1)
-                if not r:
-                    return False
+                if r:
+                    inval.update(r)
         else:
-            print(f"INVALID ENTRY: {k}={v}")
-            return False
-    return True
+            inval[k] = v
+    return inval
 
 
 def filter_dict(dict_o, keys_regex):
@@ -579,9 +580,11 @@ def cfg_main():
         cfg_t = load_config_file(args.validate, 1)
         r = check_structure_dict(cfg, cfg_t)
         if r:
-            print("SUCCESS")
-        else:
+            for k in r:
+                print(f"INVALID ENTRY: {k}={r[k]}")
             print("FAILURE")
+        else:
+            print("SUCCESS")
     else:
         if args.template:
             cfg = flatten_dict(cfg)

--- a/ush/python_utils/config_parser.py
+++ b/ush/python_utils/config_parser.py
@@ -472,7 +472,7 @@ def check_structure_dict(dict_o, dict_t):
         dict_o: target dictionary
         dict_t: template dictionary to compare structure to
     Returns:
-        inval:  dictionary of invalid key-value pairs
+        dict:  Invalid key-value pairs.
     """
     inval = {}
     for k, v in dict_o.items():

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -80,15 +80,13 @@ def load_config_for_setup(ushdir, default_config, user_config):
 
     # Make sure the keys in user config match those in the default
     # config.
-    if not check_structure_dict(cfg_u, cfg_d):
-        raise Exception(
-            dedent(
-                f"""
-                User-specified variable "{key}" in {user_config} is not valid
-                Check {EXPT_DEFAULT_CONFIG_FN} for allowed user-specified variables\n
-                """
-            )
-        )
+    invalid = check_structure_dict(cfg_u, cfg_d)
+    if invalid:
+        errmsg = "Invalid key(s) specified in {user_config}:\n"
+        for entry in invalid:
+            errmsg = errmsg + f"{entry} = {invalid[entry]}\n"
+        errmsg = errmsg + f"\nCheck {default_config} for allowed user-specified variables\n"
+        raise Exception(errmsg)
 
     # Mandatory variables *must* be set in the user's config; the default value is invalid
     mandatory = ["user.MACHINE"]


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This is actually two fixes/enhancements, one required by the other:

1. Fix error message that appears when user specifies an invalid key in their config.yaml file. The current version references undefined variables and appears to be a copy/paste error from some other exception.
2. In order to achieve the above neatly, I had to change the behavior of the python_utils function `check_structure_dict()`. Rather than simply printing the invalid key/value pair, it now returns a dictionary of invalid key/value pairs (that is empty if all keys are valid). I also fixed a minor bug here: even though this function *claimed* to detect all invalid entries, it actually only printed the first before returning. Now all invalid entries are returned.

With this change users will now see the following type of error if they specify one or more invalid keys in their config.yaml file:
```

*********************************************************************
FATAL ERROR:
Experiment generation failed. See the error message(s) printed below.
For more detailed information, check the log file from the workflow
generation script: /glade/scratch/kavulich/workdir/UFS/issue_541/ufs-srweather-app/ush/log.generate_FV3LAM_wflow
*********************************************************************

Traceback (most recent call last):
  File "/glade/scratch/kavulich/workdir/UFS/issue_541/ufs-srweather-app/ush/./generate_FV3LAM_wflow.py", line 774, in <module>
    generate_FV3LAM_wflow(USHdir, wflow_logfile)
  File "/glade/scratch/kavulich/workdir/UFS/issue_541/ufs-srweather-app/ush/./generate_FV3LAM_wflow.py", line 70, in generate_FV3LAM_wflow
    expt_config = setup(ushdir)
  File "/glade/scratch/kavulich/workdir/UFS/issue_541/ufs-srweather-app/ush/setup.py", line 297, in setup
    expt_config = load_config_for_setup(USHdir, default_config_fp, user_config_fp)
  File "/glade/scratch/kavulich/workdir/UFS/issue_541/ufs-srweather-app/ush/setup.py", line 89, in load_config_for_setup
    raise Exception(errmsg)
Exception: Invalid key(s) specified in {user_config}:
badvalue1 = bad
badvalue2 = 2019061500
badvalue3 = False

Check /glade/scratch/kavulich/workdir/UFS/issue_541/ufs-srweather-app/ush/config_defaults.yaml for allowed user-specified variables
```

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
Ran unit tests for python_utils which were successful. Ran several iterations of incorrect config.yaml entries on Hera and Cheyenne, which produced expected results. Also ran fundamental suite of tests on Hera as a sanity check, but this change should not impact correctly configured runs.

- [x] hera.intel
- [ ] orion.intel
- [x] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE: 
Fixes #541 

## CHECKLIST
<!-- Add an X to check off a box. -->
- [ ] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## CONTRIBUTORS: 
Thank you to @zmoon for taking the time to open an issue describing this problem.

