### PR TITLE
[develop] Fix for error at the end of monitor_jobs.py, other minor improvements

### DIFF
--- a/tests/WE2E/monitor_jobs.py
+++ b/tests/WE2E/monitor_jobs.py
@@ -81,7 +81,7 @@ def monitor_jobs(expt_dict: dict, monitor_file: str = '', debug: bool = False) -
     endtime = datetime.now()
     total_walltime = endtime - starttime
 
-    logging.info(f'All {num_expts} experiments finished in {str(total_walltime)}')
+    logging.info(f'All {len(running_expts)} experiments finished in {str(total_walltime)}')
 
     return monitor_file
 

--- a/tests/WE2E/monitor_jobs.py
+++ b/tests/WE2E/monitor_jobs.py
@@ -46,7 +46,7 @@ def monitor_jobs(expt_dict: dict, monitor_file: str = '', debug: bool = False) -
     logging.info("Checking tests available for monitoring...")
     for expt in expt_dict:
         logging.info(f"Starting experiment {expt} running")
-        expt_dict[expt] = update_expt_status(expt_dict[expt], expt)
+        expt_dict[expt] = update_expt_status(expt_dict[expt], expt, True)
 
     write_monitor_file(monitor_file,expt_dict)
 
@@ -81,11 +81,11 @@ def monitor_jobs(expt_dict: dict, monitor_file: str = '', debug: bool = False) -
     endtime = datetime.now()
     total_walltime = endtime - starttime
 
-    logging.info(f'All {len(running_expts)} experiments finished in {str(total_walltime)}')
+    logging.info(f'All {len(expt_dict)} experiments finished in {str(total_walltime)}')
 
     return monitor_file
 
-def update_expt_status(expt: dict, name: str) -> dict:
+def update_expt_status(expt: dict, name: str, refresh: bool = False) -> dict:
     """
     This function reads the dictionary showing the location of a given experiment, runs a
     `rocotorun` command to update the experiment (running new jobs and updating the status of
@@ -121,15 +121,18 @@ def update_expt_status(expt: dict, name: str) -> dict:
              to ensure there are no un-submitted jobs. We will no longer monitor this experiment.
 
     Args:
-        expt (dict): A dictionary containing the information for an individual experiment, as
-                     described in the main monitor_jobs() function.
-        name  (str): [optional]
+        expt    (dict):    A dictionary containing the information for an individual experiment, as
+                           described in the main monitor_jobs() function.
+        name     (str):    Name of the experiment; used for logging only
+        refresh (bool):    If true, this flag will check an experiment status even if it is listed
+                           as DEAD, ERROR, or COMPLETE. Used for initial checks for experiments
+                           that may have been restarted.
     Returns:
         dict: The updated experiment dictionary.
     """
 
     #If we are no longer tracking this experiment, return unchanged
-    if expt["status"] in ['DEAD','ERROR','COMPLETE']:
+    if (expt["status"] in ['DEAD','ERROR','COMPLETE']) and not refresh:
         return expt
 
     # Update experiment, read rocoto database

--- a/tests/WE2E/run_WE2E_tests.py
+++ b/tests/WE2E/run_WE2E_tests.py
@@ -179,7 +179,7 @@ def run_we2e_tests(homedir, args) -> None:
         with open(ushdir + "/config.yaml","w") as f:
             f.writelines(cfg_to_yaml_str(test_cfg))
 
-        logging.debug(f"Calling workflow generation function for test {test_name}\n")
+        logging.info(f"Calling workflow generation function for test {test_name}\n")
         if args.quiet:
             console_handler = logging.getLogger().handlers[1]
             console_handler.setLevel(logging.WARNING)

--- a/tests/WE2E/run_WE2E_tests.py
+++ b/tests/WE2E/run_WE2E_tests.py
@@ -40,6 +40,11 @@ def run_we2e_tests(homedir, args) -> None:
     run_envir = args.run_envir
     machine = args.machine.lower()
 
+    # Check for invalid input
+    if run_envir:
+        if run_envir not in ['nco', 'community']:
+            raise KeyError(f"Invalid 'run_envir' provided: {run_envir}")
+
     # If args.tests is a list of length more than one, we assume it is a list of test names
     if len(args.tests) > 1:
         tests_to_check=args.tests
@@ -134,6 +139,10 @@ def run_we2e_tests(homedir, args) -> None:
         test_cfg['user'].update({"ACCOUNT": args.account})
         if run_envir:
             test_cfg['user'].update({"RUN_ENVIR": run_envir})
+            if run_envir == "nco":
+                if 'nco' not in test_cfg:
+                    test_cfg['nco'] = dict()
+                test_cfg['nco'].update({"model_ver": "we2e"})
         # if platform section was not in input config, initialize as empty dict
         if 'platform' not in test_cfg:
             test_cfg['platform'] = dict()

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -201,7 +201,7 @@ def load_config_for_setup(ushdir, default_config, user_config):
             raise Exception(
                 dedent(
                     f"""
-                            Date variable {val}={cfg_d['user'][val]} is not in a valid date format.
+                            Date variable {val}={cfg_d['workflow'][val]} is not in a valid date format.
 
                             For examples of valid formats, see the Users' Guide.
                             """


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This is another round of improvements for the pythonized WE2E test scripts. I was originally going to wait until the script was ready to replace, but I accidentally forgot to make a change to a final log message in monitor_jobs.py; this results in a scary-looking error message even though all experiments may have completed successfully.
```
calling function that monitors jobs, prints summary
Writing information for all experiments to monitor_jobs_20230208170852.yaml
Checking tests available for monitoring...
Starting experiment get_from_HPSS_ics_GDAS_lbcs_GDAS_fmt_netcdf_2022040400_ensemble_2mems running
Setup complete; monitoring 1 experiments
Experiment get_from_HPSS_ics_GDAS_lbcs_GDAS_fmt_netcdf_2022040400_ensemble_2mems is COMPLETE; will no longer monitor.

*********************************************************************
FATAL ERROR:
Experiment generation failed. See the error message(s) printed below.
For more detailed information, check the log file from the workflow
generation script: log.run_WE2E_tests
*********************************************************************

Traceback (most recent call last):
  File "/mnt/lfs4/HFIP/hfv3gfs/Michael.Lueken/new_tests/tests/WE2E/./run_WE2E_tests.py", line 461, in <module>
    run_we2e_tests(homedir,args)
  File "/mnt/lfs4/HFIP/hfv3gfs/Michael.Lueken/new_tests/tests/WE2E/./run_WE2E_tests.py", line 195, in run_we2e_tests
    monitor_file = monitor_jobs(monitor_yaml, debug=args.debug)
  File "/mnt/lfs4/HFIP/hfv3gfs/Michael.Lueken/new_tests/tests/WE2E/monitor_jobs.py", line 84, in monitor_jobs
    logging.info(f'All {num_expts} experiments finished in {str(total_walltime)}')
NameError: name 'num_expts' is not defined
```

The solution was simply to replace the undefined variable with a correct one.

This PR comes from an in-progress branch for improvements to the python scripts, so a few other improvements are coming along with this bug fix:

 - When monitor_jobs.py is called for the first time, it will check the status of *all* jobs, not just those that are incomplete. This will allow users to use this script to monitor a previously failed job that has been fixed.
 - Add checks for proper `run_envir`, and add all needed variables for `run_envir=nco` mode.
 - Fix another incorrect error message in setup.py

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
This change mostly impacts the new python-based tests which are not yet used for official testing. Ran some tests on Hera to ensure the problem with the WE2E testin scripts was fixed. Also running fundamental tests on Hera and Jet due to change in setup.py.

- [x] hera.intel
- [x] jet.intel

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE: 
Related to #586, more work needed.

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes


## CONTRIBUTORS (optional): 
Thanks to @MichaelLueken for pointing out the error.