### PR TITLE
[develop] Fix failing unit test due to renamed variable

### DIFF
--- a/ush/config.community.yaml
+++ b/ush/config.community.yaml
@@ -6,7 +6,6 @@ user:
   MACHINE: hera
   ACCOUNT: an_account
 platform:
-  MODEL: FV3_GFS_v16_CONUS_25km
   MET_INSTALL_DIR: ""
   METPLUS_PATH: ""
   CCPA_OBS_DIR: ""
@@ -50,3 +49,5 @@ task_plot_allvars:
 global:
   DO_ENSEMBLE: false
   NUM_ENS_MEMBERS: 2
+verification:
+  VX_FCST_MODEL_NAME: FV3_GFS_v16_CONUS_25km

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -87,7 +87,7 @@ def load_config_for_setup(ushdir, default_config, user_config):
     # config.
     invalid = check_structure_dict(cfg_u, cfg_d)
     if invalid:
-        errmsg = "Invalid key(s) specified in {user_config}:\n"
+        errmsg = f"Invalid key(s) specified in {user_config}:\n"
         for entry in invalid:
             errmsg = errmsg + f"{entry} = {invalid[entry]}\n"
         errmsg = errmsg + f"\nCheck {default_config} for allowed user-specified variables\n"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
PR #566 changed the variable "MODEL" to a more descriptive name, but failed to make this change in `config.community.yaml`. The unit tests for `generate_FV3LAM_wflow.py` make use of this file as an input config.yaml, so they are now failing due to this incorrect variable name. This wasn't caught because prior to #558 the unit tests were broken for a different reason. 

This change simply makes the appropriate rename, which should fix the failing unit test. Also created an f-string that was missed in a setup.py error message.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
This change only impacts the unit tests or other uses of `config.community.yaml`, so all tests should pass. Out of an abundance of caution, running fundamental tests on Jet (Hera is down today).

- [x] jet.intel (pending)
- [x] fundamental test suite

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE: 
None

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
