### PR TITLE
[develop] Fixed issue #649 and tested on cheyenne.

### DIFF
--- a/scripts/exregional_aqm_lbcs.sh
+++ b/scripts/exregional_aqm_lbcs.sh
@@ -215,7 +215,7 @@ Please ensure that you've built this executable."
 #----------------------------------------------------------------------
 #
   PREP_STEP
-  eval ${RUN_CMD_UTILS} ${exec_fp} -n ${NUMTS} ${REDIRECT_OUT_ERR} || \
+  eval ${RUN_CMD_AQMLBC} ${exec_fp} ${REDIRECT_OUT_ERR} || \
     print_err_msg_exit "\
 Call to executable (exec_fp) to generate chemical and GEFS LBCs
 file for RRFS-CMAQ failed:

--- a/scripts/exregional_aqm_lbcs.sh
+++ b/scripts/exregional_aqm_lbcs.sh
@@ -215,7 +215,7 @@ Please ensure that you've built this executable."
 #----------------------------------------------------------------------
 #
   PREP_STEP
-  eval ${RUN_CMD_UTILS} -n ${NUMTS} ${exec_fp} ${REDIRECT_OUT_ERR} || \
+  eval ${RUN_CMD_UTILS} ${exec_fp} -n ${NUMTS} ${REDIRECT_OUT_ERR} || \
     print_err_msg_exit "\
 Call to executable (exec_fp) to generate chemical and GEFS LBCs
 file for RRFS-CMAQ failed:

--- a/ush/config_defaults.yaml
+++ b/ush/config_defaults.yaml
@@ -199,6 +199,9 @@ platform:
   # RUN_CMD_AQM:
   # The run command for some AQM tasks.
   #
+  # RUN_CMD_AQMLBC:
+  # The run command for the AQM_LBCS task.
+  #
   #-----------------------------------------------------------------------
   #
   RUN_CMD_SERIAL: ""
@@ -206,6 +209,7 @@ platform:
   RUN_CMD_FCST: ""
   RUN_CMD_POST: ""
   RUN_CMD_AQM: ""
+  RUN_CMD_AQMLBC: ""
 
   #
   #-----------------------------------------------------------------------

--- a/ush/machine/cheyenne.yaml
+++ b/ush/machine/cheyenne.yaml
@@ -16,6 +16,7 @@ platform:
   RUN_CMD_POST: mpirun -np $nprocs
   RUN_CMD_SERIAL: time
   RUN_CMD_UTILS: mpirun -np $nprocs
+  RUN_CMD_AQMLBC: mpirun -np ${NUMTS}
   PRE_TASK_CMDS: '{ ulimit -s unlimited; ulimit -a; }'
   TEST_EXTRN_MDL_SOURCE_BASEDIR: /glade/p/ral/jntp/UFS_SRW_App/develop/input_model_data
   TEST_PREGEN_BASEDIR: /glade/p/ral/jntp/UFS_SRW_App/develop/FV3LAM_pregen

--- a/ush/machine/cheyenne.yaml
+++ b/ush/machine/cheyenne.yaml
@@ -16,6 +16,7 @@ platform:
   RUN_CMD_POST: mpirun -np $nprocs
   RUN_CMD_SERIAL: time
   RUN_CMD_UTILS: mpirun -np $nprocs
+  RUN_CMD_AQM: mpirun -np $nprocs
   RUN_CMD_AQMLBC: mpirun -np ${NUMTS}
   PRE_TASK_CMDS: '{ ulimit -s unlimited; ulimit -a; }'
   TEST_EXTRN_MDL_SOURCE_BASEDIR: /glade/p/ral/jntp/UFS_SRW_App/develop/input_model_data

--- a/ush/machine/hera.yaml
+++ b/ush/machine/hera.yaml
@@ -17,6 +17,7 @@ platform:
   QUEUE_HPSS: batch
   RUN_CMD_FCST: srun --export=ALL
   RUN_CMD_POST: srun --export=ALL
+  RUN_CMD_AQMLBC: srun --export=ALL -n ${NUMTS}
   RUN_CMD_SERIAL: time
   RUN_CMD_UTILS: srun --export=ALL
   RUN_CMD_AQM: srun -n ${nprocs} --export=ALL

--- a/ush/machine/hera.yaml
+++ b/ush/machine/hera.yaml
@@ -17,10 +17,10 @@ platform:
   QUEUE_HPSS: batch
   RUN_CMD_FCST: srun --export=ALL
   RUN_CMD_POST: srun --export=ALL
-  RUN_CMD_AQMLBC: srun --export=ALL -n ${NUMTS}
   RUN_CMD_SERIAL: time
   RUN_CMD_UTILS: srun --export=ALL
   RUN_CMD_AQM: srun -n ${nprocs} --export=ALL
+  RUN_CMD_AQMLBC: srun --export=ALL -n ${NUMTS}
   SCHED_NATIVE_CMD: --export=NONE
   PRE_TASK_CMDS: '{ ulimit -s unlimited; ulimit -a; }'
   TEST_EXTRN_MDL_SOURCE_BASEDIR: /scratch2/BMC/det/UFS_SRW_App/develop/input_model_data

--- a/ush/machine/orion.yaml
+++ b/ush/machine/orion.yaml
@@ -20,6 +20,7 @@ platform:
   RUN_CMD_SERIAL: time
   RUN_CMD_UTILS: srun --export=ALL
   RUN_CMD_AQM: srun --export=ALL
+  RUN_CMD_AQMLBC: srun --export=ALL -n ${NUMTS}
   SCHED_NATIVE_CMD: --export=NONE
   PRE_TASK_CMDS: '{ ulimit -s unlimited; ulimit -a; }'
   TEST_EXTRN_MDL_SOURCE_BASEDIR: /work/noaa/fv3-cam/UFS_SRW_App/develop/input_model_data

--- a/ush/machine/wcoss2.yaml
+++ b/ush/machine/wcoss2.yaml
@@ -17,6 +17,7 @@ platform:
   RUN_CMD_SERIAL: mpiexec
   RUN_CMD_UTILS: mpiexec -n ${nprocs}
   RUN_CMD_AQM: mpiexec -n ${nprocs} -ppn ${ppn_run_aqm} --cpu-bind core -depth ${omp_num_threads_run_aqm}
+  RUN_CMD_AQMLBC: mpiexec -n ${NUMTS}
   SCHED_NATIVE_CMD: -l place=excl
   PRE_TASK_CMDS: '{ ulimit -s unlimited; ulimit -a; }'
   TEST_EXTRN_MDL_SOURCE_BASEDIR: /lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/input_model_data


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Please review this one-line change, that I believe resolves issue #649. As far as I can tell, the problem was a typo that places the '-n ${NUMTS}' argument *before* the gefs2lbc_para executable instead of after. This causes mpirun to fail on cheyenne because it's an invalid mpirun argument.


### Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
Now runs on cheyenne with RUN_TASK_AQM_LBCS and DO_AQM_GEFS_LBCS both set to true. I have extensive local configuration changes that allow the overall workflow to run on cheyenne. I have no access to Hera, Orion, WCOSS3, etc.

## ISSUE: 
https://github.com/ufs-community/ufs-srweather-app/issues/649

