### PR TITLE
[develop]: Update for Gaea software stack location and Lmod initialization script 

### DIFF
--- a/etc/lmod-setup.csh
+++ b/etc/lmod-setup.csh
@@ -36,7 +36,11 @@ else if ( "$L_MACHINE" == singularity ) then
    module purge
 
 else if ( "$L_MACHINE" == gaea ) then
-   source /lustre/f2/dev/role.epic/contrib/Lmod_init.csh
+   set ENV="/lustre/f2/dev/role.epic/contrib/apps/lmod/lmod/init/csh"
+   source $ENV
+
+   setenv LMOD_SYSTEM_DEFAULT_MODULES "modules/3.2.11.4"
+   module --initial_load --no_redirect restore
 
 else if ( "$L_MACHINE" == odin ) then
    module unload modules

--- a/etc/lmod-setup.csh
+++ b/etc/lmod-setup.csh
@@ -36,11 +36,7 @@ else if ( "$L_MACHINE" == singularity ) then
    module purge
 
 else if ( "$L_MACHINE" == gaea ) then
-   set ENV="/lustre/f2/dev/role.epic/contrib/apps/lmod/lmod/init/csh"
-   source $ENV
-
-   setenv LMOD_SYSTEM_DEFAULT_MODULES "modules/3.2.11.4"
-   module --initial_load --no_redirect restore
+   source /lustre/f2/dev/role.epic/contrib/Lmod_init.sh
 
 else if ( "$L_MACHINE" == odin ) then
    module unload modules

--- a/etc/lmod-setup.csh
+++ b/etc/lmod-setup.csh
@@ -36,7 +36,7 @@ else if ( "$L_MACHINE" == singularity ) then
    module purge
 
 else if ( "$L_MACHINE" == gaea ) then
-   source /lustre/f2/dev/role.epic/contrib/Lmod_init.sh
+   source /lustre/f2/dev/role.epic/contrib/Lmod_init.csh
 
 else if ( "$L_MACHINE" == odin ) then
    module unload modules

--- a/etc/lmod-setup.sh
+++ b/etc/lmod-setup.sh
@@ -43,11 +43,8 @@ elif [ "$L_MACHINE" = singularity ]; then
    module purge
 
 elif [ "$L_MACHINE" = gaea ]; then
-   export BASH_ENV="/lustre/f2/dev/role.epic/contrib/apps/lmod/lmod/init/bash"
-   source $BASH_ENV
+   source /lustre/f2/dev/role.epic/contrib/Lmod_init.sh
 
-   export LMOD_SYSTEM_DEFAULT_MODULES="modules/3.2.11.4"
-   module --initial_load --no_redirect restore
 elif [ "$L_MACHINE" = odin ]; then
    module unload modules
    unset -f module

--- a/modulefiles/build_gaea_intel.lua
+++ b/modulefiles/build_gaea_intel.lua
@@ -7,7 +7,7 @@ whatis([===[Loads libraries needed for building the UFS SRW App on Gaea ]===])
 
 load(pathJoin("cmake", os.getenv("cmake_ver") or "3.20.1"))
 
-prepend_path("MODULEPATH","/lustre/f2/dev/role.epic/contrib/hpc-stack/intel-2021.3.0/modulefiles/stack")
+prepend_path("MODULEPATH","/lustre/f2/dev/role.epic/contrib/hpc-stack/intel-2021.3.0_noarch/modulefiles/stack")
 load(pathJoin("hpc", os.getenv("hpc_ver") or "1.2.0"))
 load(pathJoin("intel", os.getenv("intel_ver") or "2021.3.0"))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver") or "2021.3.0"))


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Gaea hpc-stack location has changed to match that for the UFS-WM that results in all regression test passed successfully.
Lmod initialization has been updated as well, similar to the one that worked for the UFS-WM to pass RTs. It is done by sourcing a single initialization script.

Files changed:
**./modulefiles/build_gaea_intel.lua
./etc/lmod-setup.sh**
UPDATE: ./etc/lmod-setup.csh is not changed

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
UFS-WM has passed all the regression tests using this updated hpc-stack location.
The SRW code has successfully compiled.

<!-- Add an X to check off a box. -->

- [x] gaea.intel


## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
Update for the UFS-WM that passed all the regression tests is made in
[this PR:](https://github.com/ufs-community/ufs-weather-model/pull/1617)

- https://github.com/ufs-community/ufs-weather-model/pull/1617

It is update for the earlier PR-419: https://github.com/ufs-community/ufs-srweather-app/pull/419

## DOCUMENTATION:

## ISSUE: 

This PR finalized the transition to use of EPIC-maintained hpc-stack on NOAA Tier 1 systems (Hera, Gaea, Orion, Jet, Cheyenne)



## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 

- [ ] Work In Progress
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests



