### PR TITLE
[develop] Added environment variable LDFLAGS on macOS as requested by the corresponding module file

### DIFF
--- a/devbuild.sh
+++ b/devbuild.sh
@@ -450,7 +450,7 @@ else
     module use ${SRW_DIR}/modulefiles
     module load ${MODULE_FILE}
     if [[ "${MODULE_FILE}" == "build_macos_gnu" ]]; then
-        export LDFLAGS="-L$MPI_ROOT/lib "
+        export LDFLAGS+=" -L$MPI_ROOT/lib "
     fi
 fi
 module list

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -118,7 +118,7 @@ CONTINUE=false
 VERBOSE=false
 
 # Turn off all apps to build and choose default later
-DEFAULT_BUILD=true 
+DEFAULT_BUILD=true
 BUILD_UFS="off"
 BUILD_UFS_UTILS="off"
 BUILD_UPP="off"
@@ -263,7 +263,7 @@ fi
 RUN_VERSION_FILE="${SRW_DIR}/versions/run.ver.${PLATFORM}"
 if [ -f ${RUN_VERSION_FILE} ]; then
   . ${RUN_VERSION_FILE}
-fi 
+fi
 
 # set MODULE_FILE for this platform/compiler combination
 MODULE_FILE="build_${PLATFORM}_${COMPILER}"
@@ -352,7 +352,7 @@ if [ "${APPLICATION}" = "ATMAQ" ]; then
     cp "${SRW_DIR}/sorc/UFS_UTILS/modulefiles/build.${PLATFORM}.${COMPILER}.lua" "${EXTRN_BUILD_MOD_DIR}/mod_ufs-utils.lua"
   fi
   if [ "${BUILD_UPP}" = "on" ]; then
-    cp "${SRW_DIR}/sorc/UPP/modulefiles/${PLATFORM}.lua" "${EXTRN_BUILD_MOD_DIR}/mod_upp.lua" 
+    cp "${SRW_DIR}/sorc/UPP/modulefiles/${PLATFORM}.lua" "${EXTRN_BUILD_MOD_DIR}/mod_upp.lua"
   fi
   if [ "${BUILD_NEXUS}" = "on" ]; then
     cp "${SRW_DIR}/sorc/AQM-utils/parm/nexus_modulefiles/${PLATFORM}.${COMPILER}.lua" "${EXTRN_BUILD_MOD_DIR}/mod_nexus.lua"
@@ -449,6 +449,9 @@ if [ $USE_SUB_MODULES = true ]; then
 else
     module use ${SRW_DIR}/modulefiles
     module load ${MODULE_FILE}
+    if [[ "${MODULE_FILE}" == "build_macos_gnu" ]]; then
+        export LDFLAGS="-L$MPI_ROOT/lib "
+    fi
 fi
 module list
 

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -449,7 +449,7 @@ if [ $USE_SUB_MODULES = true ]; then
 else
     module use ${SRW_DIR}/modulefiles
     module load ${MODULE_FILE}
-    if [[ "${MODULE_FILE}" == "build_macos_gnu" ]]; then
+    if [[ "${PLATFORM}" == "macos" ]]; then
         export LDFLAGS+=" -L$MPI_ROOT/lib "
     fi
 fi

--- a/modulefiles/build_macos_gnu.lua
+++ b/modulefiles/build_macos_gnu.lua
@@ -60,7 +60,7 @@ setenv("FFLAGS", " -DNO_QUAD_PRECISION -fallow-argument-mismatch ")
 if mode() == "load" then
   LmodMsgRaw([===[
    Please export env. variable LDFLAGS after the module is successfully loaded:
-       > export LDFLAGS=\"-L\$MPI_ROOT/lib \" "
+       > export LDFLAGS+=\"-L\$MPI_ROOT/lib \" "
   ]===])
 end
 

--- a/modulefiles/build_macos_gnu.lua
+++ b/modulefiles/build_macos_gnu.lua
@@ -60,7 +60,7 @@ setenv("FFLAGS", " -DNO_QUAD_PRECISION -fallow-argument-mismatch ")
 if mode() == "load" then
   LmodMsgRaw([===[
    Please export env. variable LDFLAGS after the module is successfully loaded:
-       > export LDFLAGS+=\"-L\$MPI_ROOT/lib \" "
+       > export LDFLAGS+=" -L$MPI_ROOT/lib " 
   ]===])
 end
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

On macOS with GNU compiler, once the module file _build_macos_gnu.lua_ is loaded, it outputs a message to request for setting environment variable **LDFLAGS**:

>    Please export env. variable LDFLAGS after the module is successfully loaded:
>        > export LDFLAGS=\"-L\$MPI_ROOT/lib \" "
>   %

When using script _devbuild.sh_ however, it does not give users a chance to read/set this environment variable. I added three lines in the script _devbuild.sh_, which will set this environment variable automatically when the module **build_macos_gnu** is detected.

>     if [[ "${MODULE_FILE}" == "build_macos_gnu" ]]; then
>         export LDFLAGS="-L$MPI_ROOT/lib "
>     fi

This will make script _devbuild.sh_ working on macOS as it is on other platforms and will also avoid a _library not found_ error on macOS.

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 

It is tested on Mac OS Monterey using GNU compiler and the latest HPC-stack installation (from develop branch). It should not affect the performance of this script on other platforms and it is also confirmed on Jet using Intel compiler.

<!-- Add an X to check off a box. -->

- [ ] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [x] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:

None

## DOCUMENTATION:
N/A

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 

A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [x] bug
- [x] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted


