### PR TITLE
[develop] Fix retrieve data.

### DIFF
--- a/tests/WE2E/run_WE2E_tests.py
+++ b/tests/WE2E/run_WE2E_tests.py
@@ -8,7 +8,7 @@ import logging
 from textwrap import dedent
 from datetime import datetime
 
-sys.path.append("../../ush")
+sys.path.insert(0, "../../ush")
 
 from generate_FV3LAM_wflow import generate_FV3LAM_wflow
 from python_utils import (

--- a/tests/WE2E/run_WE2E_tests.py
+++ b/tests/WE2E/run_WE2E_tests.py
@@ -8,7 +8,7 @@ import logging
 from textwrap import dedent
 from datetime import datetime
 
-sys.path.insert(0, "../../ush")
+sys.path.insert(1, "../../ush")
 
 from generate_FV3LAM_wflow import generate_FV3LAM_wflow
 from python_utils import (

--- a/ush/retrieve_data.py
+++ b/ush/retrieve_data.py
@@ -609,11 +609,11 @@ def hpss_requested_files(cla, file_names, store_specs, members=-1, ens_group=-1)
             # something has gone wrong.
             unavailable = set.union(*unavailable.values())
         
-        # Break loop if unexpected files were found or if files were found
-        # A successful file found does not equal the expected file list and 
-        # returns an empty set function.
-        if not expected == unavailable:
-            return unavailable - expected
+    # Break loop if unexpected files were found or if files were found
+    # A successful file found does not equal the expected file list and 
+    # returns an empty set function.
+    if not expected == unavailable:
+        return unavailable - expected
     
     # If this loop has completed successfully without returning early, then all files have been found
     return {}


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more paragraphs describing the problem, solution, and required changes. -->

Fix a whitespace issue that leads to pre-mature exit when looking through the possible archive internal directories.

Also addresses an issue uncovered when a user has a pre-existing PYTHONPATH set. We should be prepending the path instead of appending it so that we override any other clones a user might have in their PYTHONPATH.

This fixes an issue with the `nco_grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_timeoffset_suite_GFS_v16` test.

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [x] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [x] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

Several manual tests were run in conjunction with @MichaelLueken and @mkavulich to isolate the sort of behavior that led to the failure for the NCO test. The Intel fundamental tests were run in a clean clone in a different directory structure than my usual (see below) to ensure that the NCO directories were indeed "fresh".

After the failure was identified a few different tests were run with the user PYTHONPATH set to other clones' ush dirs. This type of failure is addressed by the "prepend" instead of the "append" in the "run tests" script.


## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
- ufs-community/regional_workflow/pull/<pr_number>
- ufs-community/UFS_UTILS/pull/<pr_number>
- ufs-community/ufs-weather-model/pull/<pr_number> -->

n/a

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->

n/a

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here (Remember, issues must always be created before starting work on a PR branch!). For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/ufs-community/other_repository/pull/63" -->

Related to bug in Issue #652 

The intermittent nature of that failure could be explained by the location of the tester's clone, and how the NCO directories are set. For example, I personally tend to cloning the repo with a different name under the same directory, and have forever. This means that all my tests for all repos forever have had the same NCO directories by default. So, way back when this test wasn't broken, I pulled the data and it has lived there on disk since, so all my fundamental tests pass.

When I clone the repo anywhere else and run the fundamental tests, I observe the data failure associated with not finding the data in the correct internal archive directory structure. The get_data_* test do not complain, and the make_ics and make_lbcs tasks fail with no data.

I believe this is why some folks may have seen intermittent or random failures, as outlined in Issue #652.

## CHECKLIST
<!-- Add an X to check off a box. -->
- [ ] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published


## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
Thanks @mkavulich @MichaelLueken for running tests to help isolate the problem!
