### PR TITLE
[production/AQM.v7] Code merge for ecflow updates into the production/AQM.v7 #cf184119

### DIFF
--- a/docs/ECFLOW_NCO
+++ b/docs/ECFLOW_NCO
@@ -1,0 +1,28 @@
+The condition of the current AQM package production/AQM.v7 #cf184119b. 
+
+The package is currently under develop. Not ready for NCO code delivery.
+This document is subject to be changed every time the production/AQM.v7 package update. 
+
+Background:
+This is the code delivery instruction for NCO SPA team. It outlines the ecflow workflow and condition of using it on the current AQM package.
+
+The following condition have impact to the configuration of the ecflow workflow:
+- Forecast restart does not reproduce:
+    ECF_TRIES should be set to 1. 
+    The RESTART directory under the COM and the DATA directory of the failed forecast job need to be removed before a rerun can be started. 
+- The executable gefs2lbc_para used by job aqm_lbcs unstable. It unpredictably failed sometimes during execution:
+    ECF_TRIES should be set to 2.
+- There are four jobs that write output in its DATA location for other jobs to access. Therefore these four jobs can not remove the DATA when the job is completed. There are nexus_gfs_sfc, forecast, get_extrn_ics, and get_extrn_lbcs:
+    These four jobs will not use the NCO's KEEPDATA clean up procedure.
+    The AQM ecflow workflow has a dedicated job data_cleanup to do the DATA cleaning for these four jobs.
+
+NCO ECFLOW setup steps:
+(1) Configure ecflow include files to use AQM version identified in $HOMEaqm/versions/run.ver
+(2) Modify ecflow definition file with NCO production time based trigger as needed.
+(3) Add ecflow suite to NCO ECFLOW test suite.
+(4) Create AQM COM, AQM bias correction output location
+(5) Copy ICS from EMC AQM developer to AQM COM
+(6) Copy AQM bias data from EMC AQM developer to AQM bias correction output location.
+(7) Setup PDY
+(8) Start AQM ecflow workflow jobs
+

--- a/ecf/defs/aqm-cycled.def
+++ b/ecf/defs/aqm-cycled.def
@@ -1,0 +1,818 @@
+extern /totality_limit:TOTALITY
+extern /cycled_v16_3/primary/00/gfs/v16.3/gfs/jgfs_forecast
+extern /cycled_v16_3/primary/06/gfs/v16.3/gfs/jgfs_forecast
+extern /cycled_v16_3/primary/12/gfs/v16.3/gfs/jgfs_forecast
+extern /cycled_v16_3/primary/18/gfs/v16.3/gfs/jgfs_forecast
+
+suite emc_aqm
+  inlimit /totality_limit:TOTALITY
+  family primary
+    edit aqm_ver 'v7.0.46'
+    edit PACKAGEHOME '/lfs/h2/emc/global/noscrub/%EMC_USER%/para/packages/aqm.%aqm_ver%'
+    edit NET 'aqm'
+    edit RUN 'aqm'
+    edit PROJ 'AQM'
+    edit PROJENVIR 'DEV'
+    edit MACHINE_SITE 'development' 
+    edit ENVIR 'prod'
+    edit QUEUE 'dev'
+    edit QUEUE_ARCH 'dev_transfer'
+    edit OUTPUTDIR '/lfs/h2/emc/ptmp/%EMC_USER%/ecflow_aqm/para/output/prod/today'
+    family 00
+      edit CYC '00'
+      family aqm
+        family v1.0
+          edit ECF_FILES '%PACKAGEHOME%/ecf/scripts'
+          family nexus
+            task jnexus_gfs_sfc
+              trigger /cycled_v16_3/primary/18/gfs/v16.3/gfs/jgfs_forecast==complete or ../../../../18/aqm/v1.0/aqm_manager/aqm_manager:release_next_cycle
+              # NCO replace with time based trigger
+            task jnexus_emission_00
+              edit NSPT '00'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_01
+              edit NSPT '01'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_02
+              edit NSPT '02'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_03
+              edit NSPT '03'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_04
+              edit NSPT '04'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_05
+              edit NSPT '05'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_post_split
+              trigger ./jnexus_emission_00==complete and ./jnexus_emission_01==complete and ./jnexus_emission_02==complete
+          endfamily
+          family prep
+            task jget_extrn_ics
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+            task jget_extrn_lbcs
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+            task jmake_ics
+              trigger ./jget_extrn_ics==complete
+            task jmake_lbcs
+              trigger ./jget_extrn_lbcs==complete
+            task jics
+              trigger ./jmake_ics==complete
+            task jlbcs
+              trigger ./jmake_lbcs==complete
+          endfamily
+          family pts_fire_emis
+            task jpoint_source
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+            task jfire_emission
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+          endfamily
+          family forecast
+            task jforecast
+              trigger ../nexus==complete and ../prep==complete and ../pts_fire_emis==complete
+          endfamily
+          family post
+            task jpost_f000
+              edit FHR '000'
+              trigger ../forecast==complete
+            task jpost_f001
+              edit FHR '001'
+              trigger ../forecast==complete
+            task jpost_f002
+              edit FHR '002'
+              trigger ../forecast==complete
+            task jpost_f003
+              edit FHR '003'
+              trigger ../forecast==complete
+            task jpost_f004
+              edit FHR '004'
+              trigger ../forecast==complete
+            task jpost_f005
+              edit FHR '005'
+              trigger ../forecast==complete
+            task jpost_f006
+              edit FHR '006'
+              trigger ../forecast==complete
+          endfamily
+          family product
+            task jpre_post_stat
+              trigger ../forecast==complete
+            task jpost_stat_o3
+              trigger ./jpre_post_stat==complete
+            task jpost_stat_pm25
+              trigger ./jpre_post_stat==complete
+            task jbias_correction_o3
+              trigger ./jpre_post_stat==complete
+            task jbias_correction_pm25
+              trigger ./jpre_post_stat==complete
+          endfamily
+          family aqm_manager
+            task aqm_manager
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+              event 1 release_next_cycle
+              event 2 requeue_cycle
+            task data_cleanup
+              trigger ../forecast==complete
+          endfamily
+        endfamily  # v1.0
+      endfamily    # aqm
+    endfamily      # 00
+    family 06
+      edit CYC '06'
+      family aqm
+        family v1.0
+          edit ECF_FILES '%PACKAGEHOME%/ecf/scripts'
+          family nexus
+            task jnexus_gfs_sfc
+              trigger /cycled_v16_3/primary/18/gfs/v16.3/gfs/jgfs_forecast==complete or ../../../../00/aqm/v1.0/aqm_manager/aqm_manager:release_next_cycle
+              # NCO replace with time based trigger
+            task jnexus_emission_00
+              edit NSPT '00'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_01
+              edit NSPT '01'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_02
+              edit NSPT '02'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_03
+              edit NSPT '03'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_04
+              edit NSPT '04'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_05
+              edit NSPT '05'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_post_split
+              trigger ./jnexus_emission_00==complete and ./jnexus_emission_01==complete and ./jnexus_emission_02==complete
+          endfamily
+          family prep
+            task jget_extrn_ics
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+            task jget_extrn_lbcs
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+            task jmake_ics
+              trigger ./jget_extrn_ics==complete
+            task jmake_lbcs
+              trigger ./jget_extrn_lbcs==complete
+            task jics
+              trigger ./jmake_ics==complete
+            task jlbcs
+              trigger ./jmake_lbcs==complete
+          endfamily
+          family pts_fire_emis
+            task jpoint_source
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+            task jfire_emission
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+          endfamily
+          family forecast
+            task jforecast
+              trigger ../nexus==complete and ../prep==complete and ../pts_fire_emis==complete
+          endfamily
+          family post
+            task jpost_f000
+              edit FHR '000'
+              trigger ../forecast==complete
+            task jpost_f001
+              edit FHR '001'
+              trigger ../forecast==complete
+            task jpost_f002
+              edit FHR '002'
+              trigger ../forecast==complete
+            task jpost_f003
+              edit FHR '003'
+              trigger ../forecast==complete
+            task jpost_f004
+              edit FHR '004'
+              trigger ../forecast==complete
+            task jpost_f005
+              edit FHR '005'
+              trigger ../forecast==complete
+            task jpost_f006
+              edit FHR '006'
+              trigger ../forecast==complete
+            task jpost_f007
+              edit FHR '007'
+              trigger ../forecast==complete
+            task jpost_f008
+              edit FHR '008'
+              trigger ../forecast==complete
+            task jpost_f009
+              edit FHR '009'
+              trigger ../forecast==complete
+            task jpost_f010
+              edit FHR '010'
+              trigger ../forecast==complete
+            task jpost_f011
+              edit FHR '011'
+              trigger ../forecast==complete
+            task jpost_f012
+              edit FHR '012'
+              trigger ../forecast==complete
+            task jpost_f013
+              edit FHR '013'
+              trigger ../forecast==complete
+            task jpost_f014
+              edit FHR '014'
+              trigger ../forecast==complete
+            task jpost_f015
+              edit FHR '015'
+              trigger ../forecast==complete
+            task jpost_f016
+              edit FHR '016'
+              trigger ../forecast==complete
+            task jpost_f017
+              edit FHR '017'
+              trigger ../forecast==complete
+            task jpost_f018
+              edit FHR '018'
+              trigger ../forecast==complete
+            task jpost_f019
+              edit FHR '019'
+              trigger ../forecast==complete
+            task jpost_f020
+              edit FHR '020'
+              trigger ../forecast==complete
+            task jpost_f021
+              edit FHR '021'
+              trigger ../forecast==complete
+            task jpost_f022
+              edit FHR '022'
+              trigger ../forecast==complete
+            task jpost_f023
+              edit FHR '023'
+              trigger ../forecast==complete
+            task jpost_f024
+              edit FHR '024'
+              trigger ../forecast==complete
+            task jpost_f025
+              edit FHR '025'
+              trigger ../forecast==complete
+            task jpost_f026
+              edit FHR '026'
+              trigger ../forecast==complete
+            task jpost_f027
+              edit FHR '027'
+              trigger ../forecast==complete
+            task jpost_f028
+              edit FHR '028'
+              trigger ../forecast==complete
+            task jpost_f029
+              edit FHR '029'
+              trigger ../forecast==complete
+            task jpost_f030
+              edit FHR '030'
+              trigger ../forecast==complete
+            task jpost_f031
+              edit FHR '031'
+              trigger ../forecast==complete
+            task jpost_f032
+              edit FHR '032'
+              trigger ../forecast==complete
+            task jpost_f033
+              edit FHR '033'
+              trigger ../forecast==complete
+            task jpost_f034
+              edit FHR '034'
+              trigger ../forecast==complete
+            task jpost_f035
+              edit FHR '035'
+              trigger ../forecast==complete
+            task jpost_f036
+              edit FHR '036'
+              trigger ../forecast==complete
+            task jpost_f037
+              edit FHR '037'
+              trigger ../forecast==complete
+            task jpost_f038
+              edit FHR '038'
+              trigger ../forecast==complete
+            task jpost_f039
+              edit FHR '039'
+              trigger ../forecast==complete
+            task jpost_f040
+              edit FHR '040'
+              trigger ../forecast==complete
+            task jpost_f041
+              edit FHR '041'
+              trigger ../forecast==complete
+            task jpost_f042
+              edit FHR '042'
+              trigger ../forecast==complete
+            task jpost_f043
+              edit FHR '043'
+              trigger ../forecast==complete
+            task jpost_f044
+              edit FHR '044'
+              trigger ../forecast==complete
+            task jpost_f045
+              edit FHR '045'
+              trigger ../forecast==complete
+            task jpost_f046
+              edit FHR '046'
+              trigger ../forecast==complete
+            task jpost_f047
+              edit FHR '047'
+              trigger ../forecast==complete
+            task jpost_f048
+              edit FHR '048'
+              trigger ../forecast==complete
+            task jpost_f049
+              edit FHR '049'
+              trigger ../forecast==complete
+            task jpost_f050
+              edit FHR '050'
+              trigger ../forecast==complete
+            task jpost_f051
+              edit FHR '051'
+              trigger ../forecast==complete
+            task jpost_f052
+              edit FHR '052'
+              trigger ../forecast==complete
+            task jpost_f053
+              edit FHR '053'
+              trigger ../forecast==complete
+            task jpost_f054
+              edit FHR '054'
+              trigger ../forecast==complete
+            task jpost_f055
+              edit FHR '055'
+              trigger ../forecast==complete
+            task jpost_f056
+              edit FHR '056'
+              trigger ../forecast==complete
+            task jpost_f057
+              edit FHR '057'
+              trigger ../forecast==complete
+            task jpost_f058
+              edit FHR '058'
+              trigger ../forecast==complete
+            task jpost_f059
+              edit FHR '059'
+              trigger ../forecast==complete
+            task jpost_f060
+              edit FHR '060'
+              trigger ../forecast==complete
+            task jpost_f061
+              edit FHR '061'
+              trigger ../forecast==complete
+            task jpost_f062
+              edit FHR '062'
+              trigger ../forecast==complete
+            task jpost_f063
+              edit FHR '063'
+              trigger ../forecast==complete
+            task jpost_f064
+              edit FHR '064'
+              trigger ../forecast==complete
+            task jpost_f065
+              edit FHR '065'
+              trigger ../forecast==complete
+            task jpost_f066
+              edit FHR '066'
+              trigger ../forecast==complete
+            task jpost_f067
+              edit FHR '067'
+              trigger ../forecast==complete
+            task jpost_f068
+              edit FHR '068'
+              trigger ../forecast==complete
+            task jpost_f069
+              edit FHR '069'
+              trigger ../forecast==complete
+            task jpost_f070
+              edit FHR '070'
+              trigger ../forecast==complete
+            task jpost_f071
+              edit FHR '071'
+              trigger ../forecast==complete
+            task jpost_f072
+              edit FHR '072'
+              trigger ../forecast==complete
+          endfamily
+          family product
+            task jpre_post_stat
+              trigger ../forecast==complete
+            task jpost_stat_o3
+              trigger ./jpre_post_stat==complete
+            task jpost_stat_pm25
+              trigger ./jpre_post_stat==complete
+            task jbias_correction_o3
+              trigger ./jpre_post_stat==complete
+            task jbias_correction_pm25
+              trigger ./jpre_post_stat==complete
+          endfamily
+          family aqm_manager
+            task aqm_manager
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+              event 1 release_next_cycle
+              event 2 requeue_cycle
+            task data_cleanup
+              trigger ../forecast==complete
+          endfamily
+        endfamily  # v1.0
+      endfamily    # aqm
+    endfamily      # 06
+    family 12
+      edit CYC '12'
+      family aqm
+        family v1.0
+          edit ECF_FILES '%PACKAGEHOME%/ecf/scripts'
+          family nexus
+            task jnexus_gfs_sfc
+              trigger /cycled_v16_3/primary/18/gfs/v16.3/gfs/jgfs_forecast==complete or ../../../../06/aqm/v1.0/aqm_manager/aqm_manager:release_next_cycle
+              # NCO replace with time based trigger
+            task jnexus_emission_00
+              edit NSPT '00'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_01
+              edit NSPT '01'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_02
+              edit NSPT '02'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_03
+              edit NSPT '03'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_04
+              edit NSPT '04'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_05
+              edit NSPT '05'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_post_split
+              trigger ./jnexus_emission_00==complete and ./jnexus_emission_01==complete and ./jnexus_emission_02==complete
+          endfamily
+          family prep
+            task jget_extrn_ics
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+            task jget_extrn_lbcs
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+            task jmake_ics
+              trigger ./jget_extrn_ics==complete
+            task jmake_lbcs
+              trigger ./jget_extrn_lbcs==complete
+            task jics
+              trigger ./jmake_ics==complete
+            task jlbcs
+              trigger ./jmake_lbcs==complete
+          endfamily
+          family pts_fire_emis
+            task jpoint_source
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+            task jfire_emission
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+          endfamily
+          family forecast
+            task jforecast
+              trigger ../nexus==complete and ../prep==complete and ../pts_fire_emis==complete
+          endfamily
+          family post
+            task jpost_f000
+              edit FHR '000'
+              trigger ../forecast==complete
+            task jpost_f001
+              edit FHR '001'
+              trigger ../forecast==complete
+            task jpost_f002
+              edit FHR '002'
+              trigger ../forecast==complete
+            task jpost_f003
+              edit FHR '003'
+              trigger ../forecast==complete
+            task jpost_f004
+              edit FHR '004'
+              trigger ../forecast==complete
+            task jpost_f005
+              edit FHR '005'
+              trigger ../forecast==complete
+            task jpost_f006
+              edit FHR '006'
+              trigger ../forecast==complete
+            task jpost_f007
+              edit FHR '007'
+              trigger ../forecast==complete
+            task jpost_f008
+              edit FHR '008'
+              trigger ../forecast==complete
+            task jpost_f009
+              edit FHR '009'
+              trigger ../forecast==complete
+            task jpost_f010
+              edit FHR '010'
+              trigger ../forecast==complete
+            task jpost_f011
+              edit FHR '011'
+              trigger ../forecast==complete
+            task jpost_f012
+              edit FHR '012'
+              trigger ../forecast==complete
+            task jpost_f013
+              edit FHR '013'
+              trigger ../forecast==complete
+            task jpost_f014
+              edit FHR '014'
+              trigger ../forecast==complete
+            task jpost_f015
+              edit FHR '015'
+              trigger ../forecast==complete
+            task jpost_f016
+              edit FHR '016'
+              trigger ../forecast==complete
+            task jpost_f017
+              edit FHR '017'
+              trigger ../forecast==complete
+            task jpost_f018
+              edit FHR '018'
+              trigger ../forecast==complete
+            task jpost_f019
+              edit FHR '019'
+              trigger ../forecast==complete
+            task jpost_f020
+              edit FHR '020'
+              trigger ../forecast==complete
+            task jpost_f021
+              edit FHR '021'
+              trigger ../forecast==complete
+            task jpost_f022
+              edit FHR '022'
+              trigger ../forecast==complete
+            task jpost_f023
+              edit FHR '023'
+              trigger ../forecast==complete
+            task jpost_f024
+              edit FHR '024'
+              trigger ../forecast==complete
+            task jpost_f025
+              edit FHR '025'
+              trigger ../forecast==complete
+            task jpost_f026
+              edit FHR '026'
+              trigger ../forecast==complete
+            task jpost_f027
+              edit FHR '027'
+              trigger ../forecast==complete
+            task jpost_f028
+              edit FHR '028'
+              trigger ../forecast==complete
+            task jpost_f029
+              edit FHR '029'
+              trigger ../forecast==complete
+            task jpost_f030
+              edit FHR '030'
+              trigger ../forecast==complete
+            task jpost_f031
+              edit FHR '031'
+              trigger ../forecast==complete
+            task jpost_f032
+              edit FHR '032'
+              trigger ../forecast==complete
+            task jpost_f033
+              edit FHR '033'
+              trigger ../forecast==complete
+            task jpost_f034
+              edit FHR '034'
+              trigger ../forecast==complete
+            task jpost_f035
+              edit FHR '035'
+              trigger ../forecast==complete
+            task jpost_f036
+              edit FHR '036'
+              trigger ../forecast==complete
+            task jpost_f037
+              edit FHR '037'
+              trigger ../forecast==complete
+            task jpost_f038
+              edit FHR '038'
+              trigger ../forecast==complete
+            task jpost_f039
+              edit FHR '039'
+              trigger ../forecast==complete
+            task jpost_f040
+              edit FHR '040'
+              trigger ../forecast==complete
+            task jpost_f041
+              edit FHR '041'
+              trigger ../forecast==complete
+            task jpost_f042
+              edit FHR '042'
+              trigger ../forecast==complete
+            task jpost_f043
+              edit FHR '043'
+              trigger ../forecast==complete
+            task jpost_f044
+              edit FHR '044'
+              trigger ../forecast==complete
+            task jpost_f045
+              edit FHR '045'
+              trigger ../forecast==complete
+            task jpost_f046
+              edit FHR '046'
+              trigger ../forecast==complete
+            task jpost_f047
+              edit FHR '047'
+              trigger ../forecast==complete
+            task jpost_f048
+              edit FHR '048'
+              trigger ../forecast==complete
+            task jpost_f049
+              edit FHR '049'
+              trigger ../forecast==complete
+            task jpost_f050
+              edit FHR '050'
+              trigger ../forecast==complete
+            task jpost_f051
+              edit FHR '051'
+              trigger ../forecast==complete
+            task jpost_f052
+              edit FHR '052'
+              trigger ../forecast==complete
+            task jpost_f053
+              edit FHR '053'
+              trigger ../forecast==complete
+            task jpost_f054
+              edit FHR '054'
+              trigger ../forecast==complete
+            task jpost_f055
+              edit FHR '055'
+              trigger ../forecast==complete
+            task jpost_f056
+              edit FHR '056'
+              trigger ../forecast==complete
+            task jpost_f057
+              edit FHR '057'
+              trigger ../forecast==complete
+            task jpost_f058
+              edit FHR '058'
+              trigger ../forecast==complete
+            task jpost_f059
+              edit FHR '059'
+              trigger ../forecast==complete
+            task jpost_f060
+              edit FHR '060'
+              trigger ../forecast==complete
+            task jpost_f061
+              edit FHR '061'
+              trigger ../forecast==complete
+            task jpost_f062
+              edit FHR '062'
+              trigger ../forecast==complete
+            task jpost_f063
+              edit FHR '063'
+              trigger ../forecast==complete
+            task jpost_f064
+              edit FHR '064'
+              trigger ../forecast==complete
+            task jpost_f065
+              edit FHR '065'
+              trigger ../forecast==complete
+            task jpost_f066
+              edit FHR '066'
+              trigger ../forecast==complete
+            task jpost_f067
+              edit FHR '067'
+              trigger ../forecast==complete
+            task jpost_f068
+              edit FHR '068'
+              trigger ../forecast==complete
+            task jpost_f069
+              edit FHR '069'
+              trigger ../forecast==complete
+            task jpost_f070
+              edit FHR '070'
+              trigger ../forecast==complete
+            task jpost_f071
+              edit FHR '071'
+              trigger ../forecast==complete
+            task jpost_f072
+              edit FHR '072'
+              trigger ../forecast==complete
+          endfamily
+          family product
+            task jpre_post_stat
+              trigger ../forecast==complete
+            task jpost_stat_o3
+              trigger ./jpre_post_stat==complete
+            task jpost_stat_pm25
+              trigger ./jpre_post_stat==complete
+            task jbias_correction_o3
+              trigger ./jpre_post_stat==complete
+            task jbias_correction_pm25
+              trigger ./jpre_post_stat==complete
+          endfamily
+          family aqm_manager
+            task aqm_manager
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+              event 1 release_next_cycle
+              event 2 requeue_cycle
+            task data_cleanup
+              trigger ../forecast==complete
+          endfamily
+        endfamily  # v1.0
+      endfamily    # aqm
+    endfamily      # 12
+    family 18
+      edit CYC '18'
+      family aqm
+        family v1.0
+          edit ECF_FILES '%PACKAGEHOME%/ecf/scripts'
+          family nexus
+            task jnexus_gfs_sfc
+              trigger /cycled_v16_3/primary/18/gfs/v16.3/gfs/jgfs_forecast==complete or ../../../../12/aqm/v1.0/aqm_manager/aqm_manager:release_next_cycle
+              # NCO replace with time based trigger
+            task jnexus_emission_00
+              edit NSPT '00'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_01
+              edit NSPT '01'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_02
+              edit NSPT '02'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_03
+              edit NSPT '03'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_04
+              edit NSPT '04'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_emission_05
+              edit NSPT '05'
+              trigger ./jnexus_gfs_sfc==complete
+            task jnexus_post_split
+              trigger ./jnexus_emission_00==complete and ./jnexus_emission_01==complete and ./jnexus_emission_02==complete
+          endfamily
+          family prep
+            task jget_extrn_ics
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+            task jget_extrn_lbcs
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+            task jmake_ics
+              trigger ./jget_extrn_ics==complete
+            task jmake_lbcs
+              trigger ./jget_extrn_lbcs==complete
+            task jics
+              trigger ./jmake_ics==complete
+            task jlbcs
+              trigger ./jmake_lbcs==complete
+          endfamily
+          family pts_fire_emis
+            task jpoint_source
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+            task jfire_emission
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+          endfamily
+          family forecast
+            task jforecast
+              trigger ../nexus==complete and ../prep==complete and ../pts_fire_emis==complete
+          endfamily
+          family post
+            task jpost_f000
+              edit FHR '000'
+              trigger ../forecast==complete
+            task jpost_f001
+              edit FHR '001'
+              trigger ../forecast==complete
+            task jpost_f002
+              edit FHR '002'
+              trigger ../forecast==complete
+            task jpost_f003
+              edit FHR '003'
+              trigger ../forecast==complete
+            task jpost_f004
+              edit FHR '004'
+              trigger ../forecast==complete
+            task jpost_f005
+              edit FHR '005'
+              trigger ../forecast==complete
+            task jpost_f006
+              edit FHR '006'
+              trigger ../forecast==complete
+          endfamily
+          family product
+            task jpre_post_stat
+              trigger ../forecast==complete
+            task jpost_stat_o3
+              trigger ./jpre_post_stat==complete
+            task jpost_stat_pm25
+              trigger ./jpre_post_stat==complete
+            task jbias_correction_o3
+              trigger ./jpre_post_stat==complete
+            task jbias_correction_pm25
+              trigger ./jpre_post_stat==complete
+          endfamily
+          family aqm_manager
+            task aqm_manager
+              trigger ../nexus/jnexus_gfs_sfc==active or ../nexus/jnexus_gfs_sfc==complete
+              event 1 release_next_cycle
+              event 2 requeue_cycle
+            task data_cleanup
+              trigger ../forecast==complete
+          endfamily
+        endfamily  # v1.0
+      endfamily    # aqm
+    endfamily      # 18
+  endfamily        # primary
+endsuite

--- a/ecf/scripts/aqm_manager/aqm_manager.ecf
+++ b/ecf/scripts/aqm_manager/aqm_manager.ecf
@@ -1,0 +1,31 @@
+#PBS -N %RUN%_aqm_manager_%CYC%
+#PBS -j oe
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=06:00:00
+#PBS -l select=1:ncpus=1:mem=1GB
+#PBS -l place=vscatter
+#PBS -l debug=true
+
+model=aqm
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+
+module list
+
+export cyc=%CYC%
+export cycle=t${cyc}z
+
+############################################################
+# CALL executable job script here
+############################################################
+${HOMEaqm}/jobs/JAQM_MANAGER
+
+%include <tail.h>
+%manual
+
+%end

--- a/ecf/scripts/aqm_manager/data_cleanup.ecf
+++ b/ecf/scripts/aqm_manager/data_cleanup.ecf
@@ -1,0 +1,31 @@
+#PBS -N %RUN%_data_cleanup_%CYC%
+#PBS -j oe
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=06:00:00
+#PBS -l select=1:ncpus=1:mem=1GB
+#PBS -l place=vscatter
+#PBS -l debug=true
+
+model=aqm
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+
+module list
+
+export cyc=%CYC%
+export cycle=t${cyc}z
+
+############################################################
+# CALL executable job script here
+############################################################
+${HOMEaqm}/jobs/JDATA_CLEANUP
+
+%include <tail.h>
+%manual
+
+%end

--- a/ecf/scripts/forecast/jforecast.ecf
+++ b/ecf/scripts/forecast/jforecast.ecf
@@ -1,0 +1,47 @@
+#PBS -N aqm_forecast_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=04:00:00
+#PBS -l select=14:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=vscatter:exclhost
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load cray-pals/${cray_pals_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load esmf/${esmf_ver}
+module load libjpeg/${libjpeg_ver}
+module load zlib/${zlib_ver}
+module load libpng/${libpng_ver}
+module load pio/${pio_ver}
+module load crtm/${crtm_ver}
+module load g2/${g2_ver}
+module load g2tmpl/${g2tmpl_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export share_pid="${PDY}${cyc}"
+
+${HOMEaqm}/jobs/JREGIONAL_RUN_FCST
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/nexus/jnexus_emission.ecf
+++ b/ecf/scripts/nexus/jnexus_emission.ecf
@@ -1,0 +1,44 @@
+#PBS -N aqm_nexus_emission_%NSPT%_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=01:00:00
+#PBS -l select=4:mpiprocs=64:ompthreads=2:ncpus=128
+#PBS -l place=vscatter:exclhost
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load cray-pals/${cray_pals_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load esmf/${esmf_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load nco/${nco_ver}
+module load python/${python_ver}
+
+module list
+
+export nspt="%NSPT%"
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export DCOMINfire=/lfs/h2/emc/physics/noscrub/kai.wang/RAVE_fire/RAVE_NA_NRT
+
+${HOMEaqm}/jobs/JREGIONAL_NEXUS_EMISSION
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/nexus/jnexus_emission_00.ecf
+++ b/ecf/scripts/nexus/jnexus_emission_00.ecf
@@ -1,0 +1,1 @@
+jnexus_emission.ecf

--- a/ecf/scripts/nexus/jnexus_emission_01.ecf
+++ b/ecf/scripts/nexus/jnexus_emission_01.ecf
@@ -1,0 +1,1 @@
+jnexus_emission.ecf

--- a/ecf/scripts/nexus/jnexus_emission_02.ecf
+++ b/ecf/scripts/nexus/jnexus_emission_02.ecf
@@ -1,0 +1,1 @@
+jnexus_emission.ecf

--- a/ecf/scripts/nexus/jnexus_emission_03.ecf
+++ b/ecf/scripts/nexus/jnexus_emission_03.ecf
@@ -1,0 +1,1 @@
+jnexus_emission.ecf

--- a/ecf/scripts/nexus/jnexus_emission_04.ecf
+++ b/ecf/scripts/nexus/jnexus_emission_04.ecf
@@ -1,0 +1,1 @@
+jnexus_emission.ecf

--- a/ecf/scripts/nexus/jnexus_emission_05.ecf
+++ b/ecf/scripts/nexus/jnexus_emission_05.ecf
@@ -1,0 +1,1 @@
+jnexus_emission.ecf

--- a/ecf/scripts/nexus/jnexus_gfs_sfc.ecf
+++ b/ecf/scripts/nexus/jnexus_gfs_sfc.ecf
@@ -1,0 +1,35 @@
+#PBS -N aqm_nexus_gfs_sfc_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:30:00
+#PBS -l select=1:mpiprocs=1:ncpus=1
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export COMINgfs=$(compath.py ${envir}/gfs/${gfs_ver})
+export share_pid="${PDY}${cyc}"
+
+${HOMEaqm}/jobs/JREGIONAL_NEXUS_GFS_SFC
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/nexus/jnexus_post_split.ecf
+++ b/ecf/scripts/nexus/jnexus_post_split.ecf
@@ -1,0 +1,41 @@
+#PBS -N aqm_nexus_post_split_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:30:00
+#PBS -l select=1:mpiprocs=1:ncpus=1
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load cray-pals/${cray_pals_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load esmf/${esmf_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load nco/${nco_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+
+${HOMEaqm}/jobs/JREGIONAL_NEXUS_POST_SPLIT
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/post/jpost.ecf
+++ b/ecf/scripts/post/jpost.ecf
@@ -1,0 +1,41 @@
+#PBS -N aqm_post_%FHR%_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:15:00
+#PBS -l select=2:mpiprocs=24:ncpus=24
+#PBS -l place=vscatter:exclhost
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load cray-pals/${cray_pals_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load libjpeg/${libjpeg_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export fhr="%FHR%"
+export DATAFCST=$DATAROOT/${model}_forecast_${cyc}.${PDY}${cyc}
+
+${HOMEaqm}/jobs/JREGIONAL_RUN_POST
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/post/jpost_f000.ecf
+++ b/ecf/scripts/post/jpost_f000.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f001.ecf
+++ b/ecf/scripts/post/jpost_f001.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f002.ecf
+++ b/ecf/scripts/post/jpost_f002.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f003.ecf
+++ b/ecf/scripts/post/jpost_f003.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f004.ecf
+++ b/ecf/scripts/post/jpost_f004.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f005.ecf
+++ b/ecf/scripts/post/jpost_f005.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f006.ecf
+++ b/ecf/scripts/post/jpost_f006.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f007.ecf
+++ b/ecf/scripts/post/jpost_f007.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f008.ecf
+++ b/ecf/scripts/post/jpost_f008.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f009.ecf
+++ b/ecf/scripts/post/jpost_f009.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f010.ecf
+++ b/ecf/scripts/post/jpost_f010.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f011.ecf
+++ b/ecf/scripts/post/jpost_f011.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f012.ecf
+++ b/ecf/scripts/post/jpost_f012.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f013.ecf
+++ b/ecf/scripts/post/jpost_f013.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f014.ecf
+++ b/ecf/scripts/post/jpost_f014.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f015.ecf
+++ b/ecf/scripts/post/jpost_f015.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f016.ecf
+++ b/ecf/scripts/post/jpost_f016.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f017.ecf
+++ b/ecf/scripts/post/jpost_f017.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f018.ecf
+++ b/ecf/scripts/post/jpost_f018.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f019.ecf
+++ b/ecf/scripts/post/jpost_f019.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f020.ecf
+++ b/ecf/scripts/post/jpost_f020.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f021.ecf
+++ b/ecf/scripts/post/jpost_f021.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f022.ecf
+++ b/ecf/scripts/post/jpost_f022.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f023.ecf
+++ b/ecf/scripts/post/jpost_f023.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f024.ecf
+++ b/ecf/scripts/post/jpost_f024.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f025.ecf
+++ b/ecf/scripts/post/jpost_f025.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f026.ecf
+++ b/ecf/scripts/post/jpost_f026.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f027.ecf
+++ b/ecf/scripts/post/jpost_f027.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f028.ecf
+++ b/ecf/scripts/post/jpost_f028.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f029.ecf
+++ b/ecf/scripts/post/jpost_f029.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f030.ecf
+++ b/ecf/scripts/post/jpost_f030.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f031.ecf
+++ b/ecf/scripts/post/jpost_f031.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f032.ecf
+++ b/ecf/scripts/post/jpost_f032.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f033.ecf
+++ b/ecf/scripts/post/jpost_f033.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f034.ecf
+++ b/ecf/scripts/post/jpost_f034.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f035.ecf
+++ b/ecf/scripts/post/jpost_f035.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f036.ecf
+++ b/ecf/scripts/post/jpost_f036.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f037.ecf
+++ b/ecf/scripts/post/jpost_f037.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f038.ecf
+++ b/ecf/scripts/post/jpost_f038.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f039.ecf
+++ b/ecf/scripts/post/jpost_f039.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f040.ecf
+++ b/ecf/scripts/post/jpost_f040.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f041.ecf
+++ b/ecf/scripts/post/jpost_f041.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f042.ecf
+++ b/ecf/scripts/post/jpost_f042.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f043.ecf
+++ b/ecf/scripts/post/jpost_f043.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f044.ecf
+++ b/ecf/scripts/post/jpost_f044.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f045.ecf
+++ b/ecf/scripts/post/jpost_f045.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f046.ecf
+++ b/ecf/scripts/post/jpost_f046.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f047.ecf
+++ b/ecf/scripts/post/jpost_f047.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f048.ecf
+++ b/ecf/scripts/post/jpost_f048.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f049.ecf
+++ b/ecf/scripts/post/jpost_f049.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f050.ecf
+++ b/ecf/scripts/post/jpost_f050.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f051.ecf
+++ b/ecf/scripts/post/jpost_f051.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f052.ecf
+++ b/ecf/scripts/post/jpost_f052.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f053.ecf
+++ b/ecf/scripts/post/jpost_f053.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f054.ecf
+++ b/ecf/scripts/post/jpost_f054.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f055.ecf
+++ b/ecf/scripts/post/jpost_f055.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f056.ecf
+++ b/ecf/scripts/post/jpost_f056.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f057.ecf
+++ b/ecf/scripts/post/jpost_f057.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f058.ecf
+++ b/ecf/scripts/post/jpost_f058.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f059.ecf
+++ b/ecf/scripts/post/jpost_f059.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f060.ecf
+++ b/ecf/scripts/post/jpost_f060.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f061.ecf
+++ b/ecf/scripts/post/jpost_f061.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f062.ecf
+++ b/ecf/scripts/post/jpost_f062.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f063.ecf
+++ b/ecf/scripts/post/jpost_f063.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f064.ecf
+++ b/ecf/scripts/post/jpost_f064.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f065.ecf
+++ b/ecf/scripts/post/jpost_f065.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f066.ecf
+++ b/ecf/scripts/post/jpost_f066.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f067.ecf
+++ b/ecf/scripts/post/jpost_f067.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f068.ecf
+++ b/ecf/scripts/post/jpost_f068.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f069.ecf
+++ b/ecf/scripts/post/jpost_f069.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f070.ecf
+++ b/ecf/scripts/post/jpost_f070.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f071.ecf
+++ b/ecf/scripts/post/jpost_f071.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/post/jpost_f072.ecf
+++ b/ecf/scripts/post/jpost_f072.ecf
@@ -1,0 +1,1 @@
+jpost.ecf

--- a/ecf/scripts/prep/jget_extrn_ics.ecf
+++ b/ecf/scripts/prep/jget_extrn_ics.ecf
@@ -1,0 +1,36 @@
+#PBS -N aqm_get_extrn_ics_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:45:00
+#PBS -l select=1:mpiprocs=1:ncpus=1:mem=2G
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load python/${python_ver}
+
+module list
+
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export ICS_OR_LBCS=ICS
+export share_pid="${PDY}${cyc}"
+
+${HOMEaqm}/jobs/JREGIONAL_GET_EXTRN_MDL_FILES
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/prep/jget_extrn_lbcs.ecf
+++ b/ecf/scripts/prep/jget_extrn_lbcs.ecf
@@ -1,0 +1,35 @@
+#PBS -N aqm_get_extrn_lbcs_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=02:00:00
+#PBS -l select=1:mpiprocs=1:ncpus=1:mem=2G
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export ICS_OR_LBCS=LBCS
+export share_pid="${PDY}${cyc}"
+
+${HOMEaqm}/jobs/JREGIONAL_GET_EXTRN_MDL_FILES
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/prep/jics.ecf
+++ b/ecf/scripts/prep/jics.ecf
@@ -1,0 +1,43 @@
+#PBS -N aqm_ics_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:30:00
+#PBS -l select=1:mpiprocs=1:ncpus=1
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load nco/${nco_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export ICS_OR_LBCS=ICS
+SDATE=$($NDATE -6 ${PDY}${cyc})
+PDYS_P1=$(echo $SDATE | cut -c1-8)
+cycs_p1=$(echo $SDATE | cut -c9-10)
+export PREV_CYCLE_DIR=${COMaqm}/${model}.${PDYS_P1}/${cycs_p1}
+
+${HOMEaqm}/jobs/JREGIONAL_AQM_ICS
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/prep/jlbcs.ecf
+++ b/ecf/scripts/prep/jlbcs.ecf
@@ -1,0 +1,48 @@
+#PBS -N aqm_lbcs_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:20:00
+#PBS -l select=1:mpiprocs=24:ncpus=24
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load libjpeg/${libjpeg_ver}
+module load zlib/${zlib_ver}
+module load libpng/${libpng_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load cray-pals/${cray_pals_ver}
+module load wgrib2/${wgrib2_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load nco/${nco_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export ICS_OR_LBCS=LBCS
+export DCOMINchem_lbcs=/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/LBCS/AQM_NA13km_AM4_v1
+export DCOMINgefs=/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/GEFS_DATA
+export COMINgefs=$(compath.py ${envir}/gefs/${gefs_ver})
+
+${HOMEaqm}/jobs/JREGIONAL_AQM_LBCS
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/prep/jmake_ics.ecf
+++ b/ecf/scripts/prep/jmake_ics.ecf
@@ -1,0 +1,46 @@
+#PBS -N aqm_make_ics_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:30:00
+#PBS -l select=4:mpiprocs=12:ncpus=12
+#PBS -l place=vscatter:exclhost
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load libjpeg/${libjpeg_ver}
+module load zlib/${zlib_ver}
+module load libpng/${libpng_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load cray-pals/${cray_pals_ver}
+module load esmf/${esmf_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load nco/${nco_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export ICS_OR_LBCS=ICS
+
+${HOMEaqm}/jobs/JREGIONAL_MAKE_ICS
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/prep/jmake_lbcs.ecf
+++ b/ecf/scripts/prep/jmake_lbcs.ecf
@@ -1,0 +1,45 @@
+#PBS -N aqm_make_lbcs_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:30:00
+#PBS -l select=1:mpiprocs=128:ncpus=128
+#PBS -l place=vscatter:exclhost
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load libjpeg/${libjpeg_ver}
+module load zlib/${zlib_ver}
+module load libpng/${libpng_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load cray-pals/${cray_pals_ver}
+module load esmf/${esmf_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load nco/${nco_ver}
+module load python/${python_ver}
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export ICS_OR_LBCS=LBCS
+
+${HOMEaqm}/jobs/JREGIONAL_MAKE_LBCS
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/product/jbias_correction_o3.ecf
+++ b/ecf/scripts/product/jbias_correction_o3.ecf
@@ -1,0 +1,44 @@
+#PBS -N aqm_bias_correction_o3_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:30:00
+#PBS -l select=1:mpiprocs=1:ompthreads=32:ncpus=32:mem=120G
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load cray-pals/${cray_pals_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load libjpeg/${libjpeg_ver}
+module load zlib/${zlib_ver}
+module load libpng/${libpng_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export DCOMINairnow=/lfs/h1/ops/prod/dcom
+export COMOUTbicor=${COMaqm}
+
+${HOMEaqm}/jobs/JREGIONAL_BIAS_CORRECTION_O3
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/product/jbias_correction_pm25.ecf
+++ b/ecf/scripts/product/jbias_correction_pm25.ecf
@@ -1,0 +1,44 @@
+#PBS -N aqm_bias_correction_pm25_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:30:00
+#PBS -l select=1:mpiprocs=1:ompthreads=32:ncpus=32:mem=120G
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load cray-pals/${cray_pals_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load libjpeg/${libjpeg_ver}
+module load zlib/${zlib_ver}
+module load libpng/${libpng_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export DCOMINairnow=/lfs/h1/ops/prod/dcom
+export COMOUTbicor=${COMaqm}
+
+${HOMEaqm}/jobs/JREGIONAL_BIAS_CORRECTION_PM25
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/product/jpost_stat_o3.ecf
+++ b/ecf/scripts/product/jpost_stat_o3.ecf
@@ -1,0 +1,41 @@
+#PBS -N aqm_post_stat_o3_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:30:00
+#PBS -l select=1:mpiprocs=1:ncpus=1:mem=120G
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load cray-pals/${cray_pals_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load libjpeg/${libjpeg_ver}
+module load zlib/${zlib_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+
+${HOMEaqm}/jobs/JREGIONAL_POST_STAT_O3
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/product/jpost_stat_pm25.ecf
+++ b/ecf/scripts/product/jpost_stat_pm25.ecf
@@ -1,0 +1,41 @@
+#PBS -N aqm_post_stat_pm25_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:30:00
+#PBS -l select=1:mpiprocs=1:ncpus=1:mem=120G
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load cray-pals/${cray_pals_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load libjpeg/${libjpeg_ver}
+module load zlib/${zlib_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+
+${HOMEaqm}/jobs/JREGIONAL_POST_STAT_PM25
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/product/jpre_post_stat.ecf
+++ b/ecf/scripts/product/jpre_post_stat.ecf
@@ -1,0 +1,38 @@
+#PBS -N aqm_pre_post_stat_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:30:00
+#PBS -l select=1:mpiprocs=1:ncpus=1
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load nco/${nco_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+
+${HOMEaqm}/jobs/JREGIONAL_PRE_POST_STAT
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/pts_fire_emis/jfire_emission.ecf
+++ b/ecf/scripts/pts_fire_emis/jfire_emission.ecf
@@ -1,0 +1,38 @@
+#PBS -N aqm_fire_emission_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:30:00
+#PBS -l select=1:mpiprocs=1:ncpus=1
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load hdf5/${hdf5_ver}
+module load netcdf/${netcdf_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load nco/${nco_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+
+${HOMEaqm}/jobs/JREGIONAL_FIRE_EMISSION
+
+%include <tail.h>
+
+%manual
+%end

--- a/ecf/scripts/pts_fire_emis/jpoint_source.ecf
+++ b/ecf/scripts/pts_fire_emis/jpoint_source.ecf
@@ -1,0 +1,34 @@
+#PBS -N aqm_point_source_%CYC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=01:00:00
+#PBS -l select=1:mpiprocs=1:ncpus=1
+#PBS -l debug=true
+
+model=aqm
+export cyc="%CYC%"
+%include <head.h>
+%include <envir-p1.h>
+
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
+module load envvar/${envvar_ver}
+module load python/${python_ver}
+
+module list
+
+export subcyc=0
+. ${HOMEaqm}/parm/config/var_defns.sh
+. $USHdir/source_util_funcs.sh
+machine=$(echo_lowercase $MACHINE)
+export DCOMINpt_src=/lfs/h2/emc/physics/noscrub/Youhua.Tang/nei2016v1-pt/v2023-01-PT
+
+${HOMEaqm}/jobs/JREGIONAL_POINT_SOURCE
+
+%include <tail.h>
+
+%manual
+%end

--- a/jobs/JAQM_MANAGER
+++ b/jobs/JAQM_MANAGER
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -x
+
+export RUN_ENVIR=${RUN_ENVIR:-"nco"}
+export PS4='$SECONDS + '
+date
+
+##############################################
+# Obtain unique process id (pid) and make temp directory
+##############################################
+export pid=${pid:-$$}
+export outid=${outid:-"LL$job"}
+
+export DATA=${DATA:-${DATAROOT}/${jobid:?}}
+mkdir -p $DATA
+cd $DATA
+##############################################
+# Run setpdy and initialize PDY variables
+##############################################
+export cycle="t${cyc}z"
+setpdy.sh
+. ./PDY
+
+##############################################
+# Set variables used in the script
+##############################################
+${HOMEaqm}/scripts/exaqm_manager.sh
+status=$?
+[[ $status -ne 0 ]] && exit $status
+
+##########################################
+# Remove the Temporary working directory
+##########################################
+cd $DATAROOT
+[[ $KEEPDATA = "NO" ]] && rm -rf $DATA
+
+date
+exit 0

--- a/jobs/JDATA_CLEANUP
+++ b/jobs/JDATA_CLEANUP
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -x
+
+export RUN_ENVIR=${RUN_ENVIR:-"nco"}
+export PS4='$SECONDS + '
+date
+
+##############################################
+# Obtain unique process id (pid) and make temp directory
+##############################################
+export pid=${pid:-$$}
+export outid=${outid:-"LL$job"}
+
+export DATA=${DATA:-${DATAROOT}/${jobid:?}}
+mkdir -p $DATA
+cd $DATA
+
+##############################################
+# Run setpdy and initialize PDY variables
+##############################################
+export cycle="t${cyc}z"
+setpdy.sh
+. ./PDY
+
+##############################################
+# Set variables used in the script
+##############################################
+${HOMEaqm}/scripts/exdata_cleanup.sh
+status=$?
+[[ $status -ne 0 ]] && exit $status
+
+##########################################
+# Remove the Temporary working directory
+##########################################
+cd $DATAROOT
+[[ $KEEPDATA = "NO" ]] && rm -rf $DATA
+
+date
+exit 0

--- a/jobs/JREGIONAL_AQM_ICS
+++ b/jobs/JREGIONAL_AQM_ICS
@@ -65,7 +65,7 @@ which the model needs.
 #-----------------------------------------------------------------------
 #
 if [ $RUN_ENVIR = "nco" ]; then
-    export INPUT_DATA="${INPUT_DATA:-${COMIN}}"
+    export INPUT_DATA="${COMIN}"
 else
     export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}/INPUT"
 fi

--- a/jobs/JREGIONAL_AQM_LBCS
+++ b/jobs/JREGIONAL_AQM_LBCS
@@ -65,7 +65,7 @@ which the model needs.
 #-----------------------------------------------------------------------
 #
 if [ $RUN_ENVIR = "nco" ]; then
-    export INPUT_DATA="${INPUT_DATA:-${COMIN}}"
+    export INPUT_DATA="${COMIN}"
 else
     export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}/INPUT"
 fi

--- a/jobs/JREGIONAL_BIAS_CORRECTION_O3
+++ b/jobs/JREGIONAL_BIAS_CORRECTION_O3
@@ -19,6 +19,10 @@
 source_config_for_task "cpl_aqm_parm|task_run_post|task_bias_correction_o3" ${GLOBAL_VAR_DEFNS_FP}
 . $USHdir/job_preamble.sh
 #
+export DCOMROOT=${DCOMROOT:-/lfs/h1/ops/prod/dcom}
+export DCOMINairnow=${DCOMINairnow:-/lfs/h1/ops/prod/dcom}
+export COMINbicor=${COMINbicor:-$(compath.py ${NET}/${aqm_ver})}
+export COMOUTbicor=${COMOUTbicor:-$(compath.py ${NET}/${aqm_ver})}
 #-----------------------------------------------------------------------
 #
 # Save current shell options (in a global array).  Then set new options
@@ -67,6 +71,7 @@ if [ "${RUN_ENVIR}" = "community" ]; then
   cd $DATA
 fi
 
+COMOUTwmo="${COMOUTwmo:-${COMOUT}/wmo}"
 mkdir -p ${COMOUTwmo}
 
 export PARMaqm_utils="${PARMaqm_utils:-${HOMEaqm}/sorc/AQM-utils/parm}"

--- a/jobs/JREGIONAL_BIAS_CORRECTION_PM25
+++ b/jobs/JREGIONAL_BIAS_CORRECTION_PM25
@@ -19,6 +19,10 @@
 source_config_for_task "cpl_aqm_parm|task_run_post|task_bias_correction_pm25" ${GLOBAL_VAR_DEFNS_FP}
 . $USHdir/job_preamble.sh
 #
+export DCOMROOT=${DCOMROOT:-/lfs/h1/ops/prod/dcom}
+export DCOMINairnow=${DCOMINairnow:-/lfs/h1/ops/prod/dcom}
+export COMINbicor=${COMINbicor:-$(compath.py ${NET}/${aqm_ver})}
+export COMOUTbicor=${COMOUTbicor:-$(compath.py ${NET}/${aqm_ver})}
 #-----------------------------------------------------------------------
 #
 # Save current shell options (in a global array).  Then set new options
@@ -67,6 +71,7 @@ if [ "${RUN_ENVIR}" = "community" ]; then
   cd $DATA
 fi
 
+COMOUTwmo="${COMOUTwmo:-${COMOUT}/wmo}"
 mkdir -p ${COMOUTwmo}
 
 export PARMaqm_utils="${PARMaqm_utils:-${HOMEaqm}/sorc/AQM-utils/parm}"

--- a/jobs/JREGIONAL_FIRE_EMISSION
+++ b/jobs/JREGIONAL_FIRE_EMISSION
@@ -19,6 +19,8 @@
 source_config_for_task "cpl_aqm_parm|task_fire_emission" ${GLOBAL_VAR_DEFNS_FP}
 . $USHdir/job_preamble.sh
 #
+export DCOMINfire=${DCOMINfire:-$(compath.py ${DCOMROOT}/${PDY}/rave)}
+
 #-----------------------------------------------------------------------
 #
 # Save current shell options (in a global array).  Then set new options
@@ -103,7 +105,7 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-export FIRE_EMISSION_STAGING_DIR="${FIRE_EMISSION_STAGING_DIR:-${COMIN}/FIRE_EMISSION}"
+export FIRE_EMISSION_STAGING_DIR="${COMIN}/FIRE_EMISSION"
 mkdir -p ${FIRE_EMISSION_STAGING_DIR}
 #
 #-----------------------------------------------------------------------

--- a/jobs/JREGIONAL_GET_EXTRN_MDL_FILES
+++ b/jobs/JREGIONAL_GET_EXTRN_MDL_FILES
@@ -79,7 +79,10 @@ to generate initial or lateral boundary conditions for the FV3 model.
 #-----------------------------------------------------------------------
 #
 valid_vals_ICS_OR_LBCS=( "ICS" "LBCS" )
-check_var_valid_value "ICS_OR_LBCS" "valid_vals_ICS_OR_LBCS"
+ICS_OR_LBCS=${ICS_OR_LBCS:-""}
+if [ ! "${ICS_OR_LBCS}" = "" ]; then
+  check_var_valid_value "ICS_OR_LBCS" "valid_vals_ICS_OR_LBCS"
+fi
 #
 #-----------------------------------------------------------------------
 #
@@ -219,7 +222,12 @@ esac
 #-----------------------------------------------------------------------
 #
 if [ "${RUN_ENVIR}" = "nco" ]; then
-    export EXTRN_MDL_STAGING_DIR="${EXTRN_MDL_STAGING_DIR:-${DATA}}"
+    if [ "${ICS_OR_LBCS}" = "ICS" ]; then
+      t_text=aqm_get_extrn_ics
+    else
+      t_text=aqm_get_extrn_lbcs
+    fi
+    export EXTRN_MDL_STAGING_DIR="${DATAROOT}/${t_text}_${cyc}.${share_pid}"
 else
     export EXTRN_MDL_STAGING_DIR="${COMIN}/${EXTRN_MDL_NAME}/for_${ICS_OR_LBCS}"
     mkdir -p ${EXTRN_MDL_STAGING_DIR}
@@ -242,7 +250,7 @@ Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
 #
 #-----------------------------------------------------------------------
 #
-job_postamble "FALSE"
+# job_postamble
 #
 #-----------------------------------------------------------------------
 #

--- a/jobs/JREGIONAL_MAKE_ICS
+++ b/jobs/JREGIONAL_MAKE_ICS
@@ -56,7 +56,7 @@ for the FV3 (in NetCDF format).
 #-----------------------------------------------------------------------
 #
 if [ $RUN_ENVIR = "nco" ]; then
-    export INPUT_DATA="${INPUT_DATA:-${COMIN}}"
+    export INPUT_DATA="${COMIN}"
 else
     export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}/INPUT"
 fi

--- a/jobs/JREGIONAL_MAKE_LBCS
+++ b/jobs/JREGIONAL_MAKE_LBCS
@@ -56,7 +56,7 @@ hour zero).
 #-----------------------------------------------------------------------
 #
 if [ $RUN_ENVIR = "nco" ]; then
-    export INPUT_DATA="${INPUT_DATA:-${COMIN}}"
+    export INPUT_DATA="${COMIN}"
 else
     export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}/INPUT"
 fi

--- a/jobs/JREGIONAL_NEXUS_EMISSION
+++ b/jobs/JREGIONAL_NEXUS_EMISSION
@@ -63,7 +63,7 @@ using NEXUS which will output for FV3 (in NetCDF format).
 #-----------------------------------------------------------------------
 #
 if [ $RUN_ENVIR = "nco" ]; then
-    export INPUT_DATA="${INPUT_DATA:-${COMIN}/NEXUS}"
+    export INPUT_DATA="${COMIN}/NEXUS"
 else
     export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}/NEXUS"
 fi

--- a/jobs/JREGIONAL_NEXUS_GFS_SFC
+++ b/jobs/JREGIONAL_NEXUS_GFS_SFC
@@ -18,6 +18,9 @@
 . $USHdir/source_util_funcs.sh
 source_config_for_task "cpl_aqm_parm|task_nexus_gfs_sfc" ${GLOBAL_VAR_DEFNS_FP}
 . $USHdir/job_preamble.sh "TRUE"
+
+# export COMINgfs=${COMINgfs:-$(compath.py gfs/${gfs_ver})}
+
 #
 #-----------------------------------------------------------------------
 #
@@ -94,7 +97,10 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}/tmp_NEXUS_GFS_SFC}"
+# DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}/tmp_NEXUS_GFS_SFC}"
+DATA=${DATAROOT}/aqm_nexus_gfs_sfc_${cyc}.${share_pid}
+mkdir -p ${DATA}
+cd ${DATA}
 #
 #-----------------------------------------------------------------------
 #
@@ -103,7 +109,8 @@ DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}/tmp_NEXUS_GFS_SFC}"
 #-----------------------------------------------------------------------
 #
 if [ "${RUN_ENVIR}" = "nco" ]; then
-  export GFS_SFC_STAGING_DIR="${GFS_SFC_STAGING_DIR:-${DATA}}"
+  # export GFS_SFC_STAGING_DIR="${DATA}"
+  export GFS_SFC_STAGING_DIR=${GFS_SFC_STAGING_DIR:-${DATAROOT}/aqm_nexus_gfs_sfc_${cyc}.${share_pid}}
 else
   export GFS_SFC_STAGING_DIR="${COMIN}/GFS_SFC"
   mkdir -p ${GFS_SFC_STAGING_DIR}
@@ -126,7 +133,7 @@ Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
 #
 #-----------------------------------------------------------------------
 #
-job_postamble "FALSE"
+# job_postamble
 #
 #-----------------------------------------------------------------------
 #

--- a/jobs/JREGIONAL_NEXUS_POST_SPLIT
+++ b/jobs/JREGIONAL_NEXUS_POST_SPLIT
@@ -55,7 +55,7 @@ using NEXUS which will output for FV3 (in NetCDF format).
 #-----------------------------------------------------------------------
 #
 if [ $RUN_ENVIR = "nco" ]; then
-    export INPUT_DATA="${INPUT_DATA:-${COMIN}}"
+    export INPUT_DATA="${COMIN}"
 else
     export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}/INPUT"
 fi

--- a/jobs/JREGIONAL_POINT_SOURCE
+++ b/jobs/JREGIONAL_POINT_SOURCE
@@ -54,7 +54,7 @@ This is the J-job script for the task that generates the point source files.
 #-----------------------------------------------------------------------
 #
 if [ $RUN_ENVIR = "nco" ]; then
-    export INPUT_DATA="${INPUT_DATA:-${COMIN}}"
+    export INPUT_DATA="${COMIN}"
 else
     export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}/INPUT"
 fi

--- a/jobs/JREGIONAL_POST_STAT_O3
+++ b/jobs/JREGIONAL_POST_STAT_O3
@@ -67,6 +67,7 @@ if [ "${RUN_ENVIR}" = "community" ]; then
   cd $DATA
 fi
 
+COMOUTwmo="${COMOUTwmo:-${COMOUT}/wmo}"
 mkdir -p ${COMOUTwmo}
 
 export PARMaqm_utils="${PARMaqm_utils:-${HOMEaqm}/sorc/AQM-utils/parm}"

--- a/jobs/JREGIONAL_POST_STAT_PM25
+++ b/jobs/JREGIONAL_POST_STAT_PM25
@@ -67,6 +67,7 @@ if [ "${RUN_ENVIR}" = "community" ]; then
   cd $DATA
 fi
 
+COMOUTwmo="${COMOUTwmo:-${COMOUT}/wmo}"
 mkdir -p ${COMOUTwmo}
 
 export PARMaqm_utils="${PARMaqm_utils:-${HOMEaqm}/sorc/AQM-utils/parm}"

--- a/jobs/JREGIONAL_RUN_FCST
+++ b/jobs/JREGIONAL_RUN_FCST
@@ -63,12 +63,13 @@ the specified cycle.
 #
 #-----------------------------------------------------------------------
 #
-DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+# DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+DATA="${DATAROOT}/aqm_forecast_${cyc}.${share_pid}"
 mkdir -p ${DATA}/INPUT
 mkdir -p ${DATA}/RESTART
 
 if [ $RUN_ENVIR = "nco" ]; then
-  export INPUT_DATA="${INPUT_DATA:-${COMIN}}"
+  export INPUT_DATA="${COMIN}"
 else
   export INPUT_DATA="${COMIN}${SLASH_ENSMEM_SUBDIR}/INPUT"
 fi
@@ -91,7 +92,7 @@ Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
 #
 #-----------------------------------------------------------------------
 #
-job_postamble "FALSE"
+# job_postamble
 #
 #-----------------------------------------------------------------------
 #

--- a/jobs/JREGIONAL_RUN_POST
+++ b/jobs/JREGIONAL_RUN_POST
@@ -62,7 +62,8 @@ on the output files corresponding to a specified forecast hour.
 #
 #-----------------------------------------------------------------------
 #
-DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+export DATA="${DATA:-${COMIN}${SLASH_ENSMEM_SUBDIR}}"
+export DATAFCST=$DATAROOT/aqm_forecast_${cyc}.${PDY}${cyc}
 #
 # If SUB_HOURLY_POST is not set to "TRUE", ensure that the forecast 
 # minutes (fmn) are set to "00".  This is necessary in order to pass
@@ -131,35 +132,11 @@ Call to ex-script corresponding to J-job \"${scrfunc_fn}\" failed."
 #
 #-----------------------------------------------------------------------
 #
-# Create a flag file to make rocoto aware that the run_post task has
-# successfully completed. This flag is necessary for varying forecast
-# hours (FCST_LEN_HRS: -1)
-#
-#-----------------------------------------------------------------------
-#
-if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-  cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-  CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-  FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
-
-  fcst_len_hrs=$( printf "%03d" "${FCST_LEN_HRS}" ) 
-  if [ "${fhr}" = "${fcst_len_hrs}" ]; then
-    touch "${COMIN}/post_${PDY}${cyc}_task_complete.txt"
-  fi
-fi
-#
-#-----------------------------------------------------------------------
-#
 # Run job postamble.
 #
 #-----------------------------------------------------------------------
 #
-fcst_len_hrs=$( printf "%03d" "${FCST_LEN_HRS}" )
-if [ "${fhr}" = "${fcst_len_hrs}" ]; then
-    job_postamble "TRUE"
-else
-    job_postamble
-fi
+job_postamble
 #
 #-----------------------------------------------------------------------
 #

--- a/parm/config/field_table
+++ b/parm/config/field_table
@@ -1,0 +1,979 @@
+# added by FRE: sphum must be present in atmos
+# specific humidity for moist runs
+ "TRACER", "atmos_mod", "sphum"
+           "longname",     "specific humidity"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic cloud water mixing ratio
+ "TRACER", "atmos_mod", "liq_wat"
+           "longname",     "cloud water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "rainwat"
+           "longname",     "rain mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "ice_wat"
+           "longname",     "cloud ice mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "snowwat"
+           "longname",     "snow mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "graupel"
+           "longname",     "graupel mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic ozone mixing ratio tracer
+ "TRACER", "atmos_mod", "o3mr"
+           "longname",     "ozone mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic subgrid scale turbulent kinetic energy
+ "TRACER", "atmos_mod", "sgs_tke"
+           "longname",     "subgrid scale turbulent kinetic energy"
+           "units",        "m2/s2"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic air quality tracers
+ "TRACER", "atmos_mod", "NO2"
+           "longname",  "NO2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "NO"
+           "longname",  "NO"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "O3"
+           "longname",  "O3"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "NO3"
+           "longname",  "NO3"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "H2O2"
+           "longname",  "H2O2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "N2O5"
+           "longname",  "N2O5"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "HNO3"
+           "longname",  "HNO3"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "HONO"
+           "longname",  "HONO"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "PNA"
+           "longname",  "PNA"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SO2"
+           "longname",  "SO2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SULF"
+           "longname",  "SULF"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "PAN"
+           "longname",  "PAN"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "PACD"
+           "longname",  "PACD"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AACD"
+           "longname",  "AACD"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ALD2"
+           "longname",  "ALD2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "PANX"
+           "longname",  "PANX"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "FORM"
+           "longname",  "FORM"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "MEPX"
+           "longname",  "MEPX"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "MEOH"
+           "longname",  "MEOH"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ROOH"
+           "longname",  "ROOH"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "NTR1"
+           "longname",  "NTR1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "NTR2"
+           "longname",  "NTR2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "FACD"
+           "longname",  "FACD"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "CO"
+           "longname",  "CO"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ALDX"
+           "longname",  "ALDX"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "GLYD"
+           "longname",  "GLYD"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "GLY"
+           "longname",  "GLY"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "MGLY"
+           "longname",  "MGLY"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ETHA"
+           "longname",  "ETHA"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ETOH"
+           "longname",  "ETOH"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "KET"
+           "longname",  "KET"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "PAR"
+           "longname",  "PAR"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ACET"
+           "longname",  "ACET"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "PRPA"
+           "longname",  "PRPA"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ETHY"
+           "longname",  "ETHY"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ETH"
+           "longname",  "ETH"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "OLE"
+           "longname",  "OLE"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "IOLE"
+           "longname",  "IOLE"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ISOP"
+           "longname",  "ISOP"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ISPD"
+           "longname",  "ISPD"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "INTR"
+           "longname",  "INTR"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ISPX"
+           "longname",  "ISPX"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "HPLD"
+           "longname",  "HPLD"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "OPO3"
+           "longname",  "OPO3"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "EPOX"
+           "longname",  "EPOX"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "TERP"
+           "longname",  "TERP"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "BENZENE"
+           "longname",  "BENZENE"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "CRES"
+           "longname",  "CRES"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "OPEN"
+           "longname",  "OPEN"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "TOL"
+           "longname",  "TOL"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "XOPN"
+           "longname",  "XOPN"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "XYLMN"
+           "longname",  "XYLMN"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "NAPH"
+           "longname",  "NAPH"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "CAT1"
+           "longname",  "CAT1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "CRON"
+           "longname",  "CRON"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "OPAN"
+           "longname",  "OPAN"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ECH4"
+           "longname",  "ECH4"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "CL2"
+           "longname",  "CL2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "HOCL"
+           "longname",  "HOCL"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "FMCL"
+           "longname",  "FMCL"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "HCL"
+           "longname",  "HCL"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "CLNO2"
+           "longname",  "CLNO2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SESQ"
+           "longname",  "SESQ"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SOAALK"
+           "longname",  "SOAALK"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "VLVPO1"
+           "longname",  "VLVPO1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "VSVPO1"
+           "longname",  "VSVPO1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "VSVPO2"
+           "longname",  "VSVPO2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "VSVPO3"
+           "longname",  "VSVPO3"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "VIVPO1"
+           "longname",  "VIVPO1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "VLVOO1"
+           "longname",  "VLVOO1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "VLVOO2"
+           "longname",  "VLVOO2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "VSVOO1"
+           "longname",  "VSVOO1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "VSVOO2"
+           "longname",  "VSVOO2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "VSVOO3"
+           "longname",  "VSVOO3"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "PCVOC"
+           "longname",  "PCVOC"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "FORM_PRIMARY"
+           "longname",  "FORM_PRIMARY"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ALD2_PRIMARY"
+           "longname",  "ALD2_PRIMARY"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "BUTADIENE13"
+           "longname",  "BUTADIENE13"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ACROLEIN"
+           "longname",  "ACROLEIN"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ACRO_PRIMARY"
+           "longname",  "ACRO_PRIMARY"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "TOLU"
+           "longname",  "TOLU"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "HG"
+           "longname",  "HG"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "HGIIGAS"
+           "longname",  "HGIIGAS"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASO4J"
+           "longname",  "ASO4J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASO4I"
+           "longname",  "ASO4I"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ANH4J"
+           "longname",  "ANH4J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ANH4I"
+           "longname",  "ANH4I"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ANO3J"
+           "longname",  "ANO3J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ANO3I"
+           "longname",  "ANO3I"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AALK1J"
+           "longname",  "AALK1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AALK2J"
+           "longname",  "AALK2J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AXYL1J"
+           "longname",  "AXYL1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AXYL2J"
+           "longname",  "AXYL2J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AXYL3J"
+           "longname",  "AXYL3J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ATOL1J"
+           "longname",  "ATOL1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ATOL2J"
+           "longname",  "ATOL2J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ATOL3J"
+           "longname",  "ATOL3J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ABNZ1J"
+           "longname",  "ABNZ1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ABNZ2J"
+           "longname",  "ABNZ2J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ABNZ3J"
+           "longname",  "ABNZ3J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "APAH1J"
+           "longname",  "APAH1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "APAH2J"
+           "longname",  "APAH2J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "APAH3J"
+           "longname",  "APAH3J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ATRP1J"
+           "longname",  "ATRP1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ATRP2J"
+           "longname",  "ATRP2J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AISO1J"
+           "longname",  "AISO1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AISO2J"
+           "longname",  "AISO2J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASQTJ"
+           "longname",  "ASQTJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AORGCJ"
+           "longname",  "AORGCJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AECJ"
+           "longname",  "AECJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AECI"
+           "longname",  "AECI"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AOTHRJ"
+           "longname",  "AOTHRJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AOTHRI"
+           "longname",  "AOTHRI"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AFEJ"
+           "longname",  "AFEJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AALJ"
+           "longname",  "AALJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASIJ"
+           "longname",  "ASIJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ATIJ"
+           "longname",  "ATIJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ACAJ"
+           "longname",  "ACAJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AMGJ"
+           "longname",  "AMGJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AKJ"
+           "longname",  "AKJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AMNJ"
+           "longname",  "AMNJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ACORS"
+           "longname",  "ACORS"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASOIL"
+           "longname",  "ASOIL"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "NUMATKN"
+           "longname",  "NUMATKN"
+           "units",     "num/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "NUMACC"
+           "longname",  "NUMACC"
+           "units",     "num/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "NUMCOR"
+           "longname",  "NUMCOR"
+           "units",     "num/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SRFATKN"
+           "longname",  "SRFATKN"
+           "units",     "m2/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SRFACC"
+           "longname",  "SRFACC"
+           "units",     "m2/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SRFCOR"
+           "longname",  "SRFCOR"
+           "units",     "m2/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AH2OJ"
+           "longname",  "AH2OJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AH2OI"
+           "longname",  "AH2OI"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AH3OPJ"
+           "longname",  "AH3OPJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AH3OPI"
+           "longname",  "AH3OPI"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ANAJ"
+           "longname",  "ANAJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ANAI"
+           "longname",  "ANAI"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ACLJ"
+           "longname",  "ACLJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ACLI"
+           "longname",  "ACLI"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASEACAT"
+           "longname",  "ASEACAT"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ACLK"
+           "longname",  "ACLK"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASO4K"
+           "longname",  "ASO4K"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ANH4K"
+           "longname",  "ANH4K"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ANO3K"
+           "longname",  "ANO3K"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AH2OK"
+           "longname",  "AH2OK"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AH3OPK"
+           "longname",  "AH3OPK"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AISO3J"
+           "longname",  "AISO3J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AOLGAJ"
+           "longname",  "AOLGAJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AOLGBJ"
+           "longname",  "AOLGBJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AGLYJ"
+           "longname",  "AGLYJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "APCSOJ"
+           "longname",  "APCSOJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ALVPO1I"
+           "longname",  "ALVPO1I"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVPO1I"
+           "longname",  "ASVPO1I"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVPO2I"
+           "longname",  "ASVPO2I"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ALVPO1J"
+           "longname",  "ALVPO1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVPO1J"
+           "longname",  "ASVPO1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVPO2J"
+           "longname",  "ASVPO2J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVPO3J"
+           "longname",  "ASVPO3J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AIVPO1J"
+           "longname",  "AIVPO1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ALVOO1I"
+           "longname",  "ALVOO1I"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ALVOO2I"
+           "longname",  "ALVOO2I"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVOO1I"
+           "longname",  "ASVOO1I"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVOO2I"
+           "longname",  "ASVOO2I"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ALVOO1J"
+           "longname",  "ALVOO1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ALVOO2J"
+           "longname",  "ALVOO2J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVOO1J"
+           "longname",  "ASVOO1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVOO2J"
+           "longname",  "ASVOO2J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVOO3J"
+           "longname",  "ASVOO3J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "NH3"
+           "longname",  "NH3"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_ALK1"
+           "longname",  "SV_ALK1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_ALK2"
+           "longname",  "SV_ALK2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_XYL1"
+           "longname",  "SV_XYL1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_XYL2"
+           "longname",  "SV_XYL2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_TOL1"
+           "longname",  "SV_TOL1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_TOL2"
+           "longname",  "SV_TOL2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_BNZ1"
+           "longname",  "SV_BNZ1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_BNZ2"
+           "longname",  "SV_BNZ2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_PAH1"
+           "longname",  "SV_PAH1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_PAH2"
+           "longname",  "SV_PAH2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_TRP1"
+           "longname",  "SV_TRP1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_TRP2"
+           "longname",  "SV_TRP2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_ISO1"
+           "longname",  "SV_ISO1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_ISO2"
+           "longname",  "SV_ISO2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SV_SQT"
+           "longname",  "SV_SQT"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "LV_PCSOG"
+           "longname",  "LV_PCSOG"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+# diagnostic air quality tracers
+ "TRACER", "atmos_mod", "PM25AT"
+           "longname",     "PM2.5 fraction of Aitken mode"
+           "units",        "1"
+           "tracer_usage", "chemistry", "type=diagnostic"
+           "profile_type", "fixed", "surface_value=0.0" /
+ "TRACER", "atmos_mod", "PM25AC"
+           "longname",     "PM2.5 fraction of accumulation mode"
+           "units",        "1"
+           "tracer_usage", "chemistry", "type=diagnostic"
+           "profile_type", "fixed", "surface_value=0.0" /
+ "TRACER", "atmos_mod", "PM25CO"
+           "longname",     "PM2.5 fraction of coarse mode"
+           "units",        "1"
+           "tracer_usage", "chemistry", "type=diagnostic"
+           "profile_type", "fixed", "surface_value=0.0" /
+"TRACER", "atmos_mod", "PM25_TOT"
+           "longname",     "PM 2.5 from AQM model"
+           "units",        "ug/m3"
+           "tracer_usage", "chemistry", "type=diagnostic"
+           "profile_type", "fixed", "surface_value=0.0" /
+# non-prognostic cloud amount
+ "TRACER", "atmos_mod", "cld_amt"
+           "longname",     "cloud amount"
+           "units",        "1"
+       "profile_type", "fixed", "surface_value=1.e30" /

--- a/parm/config/input.nml
+++ b/parm/config/input.nml
@@ -1,0 +1,357 @@
+&amip_interp_nml
+    data_set = 'reynolds_oi'
+    date_out_of_range = 'climo'
+    interp_oi_sst = .true.
+    no_anom_sst = .false.
+    use_ncep_ice = .false.
+    use_ncep_sst = .true.
+/
+
+&atmos_model_nml
+    blocksize = 16
+    ccpp_suite = 'FV3_GFS_v16'
+    chksum_debug = .false.
+    dycore_only = .false.
+/
+
+&cires_ugwp_nml
+    knob_ugwp_azdir = 2, 4, 4, 4
+    knob_ugwp_doaxyz = 1
+    knob_ugwp_doheat = 1
+    knob_ugwp_dokdis = 1
+    knob_ugwp_effac = 1, 1, 1, 1
+    knob_ugwp_ndx4lh = 1
+    knob_ugwp_solver = 2
+    knob_ugwp_source = 1, 1, 0, 0
+    knob_ugwp_stoch = 0, 0, 0, 0
+    knob_ugwp_version = 0
+    knob_ugwp_wvspec = 1, 25, 25, 25
+    launch_level = 27
+/
+
+&diag_manager_nml
+    max_output_fields = 450
+    prepend_date = .false.
+/
+
+&external_ic_nml
+    checker_tr = .false.
+    filtered_terrain = .true.
+    gfs_dwinds = .true.
+    levp = 65
+    nt_checker = 0
+/
+
+&fms_io_nml
+    checksum_required = .false.
+    max_files_r = 100
+    max_files_w = 100
+/
+
+&fms_nml
+    clock_grain = 'ROUTINE'
+    domains_stack_size = 12000000
+    print_memory_usage = .false.
+/
+
+&fv_core_nml
+    a_imp = 1.0
+    adjust_dry_mass = .false.
+    agrid_vel_rst = .false.
+    bc_update_interval = 6
+    beta = 0.0
+    consv_am = .false.
+    consv_te = 0.0
+    d2_bg = 0.0
+    d2_bg_k1 = 0.2
+    d2_bg_k2 = 0.0
+    d4_bg = 0.12
+    d_con = 1.0
+    d_ext = 0.0
+    dddmp = 0.1
+    delt_max = 0.002
+    dnats = 5
+    do_sat_adj = .true.
+    do_schmidt = .true.
+    do_vort_damp = .true.
+    dwind_2d = .false.
+    dz_min = 6
+    external_eta = .true.
+    external_ic = .true.
+    fill = .true.
+    full_zs_filter = .false.
+    fv_debug = .false.
+    fv_sg_adj = 450
+    gfs_phil = .false.
+    hord_dp = -5
+    hord_mt = 5
+    hord_tm = 5
+    hord_tr = 8
+    hord_vt = 5
+    hydrostatic = .false.
+    io_layout = 1, 1
+    k_split = 1
+    ke_bg = 0.0
+    kord_mt = 9
+    kord_tm = -9
+    kord_tr = 9
+    kord_wz = 9
+    layout = 50, 34
+    make_nh = .false.
+    mountain = .false.
+    n_split = 8
+    n_sponge = 10
+    n_zs_filter = 0
+    na_init = 0
+    ncep_ic = .false.
+    nggps_ic = .true.
+    no_dycore = .false.
+    nord = 2
+    npx = 801
+    npy = 545
+    npz = 64
+    nrows_blend = 0
+    ntiles = 1
+    nudge_dz = .false.
+    nudge_qv = .true.
+    nwat = 6
+    p_fac = 0.1
+    phys_hydrostatic = .false.
+    print_freq = 6
+    psm_bc = 1
+    range_warn = .false.
+    read_increment = .false.
+    regional = .true.
+    regional_bcs_from_gsi = .false.
+    res_latlon_dynamics = ''
+    reset_eta = .false.
+    rf_cutoff = 750.0
+    stretch_fac = 0.999
+    target_lat = 50.0
+    target_lon = -118.0
+    tau = 10.0
+    use_hydro_pressure = .false.
+    vtdm4 = 0.02
+    warm_start = .false.
+    write_restart_with_bcs = .false.
+    z_tracer = .true.
+/
+
+&fv_grid_nml
+    grid_file = 'INPUT/grid_spec.nc'
+/
+
+&gfdl_cloud_microphysics_nml
+    c_cracw = 0.8
+    c_paut = 0.5
+    c_pgacs = 0.01
+    c_psaci = 0.05
+    ccn_l = 300.0
+    ccn_o = 100.0
+    const_vg = .false.
+    const_vi = .false.
+    const_vr = .false.
+    const_vs = .false.
+    de_ice = .false.
+    do_qa = .true.
+    do_sedi_heat = .false.
+    dw_land = 0.16
+    dw_ocean = 0.1
+    fast_sat_adj = .true.
+    fix_negative = .true.
+    icloud_f = 1
+    mono_prof = .true.
+    mp_time = 150.0
+    prog_ccn = .false.
+    qi0_crt = 8e-05
+    qi_lim = 1.0
+    ql_gen = 0.001
+    ql_mlt = 0.001
+    qs0_crt = 0.001
+    rad_graupel = .true.
+    rad_rain = .true.
+    rad_snow = .true.
+    reiflag = 2
+    rh_inc = 0.3
+    rh_inr = 0.3
+    rh_ins = 0.3
+    rthresh = 1e-05
+    sedi_transport = .true.
+    tau_g2v = 900.0
+    tau_i2s = 1000.0
+    tau_l2v = 225.0
+    tau_v2l = 150.0
+    use_ccn = .true.
+    use_ppm = .false.
+    vg_max = 12.0
+    vi_max = 1.0
+    vr_max = 12.0
+    vs_max = 2.0
+    z_slope_ice = .true.
+    z_slope_liq = .true.
+/
+
+&gfs_physics_nml
+    cal_pre = .false.
+    cdmbgwd = 4.0, 0.15, 1.0, 1.0
+    cnvcld = .true.
+    cnvgwd = .true.
+    cplaqm = .true.
+    cplocn2atm = .false.
+    debug = .false.
+    do_shum = .false.
+    do_skeb = .false.
+    do_spp = .false.
+    do_sppt = .false.
+    do_tofd = .true.
+    do_ugwp = .false.
+    dspheat = .true.
+    effr_in = .true.
+    fhcyc = 0
+    fhlwr = 3600.0
+    fhswr = 3600.0
+    fhzero = 1.0
+    fscav_aero = 'aacd:0.0', 'acet:0.0', 'acrolein:0.0', 'acro_primary:0.0',
+                 'ald2:0.0', 'ald2_primary:0.0', 'aldx:0.0', 'benzene:0.0',
+                 'butadiene13:0.0', 'cat1:0.0', 'cl2:0.0', 'clno2:0.0',
+                 'co:0.0', 'cres:0.0', 'cron:0.0', 'ech4:0.0', 'epox:0.0',
+                 'eth:0.0', 'etha:0.0', 'ethy:0.0', 'etoh:0.0', 'facd:0.0',
+                 'fmcl:0.0', 'form:0.0', 'form_primary:0.0', 'gly:0.0',
+                 'glyd:0.0', 'h2o2:0.0', 'hcl:0.0', 'hg:0.0', 'hgiigas:0.0',
+                 'hno3:0.0', 'hocl:0.0', 'hono:0.0', 'hpld:0.0', 'intr:0.0',
+                 'iole:0.0', 'isop:0.0', 'ispd:0.0', 'ispx:0.0', 'ket:0.0',
+                 'meoh:0.0', 'mepx:0.0', 'mgly:0.0', 'n2o5:0.0', 'naph:0.0',
+                 'no:0.0', 'no2:0.0', 'no3:0.0', 'ntr1:0.0', 'ntr2:0.0',
+                 'o3:0.0', 'ole:0.0', 'opan:0.0', 'open:0.0', 'opo3:0.0',
+                 'pacd:0.0', 'pan:0.0', 'panx:0.0', 'par:0.0', 'pcvoc:0.0',
+                 'pna:0.0', 'prpa:0.0', 'rooh:0.0', 'sesq:0.0', 'so2:0.0',
+                 'soaalk:0.0', 'sulf:0.0', 'terp:0.0', 'tol:0.0', 'tolu:0.0',
+                 'vivpo1:0.0', 'vlvoo1:0.0', 'vlvoo2:0.0', 'vlvpo1:0.0',
+                 'vsvoo1:0.0', 'vsvoo2:0.0', 'vsvoo3:0.0', 'vsvpo1:0.0',
+                 'vsvpo2:0.0', 'vsvpo3:0.0', 'xopn:0.0', 'xylmn:0.0', '*:0.2'
+    h2o_phys = .true.
+    hybedmf = .false.
+    iaer = 5111
+    ialb = 1
+    iau_inc_files = ''
+    icliq_sw = 2
+    ico2 = 2
+    iems = 1
+    imfdeepcnv = 2
+    imfshalcnv = 2
+    imp_physics = 11
+    iopt_alb = 2
+    iopt_btr = 1
+    iopt_crs = 1
+    iopt_dveg = 1
+    iopt_frz = 1
+    iopt_inf = 1
+    iopt_rad = 1
+    iopt_run = 1
+    iopt_sfc = 1
+    iopt_snf = 4
+    iopt_stc = 1
+    iopt_tbot = 2
+    iopt_trs = 2
+    iovr = 3
+    isatmedmf = 1
+    isol = 2
+    isot = 1
+    isubc_lw = 2
+    isubc_sw = 2
+    ivegsrc = 1
+    ldiag3d = .false.
+    ldiag_ugwp = .false.
+    lgfdlmprad = .true.
+    lheatstrg = .true.
+    lndp_type = 0
+    lsm = 1
+    lsoil = 4
+    lwhtr = .true.
+    n_var_lndp = 0
+    n_var_spp = 0
+    nsradar_reset = 3600
+    nst_anl = .true.
+    nstf_name = 2, 1, 0, 0, 0
+    oz_phys = .false.
+    oz_phys_2015 = .true.
+    pdfcld = .false.
+    prautco = 0.00015, 0.00015
+    pre_rad = .false.
+    print_diff_pgr = .false.
+    prslrd0 = 0.0
+    psautco = 0.0008, 0.0005
+    random_clds = .false.
+    redrag = .true.
+    satmedmf = .true.
+    sfclay_compute_flux = .false.
+    shal_cnv = .true.
+    swhtr = .true.
+    trans_trac = .true.
+    use_ufo = .true.
+/
+
+&interpolator_nml
+    interp_method = 'conserve_great_circle'
+/
+
+&mpp_io_nml
+    deflate_level = 1
+    shuffle = 1
+/
+
+&nam_sfcperts
+/
+
+&nam_sppperts
+/
+
+&nam_stochy
+/
+
+&namsfc
+    fabsl = 99999
+    faisl = 99999
+    faiss = 99999
+    fnacna = ''
+    fnaisc = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_am/CFSR.SEAICE.1982.2012.monthly.clim.grb'
+    fnglac = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_am/global_glacier.2x2.grb'
+    fnmskh = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_am/seaice_newland.grb'
+    fnmxic = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_am/global_maxice.2x2.grb'
+    fnsmcc = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_am/global_soilmgldas.t126.384.190.grb'
+    fnsnoa = ''
+    fnsnoc = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_am/global_snoclim.1.875.grb'
+    fntsfa = ''
+    fntsfc = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_am/RTGSST.1982.2012.monthly.clim.grb'
+    fnzorc = 'igbp'
+    fsicl = 99999
+    fsics = 99999
+    fslpl = 99999
+    fsmcl = 99999, 99999, 99999
+    fsnol = 99999
+    fsnos = 99999
+    fsotl = 99999
+    ftsfl = 99999
+    ftsfs = 90
+    fvetl = 99999
+    fvmnl = 99999
+    fvmxl = 99999
+    landice = .true.
+    ldebug = .false.
+/
+
+&namsfc_dict
+    fnabsc = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_lam/C793.maximum_snow_albedo.tileX.nc'
+    fnalbc = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_lam/C793.snowfree_albedo.tileX.nc'
+    fnalbc2 = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_lam/C793.facsf.tileX.nc'
+    fnslpc = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_lam/C793.slope_type.tileX.nc'
+    fnsotc = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_lam/C793.soil_type.tileX.nc'
+    fntg3c = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_lam/C793.substrate_temperature.tileX.nc'
+    fnvegc = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_lam/C793.vegetation_greenness.tileX.nc'
+    fnvetc = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_lam/C793.vegetation_type.tileX.nc'
+    fnvmnc = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_lam/C793.vegetation_greenness.tileX.nc'
+    fnvmxc = '/lfs/h2/emc/global/noscrub/lin.gan/para/packages/aqm.v7.0.75/fix/fix_lam/C793.vegetation_greenness.tileX.nc'
+/
+
+&surf_map_nml
+/

--- a/parm/config/var_defns.sh
+++ b/parm/config/var_defns.sh
@@ -1,0 +1,1109 @@
+# [metadata]
+description='config for Online-CMAQ, AQM_NA_13km, real-time, NCO mode on WCOSS2'
+version='1.0'
+
+# [user]
+RUN_ENVIR='nco'
+MACHINE='WCOSS2'
+export USHdir=${HOMEaqm}/ush
+export SCRIPTSdir=${HOMEaqm}/scripts
+export JOBSdir=${HOMEaqm}/jobs
+export SORCdir=${HOMEaqm}/sorc
+export PARMdir=${HOMEaqm}/parm
+export EXECdir=${HOMEaqm}/exec
+export VX_CONFIG_DIR=${HOMEaqm}/parm
+export UFS_WTHR_MDL_DIR=${HOMEaqm}/sorc/ufs-weather-model
+export ARL_NEXUS_DIR=${HOMEaqm}/sorc/arl_nexus
+
+
+#HOMEaqm='${HOMEaqm}'
+#export USHdir='${HOMEaqm}/ush'
+#export SCRIPTSdir='${HOMEaqm}/scripts'
+#export JOBSdir='${HOMEaqm}/jobs'
+#export SORCdir='${HOMEaqm}/sorc'
+#export PARMdir='${HOMEaqm}/parm'
+#export EXECdir='${HOMEaqm}/exec'
+#export VX_CONFIG_DIR='${HOMEaqm}/parm'
+#export UFS_WTHR_MDL_DIR='${HOMEaqm}/sorc/ufs-weather-model'
+#export ARL_NEXUS_DIR='${HOMEaqm}/sorc/arl_nexus'
+
+# [platform]
+WORKFLOW_MANAGER='ecflow'
+NCORES_PER_NODE='128'
+TASKTHROTTLE='1000'
+BUILD_MOD_FN='build_wcoss2_intel'
+WFLOW_MOD_FN='wflow_wcoss2'
+BUILD_VER_FN='build.ver.wcoss2'
+RUN_VER_FN='run.ver.wcoss2'
+SCHED='pbspro'
+PARTITION_DEFAULT=''
+QUEUE_DEFAULT='dev'
+PARTITION_HPSS=''
+QUEUE_HPSS='dev'
+PARTITION_FCST=''
+QUEUE_FCST='dev'
+RUN_CMD_SERIAL='time'
+RUN_CMD_UTILS='mpiexec -n ${nprocs}'
+RUN_CMD_FCST='mpiexec -n ${PE_MEMBER01} -ppn ${PPN_RUN_FCST} --cpu-bind core -depth ${OMP_NUM_THREADS_RUN_FCST}'
+RUN_CMD_POST='mpiexec -n ${nprocs}'
+RUN_CMD_PRDGEN='mpiexec -n ${nprocs} --cpu-bind core cfp'
+RUN_CMD_AQM='mpiexec -n ${nprocs} -ppn ${ppn_run_aqm} --cpu-bind core -depth ${omp_num_threads_run_aqm}'
+RUN_CMD_AQMLBC='mpiexec -n ${NUMTS}'
+SCHED_NATIVE_CMD='-l place=excl'
+CCPA_OBS_DIR='/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/obs_data/ccpa/proc'
+MRMS_OBS_DIR='/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/obs_data/mrms/proc'
+NDAS_OBS_DIR='/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/obs_data/ndas/proc'
+DOMAIN_PREGEN_BASEDIR='/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/FV3LAM_pregen'
+PRE_TASK_CMDS='{ ulimit -s unlimited; ulimit -a; }'
+TEST_EXTRN_MDL_SOURCE_BASEDIR='/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/input_model_data'
+TEST_PREGEN_BASEDIR='/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/FV3LAM_pregen'
+TEST_ALT_EXTRN_MDL_SYSBASEDIR_ICS=''
+TEST_ALT_EXTRN_MDL_SYSBASEDIR_LBCS=''
+TEST_VX_FCST_INPUT_BASEDIR=''
+FIXgsm='/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_am'
+FIXaer='/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_aer'
+FIXlut='/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_lut'
+FIXorg='/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_orog'
+FIXsfc='/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/fix/fix_sfc_climo'
+FIXshp='/lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/NaturalEarth'
+EXTRN_MDL_DATA_STORES='hpss aws nomads'
+COMINairnow='/lfs/h1/ops/prod/dcom'
+
+# [workflow]
+RELATIVE_LINK_FLAG='--relative'
+USE_CRON_TO_RELAUNCH='TRUE'
+CRON_RELAUNCH_INTVL_MNTS='3'
+EXPT_BASEDIR=${HOMEaqm}
+EXPT_SUBDIR='parm/config'
+EXEC_SUBDIR='exec'
+EXPTDIR=${HOMEaqm}/parm/config
+DOT_OR_USCORE='_'
+EXPT_CONFIG_FN='config.yaml'
+CONSTANTS_FN='constants.yaml'
+RGNL_GRID_NML_FN='regional_grid.nml'
+FV3_NML_BASE_SUITE_FN='input.nml.FV3'
+FV3_NML_YAML_CONFIG_FN='FV3.input.yml'
+FV3_NML_BASE_ENS_FN='input.nml.base_ens'
+FV3_NML_FN='input.nml'
+FV3_EXEC_FN='ufs_model'
+DATA_TABLE_FN='data_table'
+DIAG_TABLE_FN='diag_table'
+FIELD_TABLE_FN='field_table'
+DIAG_TABLE_TMPL_FN='diag_table_aqm.FV3_GFS_v16'
+FIELD_TABLE_TMPL_FN='field_table_aqm.FV3_GFS_v16'
+MODEL_CONFIG_FN='model_configure'
+NEMS_CONFIG_FN='nems.configure'
+AQM_RC_FN='aqm.rc'
+AQM_RC_TMPL_FN='aqm.rc'
+FV3_NML_BASE_SUITE_FP=${HOMEaqm}/parm/input.nml.FV3
+FV3_NML_YAML_CONFIG_FP=${HOMEaqm}/parm/FV3.input.yml
+FV3_NML_BASE_ENS_FP=${HOMEaqm}/parm/config/input.nml.base_ens
+DATA_TABLE_TMPL_FP=${HOMEaqm}/parm/data_table
+DIAG_TABLE_TMPL_FP=${HOMEaqm}/parm/diag_table_aqm.FV3_GFS_v16
+FIELD_TABLE_TMPL_FP=${HOMEaqm}/parm/field_table_aqm.FV3_GFS_v16
+MODEL_CONFIG_TMPL_FP=${HOMEaqm}/parm/model_configure
+NEMS_CONFIG_TMPL_FP=${HOMEaqm}/parm/nems.configure
+AQM_RC_TMPL_FP=${HOMEaqm}/parm/aqm.rc
+DATA_TABLE_FP=${HOMEaqm}/parm/config/data_table
+FIELD_TABLE_FP=${HOMEaqm}/parm/config/field_table
+NEMS_CONFIG_FP=${HOMEaqm}/parm/config/nems.configure
+FV3_NML_FP=${HOMEaqm}/parm/config/input.nml
+FCST_MODEL='ufs-weather-model'
+WFLOW_XML_FN='FV3LAM_wflow.xml'
+GLOBAL_VAR_DEFNS_FN='var_defns.sh'
+EXTRN_MDL_VAR_DEFNS_FN='extrn_mdl_var_defns'
+WFLOW_LAUNCH_SCRIPT_FN='launch_FV3LAM_wflow.sh'
+WFLOW_LAUNCH_LOG_FN='log.launch_FV3LAM_wflow'
+export GLOBAL_VAR_DEFNS_FP='${HOMEaqm}/parm/config/var_defns.sh'
+WFLOW_LAUNCH_SCRIPT_FP='${HOMEaqm}/ush/launch_FV3LAM_wflow.sh'
+WFLOW_LAUNCH_LOG_FP='${HOMEaqm}/parm/config/log.launch_FV3LAM_wflow'
+FIXdir=${HOMEaqm}/fix
+FIXam=${HOMEaqm}/fix/fix_am
+FIXclim=${HOMEaqm}/fix/fix_clim
+FIXlam=${HOMEaqm}/fix/fix_lam
+THOMPSON_MP_CLIMO_FN='Thompson_MP_MONTHLY_CLIMO.nc'
+THOMPSON_MP_CLIMO_FP='${HOMEaqm}/fix/fix_am/Thompson_MP_MONTHLY_CLIMO.nc'
+CCPP_PHYS_SUITE='FV3_GFS_v16'
+CCPP_PHYS_SUITE_FN='suite_FV3_GFS_v16.xml'
+CCPP_PHYS_SUITE_IN_CCPP_FP='${HOMEaqm}/sorc/ufs-weather-model/FV3/ccpp/suites/suite_FV3_GFS_v16.xml'
+CCPP_PHYS_SUITE_FP='${HOMEaqm}/sorc/ufs-weather-model/FV3/ccpp/suites/suite_FV3_GFS_v16.xml'
+FIELD_DICT_FN='fd_nems.yaml'
+FIELD_DICT_IN_UWM_FP='${HOMEaqm}/sorc/ufs-weather-model/tests/parm/fd_nems.yaml'
+FIELD_DICT_FP='${HOMEaqm}/sorc/ufs-weather-model/tests/parm/fd_nems.yaml'
+GRID_GEN_METHOD='ESGgrid'
+PREDEF_GRID_NAME='AQM_NA_13km'
+DATE_FIRST_CYCL='202304250000'
+DATE_LAST_CYCL='209904251800'
+INCR_CYCL_FREQ='6'
+FCST_LEN_HRS='-1'
+FCST_LEN_CYCL=( "6" "72" "72" "6" )
+PREEXISTING_DIR_METHOD='rename'
+VERBOSE='TRUE'
+DEBUG='FALSE'
+COMPILER='intel'
+SYMLINK_FIX_FILES='TRUE'
+DO_REAL_TIME='TRUE'
+COLDSTART='FALSE'
+FCST_LEN_CYCL_ALL=( "6" "72" "72" "6" )
+RES_IN_FIXLAM_FILENAMES='793'
+CRES='C793'
+SDF_USES_RUC_LSM='FALSE'
+SDF_USES_THOMPSON_MP='FALSE'
+
+# [nco]
+envir='prod'
+NET='aqm'
+RUN='aqm'
+model_ver='v7.0'
+COMIN_BASEDIR='${COMaqm}'
+COMOUT_BASEDIR='${COMaqm}'
+DBNROOT=''
+SENDECF='FALSE'
+SENDDBN='FALSE'
+SENDDBN_NTC='FALSE'
+SENDCOM='FALSE'
+SENDWEB='FALSE'
+# KEEPDATA='TRUE'
+MAILTO=''
+MAILCC=''
+
+# [workflow_switches]
+RUN_TASK_MAKE_GRID='FALSE'
+RUN_TASK_MAKE_OROG='FALSE'
+RUN_TASK_MAKE_SFC_CLIMO='FALSE'
+RUN_TASK_GET_EXTRN_ICS='TRUE'
+RUN_TASK_GET_EXTRN_LBCS='TRUE'
+RUN_TASK_MAKE_ICS='TRUE'
+RUN_TASK_MAKE_LBCS='TRUE'
+RUN_TASK_RUN_FCST='TRUE'
+RUN_TASK_RUN_POST='TRUE'
+RUN_TASK_RUN_PRDGEN='FALSE'
+RUN_TASK_GET_OBS_CCPA='FALSE'
+RUN_TASK_GET_OBS_MRMS='FALSE'
+RUN_TASK_GET_OBS_NDAS='FALSE'
+RUN_TASK_VX_GRIDSTAT='FALSE'
+RUN_TASK_VX_POINTSTAT='FALSE'
+RUN_TASK_VX_ENSGRID='FALSE'
+RUN_TASK_VX_ENSPOINT='FALSE'
+RUN_TASK_PLOT_ALLVARS='FALSE'
+RUN_TASK_AQM_ICS='TRUE'
+RUN_TASK_AQM_LBCS='TRUE'
+RUN_TASK_NEXUS_GFS_SFC='TRUE'
+RUN_TASK_NEXUS_EMISSION='TRUE'
+RUN_TASK_FIRE_EMISSION='TRUE'
+RUN_TASK_POINT_SOURCE='TRUE'
+RUN_TASK_PRE_POST_STAT='TRUE'
+RUN_TASK_POST_STAT_O3='TRUE'
+RUN_TASK_POST_STAT_PM25='TRUE'
+RUN_TASK_BIAS_CORRECTION_O3='TRUE'
+RUN_TASK_BIAS_CORRECTION_PM25='TRUE'
+
+# [task_make_grid]
+TN_MAKE_GRID='make_grid'
+NNODES_MAKE_GRID='1'
+PPN_MAKE_GRID='24'
+WTIME_MAKE_GRID='00:20:00'
+MAXTRIES_MAKE_GRID='2'
+GRID_DIR='/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/DOMAIN_DATA/AQM_NA_13km'
+ESGgrid_LON_CTR='-118.0'
+ESGgrid_LAT_CTR='50.0'
+ESGgrid_DELX='13000.0'
+ESGgrid_DELY='13000.0'
+ESGgrid_NX='800'
+ESGgrid_NY='544'
+ESGgrid_WIDE_HALO_WIDTH='6'
+ESGgrid_PAZI='0.0'
+GFDLgrid_LON_T6_CTR=''
+GFDLgrid_LAT_T6_CTR=''
+GFDLgrid_NUM_CELLS=''
+GFDLgrid_STRETCH_FAC=''
+GFDLgrid_REFINE_RATIO=''
+GFDLgrid_ISTART_OF_RGNL_DOM_ON_T6G=''
+GFDLgrid_IEND_OF_RGNL_DOM_ON_T6G=''
+GFDLgrid_JSTART_OF_RGNL_DOM_ON_T6G=''
+GFDLgrid_JEND_OF_RGNL_DOM_ON_T6G=''
+GFDLgrid_USE_NUM_CELLS_IN_FILENAMES=''
+
+# [task_make_orog]
+TN_MAKE_OROG='make_orog'
+NNODES_MAKE_OROG='1'
+PPN_MAKE_OROG='24'
+WTIME_MAKE_OROG='00:20:00'
+MAXTRIES_MAKE_OROG='2'
+KMP_AFFINITY_MAKE_OROG='disabled'
+OMP_NUM_THREADS_MAKE_OROG='6'
+OMP_STACKSIZE_MAKE_OROG='2048m'
+OROG_DIR='/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/DOMAIN_DATA/AQM_NA_13km'
+
+# [task_make_sfc_climo]
+TN_MAKE_SFC_CLIMO='make_sfc_climo'
+NNODES_MAKE_SFC_CLIMO='2'
+PPN_MAKE_SFC_CLIMO='24'
+WTIME_MAKE_SFC_CLIMO='00:20:00'
+MAXTRIES_MAKE_SFC_CLIMO='2'
+KMP_AFFINITY_MAKE_SFC_CLIMO='scatter'
+OMP_NUM_THREADS_MAKE_SFC_CLIMO='1'
+OMP_STACKSIZE_MAKE_SFC_CLIMO='1024m'
+SFC_CLIMO_DIR='/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/DOMAIN_DATA/AQM_NA_13km'
+
+# [task_get_extrn_ics]
+TN_GET_EXTRN_ICS='get_extrn_ics'
+NNODES_GET_EXTRN_ICS='1'
+PPN_GET_EXTRN_ICS='1'
+MEM_GET_EXTRN_ICS='2G'
+WTIME_GET_EXTRN_ICS='00:45:00'
+MAXTRIES_GET_EXTRN_ICS='1'
+EXTRN_MDL_NAME_ICS='FV3GFS'
+EXTRN_MDL_ICS_OFFSET_HRS='6'
+FV3GFS_FILE_FMT_ICS='netcdf'
+EXTRN_MDL_SYSBASEDIR_ICS='compath.py ${envir}/gfs/${gfs_ver}/gfs.${PDYext}/${cycext}/atmos'
+USE_USER_STAGED_EXTRN_FILES='FALSE'
+EXTRN_MDL_SOURCE_BASEDIR_ICS=''
+EXTRN_MDL_FILES_ICS=''
+
+# [task_get_extrn_lbcs]
+TN_GET_EXTRN_LBCS='get_extrn_lbcs'
+NNODES_GET_EXTRN_LBCS='1'
+PPN_GET_EXTRN_LBCS='1'
+MEM_GET_EXTRN_LBCS='2G'
+WTIME_GET_EXTRN_LBCS='02:00:00'
+MAXTRIES_GET_EXTRN_LBCS='1'
+EXTRN_MDL_NAME_LBCS='FV3GFS'
+LBC_SPEC_INTVL_HRS='6'
+EXTRN_MDL_LBCS_OFFSET_HRS='6'
+FV3GFS_FILE_FMT_LBCS='netcdf'
+EXTRN_MDL_SYSBASEDIR_LBCS='compath.py ${envir}/gfs/${gfs_ver}/gfs.${PDYext}/${cycext}/atmos'
+USE_USER_STAGED_EXTRN_FILES='FALSE'
+EXTRN_MDL_SOURCE_BASEDIR_LBCS=''
+EXTRN_MDL_FILES_LBCS=''
+
+# [task_make_ics]
+TN_MAKE_ICS='make_ics'
+NNODES_MAKE_ICS='4'
+PPN_MAKE_ICS='12'
+WTIME_MAKE_ICS='00:30:00'
+MAXTRIES_MAKE_ICS='1'
+KMP_AFFINITY_MAKE_ICS='scatter'
+OMP_NUM_THREADS_MAKE_ICS='1'
+OMP_STACKSIZE_MAKE_ICS='1024m'
+USE_FVCOM='FALSE'
+FVCOM_WCSTART='cold'
+FVCOM_DIR=''
+FVCOM_FILE='fvcom.nc'
+
+# [task_make_lbcs]
+TN_MAKE_LBCS='make_lbcs'
+NNODES_MAKE_LBCS='1'
+PPN_MAKE_LBCS='128'
+WTIME_MAKE_LBCS='00:30:00'
+MAXTRIES_MAKE_LBCS='1'
+KMP_AFFINITY_MAKE_LBCS='scatter'
+OMP_NUM_THREADS_MAKE_LBCS='1'
+OMP_STACKSIZE_MAKE_LBCS='1024m'
+
+# [task_run_fcst]
+TN_RUN_FCST='run_fcst'
+NNODES_RUN_FCST='14'
+PPN_RUN_FCST='128'
+WTIME_RUN_FCST='04:00:00'
+MAXTRIES_RUN_FCST='1'
+FV3_EXEC_FP='${HOMEaqm}/exec/ufs_model'
+KMP_AFFINITY_RUN_FCST='scatter'
+OMP_NUM_THREADS_RUN_FCST='1'
+OMP_STACKSIZE_RUN_FCST='512m'
+DT_ATMOS='180'
+FHROT='0'
+RESTART_INTERVAL='6 24 42 60'
+WRITE_DOPOST='FALSE'
+LAYOUT_X='50'
+LAYOUT_Y='34'
+BLOCKSIZE='16'
+QUILTING='TRUE'
+PRINT_ESMF='FALSE'
+PE_MEMBER01='1792'
+WRTCMP_write_groups='2'
+WRTCMP_write_tasks_per_group='46'
+WRTCMP_output_grid='rotated_latlon'
+WRTCMP_cen_lon='-118.0'
+WRTCMP_cen_lat='50.0'
+WRTCMP_lon_lwr_left='-45.25'
+WRTCMP_lat_lwr_left='-28.5'
+WRTCMP_lon_upr_rght='45.25'
+WRTCMP_lat_upr_rght='28.5'
+WRTCMP_dlon='0.116908139'
+WRTCMP_dlat='0.116908139'
+WRTCMP_stdlat1=''
+WRTCMP_stdlat2=''
+WRTCMP_nx=''
+WRTCMP_ny=''
+WRTCMP_dx=''
+WRTCMP_dy=''
+USE_MERRA_CLIMO='FALSE'
+DO_FCST_RESTART='TRUE'
+
+# [task_run_post]
+TN_RUN_POST='run_post'
+NNODES_RUN_POST='2'
+PPN_RUN_POST='24'
+WTIME_RUN_POST='00:15:00'
+MAXTRIES_RUN_POST='2'
+KMP_AFFINITY_RUN_POST='scatter'
+OMP_NUM_THREADS_RUN_POST='1'
+OMP_STACKSIZE_RUN_POST='1024m'
+SUB_HOURLY_POST='FALSE'
+DT_SUBHOURLY_POST_MNTS='0'
+USE_CUSTOM_POST_CONFIG_FILE='FALSE'
+CUSTOM_POST_CONFIG_FP=''
+POST_OUTPUT_DOMAIN_NAME='793'
+TESTBED_FIELDS_FN=''
+
+# [task_run_prdgen]
+TN_RUN_PRDGEN='run_prdgen'
+NNODES_RUN_PRDGEN='1'
+PPN_RUN_PRDGEN='22'
+WTIME_RUN_PRDGEN='00:30:00'
+MAXTRIES_RUN_PRDGEN='1'
+KMP_AFFINITY_RUN_PRDGEN='scatter'
+OMP_NUM_THREADS_RUN_PRDGEN='1'
+OMP_STACKSIZE_RUN_PRDGEN='1024m'
+DO_PARALLEL_PRDGEN='FALSE'
+ADDNL_OUTPUT_GRIDS=( "" )
+
+# [task_plot_allvars]
+TN_PLOT_ALLVARS='plot_allvars'
+NNODES_PLOT_ALLVARS='1'
+PPN_PLOT_ALLVARS='24'
+WTIME_PLOT_ALLVARS='01:00:00'
+MAXTRIES_PLOT_ALLVARS='1'
+COMOUT_REF=''
+PLOT_FCST_START='0'
+PLOT_FCST_INC='3'
+PLOT_FCST_END=''
+PLOT_DOMAINS=( "conus" )
+
+# [task_get_obs_ccpa]
+TN_GET_OBS_CCPA='get_obs_ccpa'
+NNODES_GET_OBS_CCPA='1'
+PPN_GET_OBS_CCPA='1'
+MEM_GET_OBS_CCPA='2G'
+WTIME_GET_OBS_CCPA='00:45:00'
+MAXTRIES_GET_OBS_CCPA='1'
+
+# [task_get_obs_mrms]
+TN_GET_OBS_MRMS='get_obs_mrms'
+NNODES_GET_OBS_MRMS='1'
+PPN_GET_OBS_MRMS='1'
+MEM_GET_OBS_MRMS='2G'
+WTIME_GET_OBS_MRMS='00:45:00'
+MAXTRIES_GET_OBS_MRMS='1'
+
+# [task_get_obs_ndas]
+TN_GET_OBS_NDAS='get_obs_ndas'
+NNODES_GET_OBS_NDAS='1'
+PPN_GET_OBS_NDAS='1'
+MEM_GET_OBS_NDAS='2G'
+WTIME_GET_OBS_NDAS='02:00:00'
+MAXTRIES_GET_OBS_NDAS='1'
+
+# [task_tn_run_met_pb2nc_obs]
+TN_RUN_MET_PB2NC_OBS='run_MET_Pb2nc_obs'
+NNODES_RUN_MET_PB2NC_OBS='1'
+PPN_RUN_MET_PB2NC_OBS='1'
+MEM_RUN_MET_PB2NC_OBS='2G'
+WTIME_RUN_MET_PB2NC_OBS='00:30:00'
+MAXTRIES_RUN_MET_PB2NC_OBS='2'
+
+# [task_tn_run_met_pcpcombine]
+TN_RUN_MET_PCPCOMBINE='run_MET_PcpCombine'
+NNODES_RUN_MET_PCPCOMBINE_OBS='1'
+PPN_RUN_MET_PCPCOMBINE_OBS='1'
+MEM_RUN_MET_PCPCOMBINE_OBS='2G'
+WTIME_RUN_MET_PCPCOMBINE_OBS='00:30:00'
+MAXTRIES_RUN_MET_PCPCOMBINE_OBS='2'
+NNODES_RUN_MET_PCPCOMBINE_FCST='1'
+PPN_RUN_MET_PCPCOMBINE_FCST='1'
+MEM_RUN_MET_PCPCOMBINE_FCST='2G'
+WTIME_RUN_MET_PCPCOMBINE_FCST='00:30:00'
+MAXTRIES_RUN_MET_PCPCOMBINE_FCST='2'
+
+# [task_run_met_gridstat_vx_apcp01h]
+TN_RUN_MET_GRIDSTAT_VX_APCP01H='run_MET_GridStat_vx_APCP01h'
+NNODES_RUN_MET_GRIDSTAT_VX_APCP01H='1'
+PPN_RUN_MET_GRIDSTAT_VX_APCP01H='1'
+MEM_RUN_MET_GRIDSTAT_VX_APCP01H='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_APCP01H='02:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_APCP01H='2'
+
+# [task_run_met_gridstat_vx_apcp03h]
+TN_RUN_MET_GRIDSTAT_VX_APCP03H='run_MET_GridStat_vx_APCP03h'
+NNODES_RUN_MET_GRIDSTAT_VX_APCP03H='1'
+PPN_RUN_MET_GRIDSTAT_VX_APCP03H='1'
+MEM_RUN_MET_GRIDSTAT_VX_APCP03H='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_APCP03H='02:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_APCP03H='2'
+
+# [task_run_met_gridstat_vx_apcp06h]
+TN_RUN_MET_GRIDSTAT_VX_APCP06H='run_MET_GridStat_vx_APCP06h'
+NNODES_RUN_MET_GRIDSTAT_VX_APCP06H='1'
+PPN_RUN_MET_GRIDSTAT_VX_APCP06H='1'
+MEM_RUN_MET_GRIDSTAT_VX_APCP06H='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_APCP06H='02:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_APCP06H='2'
+
+# [task_run_met_gridstat_vx_apcp24h]
+TN_RUN_MET_GRIDSTAT_VX_APCP24H='run_MET_GridStat_vx_APCP24h'
+NNODES_RUN_MET_GRIDSTAT_VX_APCP24H='1'
+PPN_RUN_MET_GRIDSTAT_VX_APCP24H='1'
+MEM_RUN_MET_GRIDSTAT_VX_APCP24H='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_APCP24H='02:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_APCP24H='2'
+
+# [task_run_met_gridstat_vx_refc]
+TN_RUN_MET_GRIDSTAT_VX_REFC='run_MET_GridStat_vx_REFC'
+NNODES_RUN_MET_GRIDSTAT_VX_REFC='1'
+PPN_RUN_MET_GRIDSTAT_VX_REFC='1'
+MEM_RUN_MET_GRIDSTAT_VX_REFC='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_REFC='02:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_REFC='2'
+
+# [task_run_met_gridstat_vx_retop]
+TN_RUN_MET_GRIDSTAT_VX_RETOP='run_MET_GridStat_vx_RETOP'
+NNODES_RUN_MET_GRIDSTAT_VX_RETOP='1'
+PPN_RUN_MET_GRIDSTAT_VX_RETOP='1'
+MEM_RUN_MET_GRIDSTAT_VX_RETOP='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_RETOP='02:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_RETOP='2'
+
+# [task_run_met_pointstat_vx_sfc]
+TN_RUN_MET_POINTSTAT_VX_SFC='run_MET_PointStat_vx_SFC'
+NNODES_RUN_MET_POINTSTAT_VX_SFC='1'
+PPN_RUN_MET_POINTSTAT_VX_SFC='1'
+MEM_RUN_MET_POINTSTAT_VX_SFC='2G'
+WTIME_RUN_MET_POINTSTAT_VX_SFC='01:00:00'
+MAXTRIES_RUN_MET_POINTSTAT_VX_SFC='2'
+
+# [task_run_met_pointstat_vx_upa]
+TN_RUN_MET_POINTSTAT_VX_UPA='run_MET_PointStat_vx_UPA'
+NNODES_RUN_MET_POINTSTAT_VX_UPA='1'
+PPN_RUN_MET_POINTSTAT_VX_UPA='1'
+MEM_RUN_MET_POINTSTAT_VX_UPA='2G'
+WTIME_RUN_MET_POINTSTAT_VX_UPA='01:00:00'
+MAXTRIES_RUN_MET_POINTSTAT_VX_UPA='2'
+
+# [task_run_met_ensemblestat_vx_apcp01h]
+TN_RUN_MET_ENSEMBLESTAT_VX_APCP01H='run_MET_EnsembleStat_vx_APCP01h'
+NNODES_RUN_MET_ENSEMBLESTAT_VX_APCP01H='1'
+PPN_RUN_MET_ENSEMBLESTAT_VX_APCP01H='1'
+MEM_RUN_MET_ENSEMBLESTAT_VX_APCP01H='2G'
+WTIME_RUN_MET_ENSEMBLESTAT_VX_APCP01H='01:00:00'
+MAXTRIES_RUN_MET_ENSEMBLESTAT_VX_APCP01H='2'
+
+# [task_run_met_ensemblestat_vx_apcp03h]
+TN_RUN_MET_ENSEMBLESTAT_VX_APCP03H='run_MET_EnsembleStat_vx_APCP03h'
+NNODES_RUN_MET_ENSEMBLESTAT_VX_APCP03H='1'
+PPN_RUN_MET_ENSEMBLESTAT_VX_APCP03H='1'
+MEM_RUN_MET_ENSEMBLESTAT_VX_APCP03H='2G'
+WTIME_RUN_MET_ENSEMBLESTAT_VX_APCP03H='01:00:00'
+MAXTRIES_RUN_MET_ENSEMBLESTAT_VX_APCP03H='2'
+
+# [task_run_met_ensemblestat_vx_apcp06h]
+TN_RUN_MET_ENSEMBLESTAT_VX_APCP06H='run_MET_EnsembleStat_vx_APCP06h'
+NNODES_RUN_MET_ENSEMBLESTAT_VX_APCP06H='1'
+PPN_RUN_MET_ENSEMBLESTAT_VX_APCP06H='1'
+MEM_RUN_MET_ENSEMBLESTAT_VX_APCP06H='2G'
+WTIME_RUN_MET_ENSEMBLESTAT_VX_APCP06H='01:00:00'
+MAXTRIES_RUN_MET_ENSEMBLESTAT_VX_APCP06H='2'
+
+# [task_run_met_ensemblestat_vx_apcp24h]
+TN_RUN_MET_ENSEMBLESTAT_VX_APCP24H='run_MET_EnsembleStat_vx_APCP24h'
+NNODES_RUN_MET_ENSEMBLESTAT_VX_APCP24H='1'
+PPN_RUN_MET_ENSEMBLESTAT_VX_APCP24H='1'
+MEM_RUN_MET_ENSEMBLESTAT_VX_APCP24H='2G'
+WTIME_RUN_MET_ENSEMBLESTAT_VX_APCP24H='01:00:00'
+MAXTRIES_RUN_MET_ENSEMBLESTAT_VX_APCP24H='2'
+
+# [task_run_met_ensemblestat_vx_refc]
+TN_RUN_MET_ENSEMBLESTAT_VX_REFC='run_MET_EnsembleStat_vx_REFC'
+NNODES_RUN_MET_ENSEMBLESTAT_VX_REFC='1'
+PPN_RUN_MET_ENSEMBLESTAT_VX_REFC='1'
+MEM_RUN_MET_ENSEMBLESTAT_VX_REFC='2G'
+WTIME_RUN_MET_ENSEMBLESTAT_VX_REFC='01:00:00'
+MAXTRIES_RUN_MET_ENSEMBLESTAT_VX_REFC='2'
+
+# [task_run_met_ensemblestat_vx_retop]
+TN_RUN_MET_ENSEMBLESTAT_VX_RETOP='run_MET_EnsembleStat_vx_RETOP'
+NNODES_RUN_MET_ENSEMBLESTAT_VX_RETOP='1'
+PPN_RUN_MET_ENSEMBLESTAT_VX_RETOP='1'
+MEM_RUN_MET_ENSEMBLESTAT_VX_RETOP='2G'
+WTIME_RUN_MET_ENSEMBLESTAT_VX_RETOP='01:00:00'
+MAXTRIES_RUN_MET_ENSEMBLESTAT_VX_RETOP='2'
+
+# [task_run_met_ensemblestat_vx_sfc]
+TN_RUN_MET_ENSEMBLESTAT_VX_SFC='run_MET_EnsembleStat_vx_SFC'
+NNODES_RUN_MET_ENSEMBLESTAT_VX_SFC='1'
+PPN_RUN_MET_ENSEMBLESTAT_VX_SFC='1'
+MEM_RUN_MET_ENSEMBLESTAT_VX_SFC='2G'
+WTIME_RUN_MET_ENSEMBLESTAT_VX_SFC='01:00:00'
+MAXTRIES_RUN_MET_ENSEMBLESTAT_VX_SFC='2'
+
+# [task_run_met_ensemblestat_vx_upa]
+TN_RUN_MET_ENSEMBLESTAT_VX_UPA='run_MET_EnsembleStat_vx_UPA'
+NNODES_RUN_MET_ENSEMBLESTAT_VX_UPA='1'
+PPN_RUN_MET_ENSEMBLESTAT_VX_UPA='1'
+MEM_RUN_MET_ENSEMBLESTAT_VX_UPA='2G'
+WTIME_RUN_MET_ENSEMBLESTAT_VX_UPA='01:00:00'
+MAXTRIES_RUN_MET_ENSEMBLESTAT_VX_UPA='2'
+
+# [task_run_met_gridstat_vx_ensmean_apcp01h]
+TN_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP01H='run_MET_GridStat_vx_ensmean_APCP01h'
+NNODES_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP01H='1'
+PPN_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP01H='1'
+MEM_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP01H='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP01H='01:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP01H='2'
+
+# [task_run_met_gridstat_vx_ensmean_apcp03h]
+TN_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP03H='run_MET_GridStat_vx_ensmean_APCP03h'
+NNODES_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP03H='1'
+PPN_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP03H='1'
+MEM_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP03H='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP03H='01:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP03H='2'
+
+# [task_run_met_gridstat_vx_ensmean_apcp06h]
+TN_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP06H='run_MET_GridStat_vx_ensmean_APCP06h'
+NNODES_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP06H='1'
+PPN_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP06H='1'
+MEM_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP06H='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP06H='01:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP06H='2'
+
+# [task_run_met_gridstat_vx_ensmean_apcp24h]
+TN_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP24H='run_MET_GridStat_vx_ensmean_APCP24h'
+NNODES_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP24H='1'
+PPN_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP24H='1'
+MEM_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP24H='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP24H='01:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_ENSMEAN_APCP24H='2'
+
+# [task_run_met_pointstat_vx_ensmean_sfc]
+TN_RUN_MET_POINTSTAT_VX_ENSMEAN_SFC='run_MET_PointStat_vx_ensmean_SFC'
+NNODES_RUN_MET_POINTSTAT_VX_ENSMEAN_SFC='1'
+PPN_RUN_MET_POINTSTAT_VX_ENSMEAN_SFC='1'
+MEM_RUN_MET_POINTSTAT_VX_ENSMEAN_SFC='2G'
+WTIME_RUN_MET_POINTSTAT_VX_ENSMEAN_SFC='01:00:00'
+MAXTRIES_RUN_MET_POINTSTAT_VX_ENSMEAN_SFC='2'
+
+# [task_run_met_pointstat_vx_ensmean_upa]
+TN_RUN_MET_POINTSTAT_VX_ENSMEAN_UPA='run_MET_PointStat_vx_ensmean_UPA'
+NNODES_RUN_MET_POINTSTAT_VX_ENSMEAN_UPA='1'
+PPN_RUN_MET_POINTSTAT_VX_ENSMEAN_UPA='1'
+MEM_RUN_MET_POINTSTAT_VX_ENSMEAN_UPA='2G'
+WTIME_RUN_MET_POINTSTAT_VX_ENSMEAN_UPA='01:00:00'
+MAXTRIES_RUN_MET_POINTSTAT_VX_ENSMEAN_UPA='2'
+
+# [task_run_met_gridstat_vx_ensprob_apcp01h]
+TN_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP01H='run_MET_GridStat_vx_ensprob_APCP01h'
+NNODES_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP01H='1'
+PPN_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP01H='1'
+MEM_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP01H='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP01H='01:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP01H='2'
+
+# [task_run_met_gridstat_vx_ensprob_apcp03h]
+TN_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP03H='run_MET_GridStat_vx_ensprob_APCP03h'
+NNODES_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP03H='1'
+PPN_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP03H='1'
+MEM_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP03H='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP03H='01:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP03H='2'
+
+# [task_run_met_gridstat_vx_ensprob_apcp06h]
+TN_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP06H='run_MET_GridStat_vx_ensprob_APCP06h'
+NNODES_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP06H='1'
+PPN_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP06H='1'
+MEM_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP06H='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP06H='01:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP06H='2'
+
+# [task_run_met_gridstat_vx_ensprob_apcp24h]
+TN_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP24H='run_MET_GridStat_vx_ensprob_APCP24h'
+NNODES_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP24H='1'
+PPN_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP24H='1'
+MEM_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP24H='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP24H='01:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_ENSPROB_APCP24H='2'
+
+# [task_run_met_gridstat_vx_ensprob_refc]
+TN_RUN_MET_GRIDSTAT_VX_ENSPROB_REFC='run_MET_GridStat_vx_ensprob_REFC'
+NNODES_RUN_MET_GRIDSTAT_VX_ENSPROB_REFC='1'
+PPN_RUN_MET_GRIDSTAT_VX_ENSPROB_REFC='1'
+MEM_RUN_MET_GRIDSTAT_VX_ENSPROB_REFC='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_ENSPROB_REFC='01:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_ENSPROB_REFC='2'
+
+# [task_run_met_gridstat_vx_ensprob_retop]
+TN_RUN_MET_GRIDSTAT_VX_ENSPROB_RETOP='run_MET_GridStat_vx_ensprob_RETOP'
+NNODES_RUN_MET_GRIDSTAT_VX_ENSPROB_RETOP='1'
+PPN_RUN_MET_GRIDSTAT_VX_ENSPROB_RETOP='1'
+MEM_RUN_MET_GRIDSTAT_VX_ENSPROB_RETOP='2G'
+WTIME_RUN_MET_GRIDSTAT_VX_ENSPROB_RETOP='01:00:00'
+MAXTRIES_RUN_MET_GRIDSTAT_VX_ENSPROB_RETOP='2'
+
+# [task_run_met_pointstat_vx_ensprob_sfc]
+TN_RUN_MET_POINTSTAT_VX_ENSPROB_SFC='run_MET_PointStat_vx_ensprob_SFC'
+NNODES_RUN_MET_POINTSTAT_VX_ENSPROB_SFC='1'
+PPN_RUN_MET_POINTSTAT_VX_ENSPROB_SFC='1'
+MEM_RUN_MET_POINTSTAT_VX_ENSPROB_SFC='2G'
+WTIME_RUN_MET_POINTSTAT_VX_ENSPROB_SFC='01:00:00'
+MAXTRIES_RUN_MET_POINTSTAT_VX_ENSPROB_SFC='2'
+
+# [task_run_met_pointstat_vx_ensprob_upa]
+TN_RUN_MET_POINTSTAT_VX_ENSPROB_UPA='run_MET_PointStat_vx_ensprob_UPA'
+NNODES_RUN_MET_POINTSTAT_VX_ENSPROB_UPA='1'
+PPN_RUN_MET_POINTSTAT_VX_ENSPROB_UPA='1'
+MEM_RUN_MET_POINTSTAT_VX_ENSPROB_UPA='2G'
+WTIME_RUN_MET_POINTSTAT_VX_ENSPROB_UPA='01:00:00'
+MAXTRIES_RUN_MET_POINTSTAT_VX_ENSPROB_UPA='2'
+
+# [task_aqm_ics]
+TN_AQM_ICS='aqm_ics'
+NNODES_AQM_ICS='1'
+PPN_AQM_ICS='1'
+WTIME_AQM_ICS='00:30:00'
+MAXTRIES_AQM_ICS='2'
+
+# [task_aqm_lbcs]
+TN_AQM_LBCS='aqm_lbcs'
+NNODES_AQM_LBCS='1'
+PPN_AQM_LBCS='24'
+WTIME_AQM_LBCS='01:00:00'
+MAXTRIES_AQM_LBCS='2'
+
+# [task_nexus_gfs_sfc]
+TN_NEXUS_GFS_SFC='nexus_gfs_sfc'
+NNODES_NEXUS_GFS_SFC='1'
+PPN_NEXUS_GFS_SFC='1'
+MEM_NEXUS_GFS_SFC='2G'
+WTIME_NEXUS_GFS_SFC='00:30:00'
+MAXTRIES_NEXUS_GFS_SFC='2'
+NEXUS_GFS_SFC_OFFSET_HRS='6'
+
+# [task_nexus_emission]
+TN_NEXUS_EMISSION='nexus_emission'
+NNODES_NEXUS_EMISSION='4'
+PPN_NEXUS_EMISSION='64'
+WTIME_NEXUS_EMISSION='01:00:00'
+MAXTRIES_NEXUS_EMISSION='2'
+KMP_AFFINITY_NEXUS_EMISSION='scatter'
+OMP_NUM_THREADS_NEXUS_EMISSION='2'
+OMP_STACKSIZE_NEXUS_EMISSION='1024m'
+
+# [task_nexus_post_split]
+TN_NEXUS_POST_SPLIT='nexus_post_split'
+NNODES_NEXUS_POST_SPLIT='1'
+PPN_NEXUS_POST_SPLIT='1'
+WTIME_NEXUS_POST_SPLIT='00:30:00'
+MAXTRIES_NEXUS_POST_SPLIT='2'
+
+# [task_fire_emission]
+TN_FIRE_EMISSION='fire_emission'
+NNODES_FIRE_EMISSION='1'
+PPN_FIRE_EMISSION='1'
+MEM_FIRE_EMISSION='2G'
+WTIME_FIRE_EMISSION='00:30:00'
+MAXTRIES_FIRE_EMISSION='2'
+AQM_FIRE_FILE_OFFSET_HRS='0'
+
+# [task_point_source]
+TN_POINT_SOURCE='point_source'
+NNODES_POINT_SOURCE='1'
+PPN_POINT_SOURCE='1'
+WTIME_POINT_SOURCE='01:00:00'
+MAXTRIES_POINT_SOURCE='2'
+
+# [task_pre_post_stat]
+TN_PRE_POST_STAT='pre_post_stat'
+NNODES_PRE_POST_STAT='1'
+PPN_PRE_POST_STAT='1'
+WTIME_PRE_POST_STAT='00:30:00'
+MAXTRIES_PRE_POST_STAT='2'
+
+# [task_post_stat_o3]
+TN_POST_STAT_O3='post_stat_o3'
+NNODES_POST_STAT_O3='1'
+PPN_POST_STAT_O3='1'
+MEM_POST_STAT_O3='120G'
+WTIME_POST_STAT_O3='00:30:00'
+MAXTRIES_POST_STAT_O3='2'
+KMP_AFFINITY_POST_STAT_O3='scatter'
+OMP_NUM_THREADS_POST_STAT_O3='1'
+OMP_STACKSIZE_POST_STAT_O3='2056M'
+
+# [task_post_stat_pm25]
+TN_POST_STAT_PM25='post_stat_pm25'
+NNODES_POST_STAT_PM25='1'
+PPN_POST_STAT_PM25='1'
+MEM_POST_STAT_PM25='120G'
+WTIME_POST_STAT_PM25='00:30:00'
+MAXTRIES_POST_STAT_PM25='2'
+KMP_AFFINITY_POST_STAT_PM25='scatter'
+OMP_NUM_THREADS_POST_STAT_PM25='1'
+OMP_STACKSIZE_POST_STAT_PM25='2056M'
+
+# [task_bias_correction_o3]
+TN_BIAS_CORRECTION_O3='bias_correction_o3'
+NNODES_BIAS_CORRECTION_O3='1'
+PPN_BIAS_CORRECTION_O3='1'
+MEM_BIAS_CORRECTION_O3='120G'
+WTIME_BIAS_CORRECTION_O3='00:30:00'
+MAXTRIES_BIAS_CORRECTION_O3='2'
+KMP_AFFINITY_BIAS_CORRECTION_O3='scatter'
+OMP_NUM_THREADS_BIAS_CORRECTION_O3='32'
+OMP_STACKSIZE_BIAS_CORRECTION_O3='2056M'
+
+# [task_bias_correction_pm25]
+TN_BIAS_CORRECTION_PM25='bias_correction_pm25'
+NNODES_BIAS_CORRECTION_PM25='1'
+PPN_BIAS_CORRECTION_PM25='1'
+MEM_BIAS_CORRECTION_PM25='120G'
+WTIME_BIAS_CORRECTION_PM25='00:30:00'
+MAXTRIES_BIAS_CORRECTION_PM25='2'
+KMP_AFFINITY_BIAS_CORRECTION_PM25='scatter'
+OMP_NUM_THREADS_BIAS_CORRECTION_PM25='32'
+OMP_STACKSIZE_BIAS_CORRECTION_PM25='2056M'
+
+# [global]
+USE_CRTM='FALSE'
+CRTM_DIR=''
+DO_ENSEMBLE='FALSE'
+NUM_ENS_MEMBERS='2'
+ENSMEM_NAMES='mem%03d, " % m  "mem%03d, " % m'
+FV3_NML_ENSMEM_FPS='{% for mem in ENSMEM_NAMES %}{{ [EXPTDIR, "%s_%s" % FV3_NML_FN, mem]|path_join }}{% endfor %}'
+ENS_TIME_LAG_HRS=( "0" "0" )
+DO_SHUM='FALSE'
+DO_SPPT='FALSE'
+DO_SKEB='FALSE'
+ISEED_SPPT='1'
+ISEED_SHUM='2'
+ISEED_SKEB='3'
+NEW_LSCALE='TRUE'
+SHUM_MAG='-999.0'
+SHUM_LSCALE='150000'
+SHUM_TSCALE='21600'
+SHUM_INT='3600'
+SPPT_MAG='-999.0'
+SPPT_LOGIT='TRUE'
+SPPT_LSCALE='150000'
+SPPT_TSCALE='21600'
+SPPT_INT='3600'
+SPPT_SFCLIMIT='TRUE'
+SKEB_MAG='-999.0'
+SKEB_LSCALE='150000'
+SKEB_TSCALE='21600'
+SKEB_INT='3600'
+SKEBNORM='1'
+SKEB_VDOF='10'
+USE_ZMTNBLCK='FALSE'
+DO_SPP='FALSE'
+SPP_VAR_LIST=( \
+"pbl" \
+"sfc" \
+"mp" \
+"rad" \
+"gwd" \
+)
+SPP_MAG_LIST=( \
+"0.2" \
+"0.2" \
+"0.75" \
+"0.2" \
+"0.2" \
+)
+SPP_LSCALE=( \
+"150000.0" \
+"150000.0" \
+"150000.0" \
+"150000.0" \
+"150000.0" \
+)
+SPP_TSCALE=( \
+"21600.0" \
+"21600.0" \
+"21600.0" \
+"21600.0" \
+"21600.0" \
+)
+SPP_SIGTOP1=( \
+"0.1" \
+"0.1" \
+"0.1" \
+"0.1" \
+"0.1" \
+)
+SPP_SIGTOP2=( \
+"0.025" \
+"0.025" \
+"0.025" \
+"0.025" \
+"0.025" \
+)
+SPP_STDDEV_CUTOFF=( \
+"1.5" \
+"1.5" \
+"2.5" \
+"1.5" \
+"1.5" \
+)
+ISEED_SPP=( \
+"4" \
+"5" \
+"6" \
+"7" \
+"8" \
+)
+DO_LSM_SPP='FALSE'
+LSM_SPP_TSCALE=( \
+"21600" \
+"21600" \
+"21600" \
+"21600" \
+"21600" \
+"21600" \
+"21600" \
+)
+LSM_SPP_LSCALE=( \
+"150000" \
+"150000" \
+"150000" \
+"150000" \
+"150000" \
+"150000" \
+"150000" \
+)
+ISEED_LSM_SPP=( "9" )
+LSM_SPP_VAR_LIST=( \
+"smc" \
+"vgf" \
+"alb" \
+"sal" \
+"emi" \
+"zol" \
+"stc" \
+)
+LSM_SPP_MAG_LIST=( \
+"0.017" \
+"0.001" \
+"0.001" \
+"0.001" \
+"0.001" \
+"0.001" \
+"0.2" \
+)
+HALO_BLEND='0'
+N_VAR_SPP='0'
+N_VAR_LNDP='0'
+LNDP_TYPE='0'
+LNDP_MODEL_TYPE='0'
+FHCYC_LSM_SPP_OR_NOT='0'
+
+# [verification]
+GET_OBS_LOCAL_MODULE_FN='get_obs'
+OBS_CCPA_APCP01h_FN_TEMPLATE='{valid?fmt=%Y%m%d}/ccpa.t{valid?fmt=%H}z.01h.hrap.conus.gb2'
+OBS_CCPA_APCPgt01h_FN_TEMPLATE='${OBS_CCPA_APCP01h_FN_TEMPLATE}_a${ACCUM_HH}h.nc'
+OBS_NDAS_SFCorUPA_FN_TEMPLATE='prepbufr.ndas.{valid?fmt=%Y%m%d%H}'
+OBS_NDAS_SFCorUPA_FN_METPROC_TEMPLATE='${OBS_NDAS_SFCorUPA_FN_TEMPLATE}.nc'
+VX_LOCAL_MODULE_FN='run_vx'
+RUN_TASKS_METVX_DET='FALSE'
+RUN_TASKS_METVX_ENS='FALSE'
+VX_FCST_MODEL_NAME='aqm.793'
+VX_FIELDS=( \
+"APCP" \
+"REFC" \
+"RETOP" \
+"SFC" \
+"UPA" \
+)
+VX_APCP_ACCUMS_HH=( "01" "03" "06" "24" )
+VX_FCST_INPUT_BASEDIR='${HOMEaqm}/parm/config'
+FCST_SUBDIR_TEMPLATE='{init?fmt=%Y%m%d%H?shift=-${time_lag}}${SLASH_ENSMEM_SUBDIR_OR_NULL}/postprd'
+FCST_FN_TEMPLATE='${NET}.t{init?fmt=%H?shift=-${time_lag}}z.prslev.f{lead?fmt=%HHH?shift=${time_lag}}.${POST_OUTPUT_DOMAIN_NAME}.grib2'
+FCST_FN_METPROC_TEMPLATE='${NET}.t{init?fmt=%H}z.prslev.f{lead?fmt=%HHH}.${POST_OUTPUT_DOMAIN_NAME}_a${ACCUM_HH}h.nc'
+NUM_MISSING_OBS_FILES_MAX='2'
+
+# [cpl_aqm_parm]
+CPL_AQM='TRUE'
+DO_AQM_DUST='TRUE'
+DO_AQM_CANOPY='FALSE'
+DO_AQM_PRODUCT='TRUE'
+DO_AQM_CHEM_LBCS='TRUE'
+DO_AQM_GEFS_LBCS='TRUE'
+DO_AQM_SAVE_AIRNOW_HIST='FALSE'
+DO_AQM_SAVE_FIRE='FALSE'
+AQM_CONFIG_DIR='/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/aqm/epa/data'
+DCOMINbio='/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/aqm/bio'
+AQM_BIO_FILE='BEIS_RRFScmaq_C775.ncf'
+DCOMINdust='/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/FENGSHA'
+AQM_DUST_FILE_PREFIX='FENGSHA_p8_10km_inputs'
+AQM_DUST_FILE_SUFFIX='.nc'
+DCOMINcanopy='/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/canopy'
+AQM_CANOPY_FILE_PREFIX='gfs.t12z.geo'
+AQM_CANOPY_FILE_SUFFIX='.canopy_regrid.nc'
+DCOMINfire='/lfs/h2/emc/physics/noscrub/kai.wang/RAVE_fire/RAVE_NA_NRT'
+AQM_FIRE_FILE_PREFIX='Hourly_Emissions_regrid_NA_13km'
+AQM_FIRE_FILE_SUFFIX='_h72.nc'
+AQM_FIRE_ARCHV_DIR='/path/to/archive/dir/for/RAVE/on/HPSS'
+AQM_RC_FIRE_FREQUENCY='hourly'
+AQM_RC_PRODUCT_FN='aqm.prod.nc'
+AQM_RC_PRODUCT_FREQUENCY='hourly'
+DCOMINchem_lbcs='/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/LBCS/AQM_NA13km_AM4_v1'
+AQM_LBCS_FILES='am4_bndy.c793.2019<MM>.v1.nc'
+DCOMINgefs='/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/GEFS_DATA'
+AQM_GEFS_FILE_PREFIX='geaer'
+AQM_GEFS_FILE_CYC=''
+NEXUS_INPUT_DIR='/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/nexus_emissions'
+NEXUS_FIX_DIR='/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/nexus/fix'
+NEXUS_GRID_FN='grid_spec_793.nc'
+NUM_SPLIT_NEXUS='6'
+NEXUS_GFS_SFC_DIR='/lfs/h2/emc/lam/noscrub/RRFS_CMAQ/GFS_DATA'
+NEXUS_GFS_SFC_ARCHV_DIR='/NCEPPROD/hpssprod/runhistory'
+DCOMINpt_src='/lfs/h2/emc/physics/noscrub/Youhua.Tang/nei2016v1-pt/v2023-01-PT'
+DCOMINairnow='/lfs/h1/ops/prod/dcom'
+# Need to define
+COMINbicor='/lfs/h2/emc/global/noscrub/lin.gan/Bias_correction/aqmv7.0'
+COMOUTbicor='/lfs/h2/emc/global/noscrub/lin.gan/Bias_correction/aqmv7.0'
+AQM_AIRNOW_HIST_DIR='/lfs/h2/emc/global/noscrub/lin.gan/Bias_correction/aqmv7.0'
+
+# [constants]
+PI_GEOM='3.141592653589793'
+DEGS_PER_RADIAN='57.29577951308232'
+RADIUS_EARTH='6371200.0'
+SECS_PER_HOUR='3600.0'
+GTYPE='regional'
+TILE_RGNL='7'
+NH0='0'
+NH3='3'
+NH4='4'
+valid_vals_BOOLEAN=( \
+"TRUE" \
+"true" \
+"YES" \
+"yes" \
+"FALSE" \
+"false" \
+"NO" \
+"no" \
+)
+
+# [fixed_files]
+FV3_NML_VARNAME_TO_SFC_CLIMO_FIELD_MAPPING=( \
+"FNALBC  | snowfree_albedo" \
+"FNALBC2 | facsf" \
+"FNTG3C  | substrate_temperature" \
+"FNVEGC  | vegetation_greenness" \
+"FNVETC  | vegetation_type" \
+"FNSOTC  | soil_type" \
+"FNVMNC  | vegetation_greenness" \
+"FNVMXC  | vegetation_greenness" \
+"FNSLPC  | slope_type" \
+"FNABSC  | maximum_snow_albedo" \
+)
+SFC_CLIMO_FIELDS=( \
+"facsf" \
+"maximum_snow_albedo" \
+"slope_type" \
+"snowfree_albedo" \
+"soil_type" \
+"substrate_temperature" \
+"vegetation_greenness" \
+"vegetation_type" \
+)
+FNGLAC='global_glacier.2x2.grb'
+FNMXIC='global_maxice.2x2.grb'
+FNTSFC='RTGSST.1982.2012.monthly.clim.grb'
+FNSNOC='global_snoclim.1.875.grb'
+FNZORC='igbp'
+FNAISC='CFSR.SEAICE.1982.2012.monthly.clim.grb'
+FNSMCC='global_soilmgldas.t126.384.190.grb'
+FNMSKH='seaice_newland.grb'
+FIXgsm_FILES_TO_COPY_TO_FIXam=( \
+"global_glacier.2x2.grb" \
+"global_maxice.2x2.grb" \
+"RTGSST.1982.2012.monthly.clim.grb" \
+"global_snoclim.1.875.grb" \
+"CFSR.SEAICE.1982.2012.monthly.clim.grb" \
+"global_soilmgldas.t126.384.190.grb" \
+"seaice_newland.grb" \
+"global_climaeropac_global.txt" \
+"fix_co2_proj/global_co2historicaldata_2010.txt" \
+"fix_co2_proj/global_co2historicaldata_2011.txt" \
+"fix_co2_proj/global_co2historicaldata_2012.txt" \
+"fix_co2_proj/global_co2historicaldata_2013.txt" \
+"fix_co2_proj/global_co2historicaldata_2014.txt" \
+"fix_co2_proj/global_co2historicaldata_2015.txt" \
+"fix_co2_proj/global_co2historicaldata_2016.txt" \
+"fix_co2_proj/global_co2historicaldata_2017.txt" \
+"fix_co2_proj/global_co2historicaldata_2018.txt" \
+"fix_co2_proj/global_co2historicaldata_2019.txt" \
+"fix_co2_proj/global_co2historicaldata_2020.txt" \
+"fix_co2_proj/global_co2historicaldata_2021.txt" \
+"global_co2historicaldata_glob.txt" \
+"co2monthlycyc.txt" \
+"global_h2o_pltc.f77" \
+"global_hyblev.l65.txt" \
+"global_zorclim.1x1.grb" \
+"global_sfc_emissivity_idx.txt" \
+"global_tg3clim.2.6x1.5.grb" \
+"global_solarconstant_noaa_an.txt" \
+"global_albedo4.1x1.grb" \
+"geo_em.d01.lat-lon.2.5m.HGT_M.nc" \
+"HGT.Beljaars_filtered.lat-lon.30s_res.nc" \
+"ozprdlos_2015_new_sbuvO3_tclm15_nuchem.f77" \
+)
+FV3_NML_VARNAME_TO_FIXam_FILES_MAPPING=( \
+"FNGLAC | global_glacier.2x2.grb" \
+"FNMXIC | global_maxice.2x2.grb" \
+"FNTSFC | RTGSST.1982.2012.monthly.clim.grb" \
+"FNSNOC | global_snoclim.1.875.grb" \
+"FNAISC | CFSR.SEAICE.1982.2012.monthly.clim.grb" \
+"FNSMCC | global_soilmgldas.t126.384.190.grb" \
+"FNMSKH | seaice_newland.grb" \
+)
+CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING=( \
+"aerosol.dat                | global_climaeropac_global.txt" \
+"co2historicaldata_2010.txt | fix_co2_proj/global_co2historicaldata_2010.txt" \
+"co2historicaldata_2011.txt | fix_co2_proj/global_co2historicaldata_2011.txt" \
+"co2historicaldata_2012.txt | fix_co2_proj/global_co2historicaldata_2012.txt" \
+"co2historicaldata_2013.txt | fix_co2_proj/global_co2historicaldata_2013.txt" \
+"co2historicaldata_2014.txt | fix_co2_proj/global_co2historicaldata_2014.txt" \
+"co2historicaldata_2015.txt | fix_co2_proj/global_co2historicaldata_2015.txt" \
+"co2historicaldata_2016.txt | fix_co2_proj/global_co2historicaldata_2016.txt" \
+"co2historicaldata_2017.txt | fix_co2_proj/global_co2historicaldata_2017.txt" \
+"co2historicaldata_2018.txt | fix_co2_proj/global_co2historicaldata_2018.txt" \
+"co2historicaldata_2019.txt | fix_co2_proj/global_co2historicaldata_2019.txt" \
+"co2historicaldata_2020.txt | fix_co2_proj/global_co2historicaldata_2020.txt" \
+"co2historicaldata_2021.txt | fix_co2_proj/global_co2historicaldata_2021.txt" \
+"co2historicaldata_glob.txt | global_co2historicaldata_glob.txt" \
+"co2monthlycyc.txt          | co2monthlycyc.txt" \
+"global_h2oprdlos.f77       | global_h2o_pltc.f77" \
+"global_albedo4.1x1.grb     | global_albedo4.1x1.grb" \
+"global_zorclim.1x1.grb     | global_zorclim.1x1.grb" \
+"global_tg3clim.2.6x1.5.grb | global_tg3clim.2.6x1.5.grb" \
+"sfc_emissivity_idx.txt     | global_sfc_emissivity_idx.txt" \
+"solarconstant_noaa_an.txt  | global_solarconstant_noaa_an.txt" \
+"global_o3prdlos.f77        | ozprdlos_2015_new_sbuvO3_tclm15_nuchem.f77" \
+)
+
+# [grid_params]
+LON_CTR='-118.0'
+LAT_CTR='50.0'
+NX='800'
+NY='544'
+PAZI='0.0'
+NHW='6'
+STRETCH_FAC='0.999'
+DEL_ANGLE_X_SG='0.05845406938018506'
+DEL_ANGLE_Y_SG='0.05845406938018506'
+NEG_NX_OF_DOM_WITH_WIDE_HALO='-812'
+NEG_NY_OF_DOM_WITH_WIDE_HALO='-556'
+

--- a/scripts/exaqm_manager.sh
+++ b/scripts/exaqm_manager.sh
@@ -1,0 +1,69 @@
+#! /bin/bash
+set -x
+
+ecflow_sid=emc_aqm
+
+##############################################
+# Set variables used in the script
+##############################################
+CDATE=${PDY}${cyc}
+GDATE=$($NDATE -06 $CDATE)
+gPDY=$(echo $GDATE | cut -c1-8)
+gcyc=$(echo $GDATE | cut -c9-10)
+NEXTDATE=$($NDATE +06 $CDATE)
+NEXTPDY=$(echo $NEXTDATE | cut -c1-8)
+NEXTcyc=$(echo $NEXTDATE | cut -c9-10)
+# NEXT24HPDY=$($NDATE +24 ${PDY}00)
+CURRENTDAYPDY=$(ecflow_client --query variable /${ecflow_sid}/primary/${gcyc}:PDY)00
+NEXTDAYPDY_CDATE=$($NDATE +24 $CURRENTDAYPDY)
+NEXTDAYPDY=$(echo $NEXTDAYPDY_CDATE | cut -c1-8)
+
+#aqm_forecast_RESTART_file=$(ls ${DATAROOT}/aqm_forecast_${cyc}.${PDY}${cyc}/RESTART/*coupler.res|wc -l)
+#aqm_forecast_RESTART_file="${DATAROOT}/aqm_forecast_${cyc}.${PDY}${cyc}/RESTART/*coupler.res"
+gefs_check=$(compath.py ${envir}/gefs/${gefs_ver})/gefs.${NEXTPDY}/${NEXTcyc}/chem/sfcsig/geaer.t${NEXTcyc}z.atmf078.nemsio
+gfs_check=$(compath.py ${envir}/gfs/${gfs_ver})/gfs.${NEXTPDY}/${NEXTcyc}/atmos/gfs.t${NEXTcyc}z.sfcf078.nc
+found_required_file_for_next_cycle=NO
+fcst_job_completed=NO
+release_next_cycle=NO
+previous_cycle_run_completed=NO
+cleanup_job_done=NO
+previous_cycle_aqm_manager_complete=NO
+
+h_try=1
+while [ $h_try -lt 70 ]; do
+  ####################################
+  # Set release_next_cycle event when 
+  #   current cycle fcst restart file exist
+  ####################################
+  if [ ${found_required_file_for_next_cycle} = "NO" ]; then
+    aqm_forecast_RESTART_file=$(ls ${DATAROOT}/aqm_forecast_${cyc}.${PDY}${cyc}/RESTART/*coupler.res|wc -l)
+    if [[ ${aqm_forecast_RESTART_file} -ge 1 && -f ${gefs_check} && -f ${gfs_check} ]]; then
+      ecflow_client --event release_next_cycle
+      found_required_file_for_next_cycle=YES
+    fi
+  fi
+  ####################################
+  # Requeue previous cycle when
+  #   current forecast job is completed
+  ####################################
+  if [ ${fcst_job_completed} = "NO" ]; then
+    P_state=$(ecflow_client --query state /${ecflow_sid}/primary/${gcyc})
+    e_state=$(ecflow_client --query state /${ecflow_sid}/primary/${cyc}/aqm/v1.0/forecast/jforecast)
+    if [[ ${e_state} = "complete" && ${P_state} = "complete" ]]; then
+      ecflow_client --event requeue_cycle
+      ecflow_client --alter change variable PDY $NEXTDAYPDY /${ecflow_sid}/primary/${gcyc}
+      ecflow_client --requeue force /${ecflow_sid}/primary/${gcyc}/aqm
+      fcst_job_completed=YES
+    fi
+  fi 
+
+  h_try=$((h_try+1))
+  if [ ${found_required_file_for_next_cycle} = "YES" -a ${fcst_job_completed} = "YES" ]; then
+    h_try=99
+  else
+    sleep 300
+  fi
+done
+if [ $h_try -eq 70 ]; then
+  exit 70
+fi

--- a/scripts/exdata_cleanup.sh
+++ b/scripts/exdata_cleanup.sh
@@ -1,0 +1,52 @@
+#! /bin/bash
+set -x
+
+##############################################
+# Clean up the DATA directory from previous cycle if found
+##############################################
+[[ $KEEPDATA = "YES" ]] && exit 0
+
+##############################################
+# Set variables used in the script
+##############################################
+CDATE=${PDY}${cyc}
+GDATE=$($NDATE -24 $CDATE)
+gPDY=$(echo $GDATE | cut -c1-8)
+gcyc=$(echo $GDATE | cut -c9-10)
+
+##############################################
+# Looking for the following directory for cleanup
+#   aqm_forecast_${gcyc}.${gPDY}${gcyc}
+#   aqm_get_extrn_ics_${gcyc}.${gPDY}${gcyc}
+#   aqm_get_extrn_lbcs_${gcyc}.${gPDY}${gcyc}
+#   aqm_nexus_gfs_sfc_${gcyc}.${gPDY}${gcyc}
+#   aqm_get_extrn_ics_${gcyc}.${gPDY}${gcyc}
+#   aqm_get_extrn_lbcs_${gcyc}.${gPDY}${gcyc}
+##############################################
+target_for_delete=${DATAROOT}/aqm_forecast_${gcyc}.${gPDY}${gcyc}
+echo "Remove DATA from ${target_for_delete}"
+[[ -d $target_for_delete ]] && rm -rf $target_for_delete
+
+target_for_delete=${DATAROOT}/aqm_get_extrn_ics_${gcyc}.${gPDY}${gcyc}
+echo "Remove DATA from ${target_for_delete}"
+[[ -d $target_for_delete ]] && rm -rf $target_for_delete
+
+target_for_delete=${DATAROOT}/aqm_get_extrn_lbcs_${gcyc}.${gPDY}${gcyc}
+echo "Remove DATA from ${target_for_delete}"
+[[ -d $target_for_delete ]] && rm -rf $target_for_delete
+
+target_for_delete=${DATAROOT}/aqm_nexus_gfs_sfc_${gcyc}.${gPDY}${gcyc}
+echo "Remove DATA from ${target_for_delete}"
+[[ -d $target_for_delete ]] && rm -rf $target_for_delete
+
+target_for_delete=${DATAROOT}/aqm_get_extrn_ics_${gcyc}.${gPDY}${gcyc}
+echo "Remove DATA from ${target_for_delete}"
+[[ -d $target_for_delete ]] && rm -rf $target_for_delete
+
+target_for_delete=${DATAROOT}/aqm_get_extrn_lbcs_${gcyc}.${gPDY}${gcyc}
+echo "Remove DATA from ${target_for_delete}"
+[[ -d $target_for_delete ]] && rm -rf $target_for_delete
+
+exit 0
+#####################################################
+

--- a/scripts/exregional_aqm_lbcs.sh
+++ b/scripts/exregional_aqm_lbcs.sh
@@ -84,11 +84,21 @@ yyyymmdd=${CDATE_MOD:0:8}
 mm="${CDATE_MOD:4:2}"
 hh="${CDATE_MOD:8:2}"
 
-if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-  cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-  CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-  FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
-fi
+case $cyc in
+  00 )
+    FCST_LEN_HRS=6
+  ;;
+  06 )
+    FCST_LEN_HRS=72
+  ;;
+  12 )
+    FCST_LEN_HRS=72
+  ;;
+  18 )
+    FCST_LEN_HRS=6
+  ;;
+esac
+
 LBC_SPEC_FCST_HRS=()
 for i_lbc in $(seq ${LBC_SPEC_INTVL_HRS} ${LBC_SPEC_INTVL_HRS} ${FCST_LEN_HRS} ); do
   LBC_SPEC_FCST_HRS+=("$i_lbc")
@@ -157,7 +167,7 @@ if [ ${DO_AQM_GEFS_LBCS} = "TRUE" ]; then
   if [ "${DO_REAL_TIME}" = "TRUE" ]; then
     AQM_MOFILE_FP="${COMINgefs}/gefs.${yyyymmdd}/${AQM_GEFS_FILE_CYC}/chem/sfcsig/${AQM_MOFILE_FN}"
   else
-    AQM_MOFILE_FP="${DCOMINgefs}/${yyyymmdd}/${AQM_GEFS_FILE_CYC}/${AQM_MOFILE_FN}"
+    AQM_MOFILE_FP="${COMINgefs}/${yyyymmdd}/${AQM_GEFS_FILE_CYC}/${AQM_MOFILE_FN}"
   fi  
 
   # Check if GEFS aerosol files exist

--- a/scripts/exregional_bias_correction_o3.sh
+++ b/scripts/exregional_bias_correction_o3.sh
@@ -93,11 +93,20 @@ if [ "${PREDEF_GRID_NAME}" = "AQM_NA_13km" ]; then
   id_domain=793
 fi
 
-if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-  cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-  CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-  FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
-fi
+case $cyc in
+  00 )
+    FCST_LEN_HRS=6
+  ;;
+  06 )
+    FCST_LEN_HRS=72
+  ;;
+  12 )
+    FCST_LEN_HRS=72
+  ;;
+  18 )
+    FCST_LEN_HRS=6
+  ;;
+esac
 
 #-----------------------------------------------------------------------------
 # STEP 1: Retrieve AIRNOW observation data
@@ -108,10 +117,11 @@ mkdir -p "${DATA}/data"
 if [ -d "${DATA}/data/bcdata.${yyyymm}" ]; then
   rm -rf "${DATA}/data/bcdata.${yyyymm}"
   mkdir -p "${DATA}/data/bcdata.${yyyymm}"
-  cp -rL "${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/airnow" "${DATA}/data/bcdata.${yyyymm}"
-  cp -rL "${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/interpolated" "${DATA}/data/bcdata.${yyyymm}" 
+  cp -rL "${COMINbicor}/bcdata.${yyyymm}/airnow" "${DATA}/data/bcdata.${yyyymm}"
+  cp -rL "${COMINbicor}/bcdata.${yyyymm}/interpolated" "${DATA}/data/bcdata.${yyyymm}"
 fi
 
+cd ${DATA}
 # Retrieve real-time airnow data for the last three days and convert them into netcdf
 if [ "${DO_REAL_TIME}" = "TRUE" ]; then
   for ipdym in {1..3}; do
@@ -214,31 +224,31 @@ POST_STEP
 
 cp ${DATA}/out/ozone/${yyyy}/*nc ${DATA}/data/bcdata.${yyyymm}/interpolated/ozone/${yyyy}
 
-if [ "${DO_AQM_SAVE_AIRNOW_HIST}" = "TRUE" ]; then
-  mkdir -p ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/interpolated/ozone/${yyyy}
-  cp ${DATA}/out/ozone/${yyyy}/*nc ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/interpolated/ozone/${yyyy}
+#if [ "${DO_AQM_SAVE_AIRNOW_HIST}" = "TRUE" ]; then
+  mkdir -p ${COMOUTbicor}/bcdata.${yyyymm}/interpolated/ozone/${yyyy}
+  cp ${DATA}/out/ozone/${yyyy}/*nc ${COMOUTbicor}/bcdata.${yyyymm}/interpolated/ozone/${yyyy}
 
   # CSV files
-  mkdir -p ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/airnow/csv/${yyyy}/${PDY}
-  mkdir -p ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm_m1}/airnow/csv/${yyyy_m1}/${PDYm1}
-  mkdir -p ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm_m2}/airnow/csv/${yyyy_m2}/${PDYm2}
-  mkdir -p ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm_m3}/airnow/csv/${yyyy_m3}/${PDYm3}
-  cp ${DCOMINairnow}/${PDYm1}/airnow/HourlyAQObs_${PDYm1}*.dat ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm_m1}/airnow/csv/${yyyy_m1}/${PDYm1}  
-  cp ${DCOMINairnow}/${PDYm2}/airnow/HourlyAQObs_${PDYm2}*.dat ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm_m2}/airnow/csv/${yyyy_m2}/${PDYm2}  
-  cp ${DCOMINairnow}/${PDYm3}/airnow/HourlyAQObs_${PDYm3}*.dat ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm_m3}/airnow/csv/${yyyy_m3}/${PDYm3}
+  mkdir -p ${COMOUTbicor}/bcdata.${yyyymm}/airnow/csv/${yyyy}/${PDY}
+  mkdir -p ${COMOUTbicor}/bcdata.${yyyymm_m1}/airnow/csv/${yyyy_m1}/${PDYm1}
+  mkdir -p ${COMOUTbicor}/bcdata.${yyyymm_m2}/airnow/csv/${yyyy_m2}/${PDYm2}
+  mkdir -p ${COMOUTbicor}/bcdata.${yyyymm_m3}/airnow/csv/${yyyy_m3}/${PDYm3}
+  cp ${DCOMINairnow}/${PDYm1}/airnow/HourlyAQObs_${PDYm1}*.dat ${COMOUTbicor}/bcdata.${yyyymm_m1}/airnow/csv/${yyyy_m1}/${PDYm1}  
+  cp ${DCOMINairnow}/${PDYm2}/airnow/HourlyAQObs_${PDYm2}*.dat ${COMOUTbicor}/bcdata.${yyyymm_m2}/airnow/csv/${yyyy_m2}/${PDYm2}  
+  cp ${DCOMINairnow}/${PDYm3}/airnow/HourlyAQObs_${PDYm3}*.dat ${COMOUTbicor}/bcdata.${yyyymm_m3}/airnow/csv/${yyyy_m3}/${PDYm3}
 
   # NetCDF files
-  mkdir -p ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/airnow/netcdf/${yyyy}/${PDY}
-  mkdir -p ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm_m1}/airnow/netcdf/${yyyy_m1}/${PDYm1}
-  mkdir -p ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm_m2}/airnow/netcdf/${yyyy_m2}/${PDYm2}
-  mkdir -p ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm_m3}/airnow/netcdf/${yyyy_m3}/${PDYm3}
-  cp ${DATA}/data/bcdata.${yyyymm_m1}/airnow/netcdf/${yyyy_m1}/${PDYm1}/HourlyAQObs.${PDYm1}.nc ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm_m1}/airnow/netcdf/${yyyy_m1}/${PDYm1}  
-  cp ${DATA}/data/bcdata.${yyyymm_m2}/airnow/netcdf/${yyyy_m2}/${PDYm2}/HourlyAQObs.${PDYm2}.nc ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm_m2}/airnow/netcdf/${yyyy_m2}/${PDYm2}  
-  cp ${DATA}/data/bcdata.${yyyymm_m3}/airnow/netcdf/${yyyy_m3}/${PDYm3}/HourlyAQObs.${PDYm3}.nc ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm_m3}/airnow/netcdf/${yyyy_m3}/${PDYm3}
+  mkdir -p ${COMOUTbicor}/bcdata.${yyyymm}/airnow/netcdf/${yyyy}/${PDY}
+  mkdir -p ${COMOUTbicor}/bcdata.${yyyymm_m1}/airnow/netcdf/${yyyy_m1}/${PDYm1}
+  mkdir -p ${COMOUTbicor}/bcdata.${yyyymm_m2}/airnow/netcdf/${yyyy_m2}/${PDYm2}
+  mkdir -p ${COMOUTbicor}/bcdata.${yyyymm_m3}/airnow/netcdf/${yyyy_m3}/${PDYm3}
+  cp ${DATA}/data/bcdata.${yyyymm_m1}/airnow/netcdf/${yyyy_m1}/${PDYm1}/HourlyAQObs.${PDYm1}.nc ${COMOUTbicor}/bcdata.${yyyymm_m1}/airnow/netcdf/${yyyy_m1}/${PDYm1}  
+  cp ${DATA}/data/bcdata.${yyyymm_m2}/airnow/netcdf/${yyyy_m2}/${PDYm2}/HourlyAQObs.${PDYm2}.nc ${COMOUTbicor}/bcdata.${yyyymm_m2}/airnow/netcdf/${yyyy_m2}/${PDYm2}  
+  cp ${DATA}/data/bcdata.${yyyymm_m3}/airnow/netcdf/${yyyy_m3}/${PDYm3}/HourlyAQObs.${PDYm3}.nc ${COMOUTbicor}/bcdata.${yyyymm_m3}/airnow/netcdf/${yyyy_m3}/${PDYm3}
 
-  mkdir -p  ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/grid/${cyc}z/${PDY}
-  cp ${COMIN}/${NET}.${cycle}.*sfc*.nc ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/grid/${cyc}z/${PDY}
-fi
+  mkdir -p  ${COMOUTbicor}/bcdata.${yyyymm}/grid/${cyc}z/${PDY}
+  cp ${COMIN}/${NET}.${cycle}.*sfc*.nc ${COMOUTbicor}/bcdata.${yyyymm}/grid/${cyc}z/${PDY}
+#fi
 
 #-----------------------------------------------------------------------------
 # STEP 4:  Performing Bias Correction for Ozone
@@ -246,7 +256,7 @@ fi
 
 rm -rf ${DATA}/data/bcdata*
 
-ln -sf ${AQM_AIRNOW_HIST_DIR}/bcdata* "${DATA}/data"
+ln -sf ${COMINbicor}/bcdata* "${DATA}/data"
 
 mkdir -p ${DATA}/data/sites
 cp ${PARMaqm_utils}/bias_correction/config.ozone.bias_corr_${id_domain}.${cyc}z ${DATA}

--- a/scripts/exregional_bias_correction_pm25.sh
+++ b/scripts/exregional_bias_correction_pm25.sh
@@ -93,11 +93,20 @@ if [ "${PREDEF_GRID_NAME}" = "AQM_NA_13km" ]; then
   id_domain=793
 fi
 
-if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-  cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-  CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-  FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
-fi
+case $cyc in
+  00 )
+    FCST_LEN_HRS=6
+  ;;
+  06 )
+    FCST_LEN_HRS=72
+  ;;
+  12 )
+    FCST_LEN_HRS=72
+  ;;
+  18 )
+    FCST_LEN_HRS=6
+  ;;
+esac
 
 #-----------------------------------------------------------------------------
 # STEP 1: Retrieve AIRNOW observation data
@@ -111,9 +120,9 @@ if [ -d "${DATA}/data/bcdata.${yyyymm}" ]; then
   cp -rL "${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/airnow" "${DATA}/data/bcdata.${yyyymm}"
   cp -rL "${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/interpolated" "${DATA}/data/bcdata.${yyyymm}"
 fi
-
+cd ${DATA}
 # Retrieve real-time airnow data for the last three days
-if [ "${DO_REAL_TIME}" = "TRUE" ]; then
+#if [ "${DO_REAL_TIME}" = "TRUE" ]; then
   for ipdym in {1..3}; do
     case $ipdym in
       1)
@@ -156,7 +165,7 @@ if [ "${DO_REAL_TIME}" = "TRUE" ]; then
     fi
     POST_STEP
   done
-fi
+#fi
 
 #-----------------------------------------------------------------------------
 # STEP 2:  Extracting PM2.5, O3, and met variables from CMAQ input and outputs
@@ -214,10 +223,10 @@ POST_STEP
 
 cp ${DATA}/out/pm25/${yyyy}/*nc ${DATA}/data/bcdata.${yyyymm}/interpolated/pm25/${yyyy}
 
-if [ "${DO_AQM_SAVE_AIRNOW_HIST}" = "TRUE" ]; then
-  mkdir -p  ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/interpolated/pm25/${yyyy}
-  cp ${DATA}/out/pm25/${yyyy}/*nc ${AQM_AIRNOW_HIST_DIR}/bcdata.${yyyymm}/interpolated/pm25/${yyyy}
-fi
+#if [ "${DO_AQM_SAVE_AIRNOW_HIST}" = "TRUE" ]; then
+  mkdir -p  ${COMOUTbicor}/bcdata.${yyyymm}/interpolated/pm25/${yyyy}
+  cp ${DATA}/out/pm25/${yyyy}/*nc ${COMOUTbicor}/bcdata.${yyyymm}/interpolated/pm25/${yyyy}
+#fi
 
 #-----------------------------------------------------------------------
 # STEP 4:  Performing Bias Correction for PM2.5 
@@ -225,7 +234,7 @@ fi
 
 rm -rf ${DATA}/data/bcdata*
 
-ln -sf ${AQM_AIRNOW_HIST_DIR}/bcdata* "${DATA}/data"
+ln -sf ${COMINbicor}/bcdata* "${DATA}/data"
 
 mkdir -p ${DATA}/data/sites
 

--- a/scripts/exregional_get_extrn_mdl_files.sh
+++ b/scripts/exregional_get_extrn_mdl_files.sh
@@ -70,11 +70,20 @@ if [ "${ICS_OR_LBCS}" = "ICS" ]; then
 elif [ "${ICS_OR_LBCS}" = "LBCS" ]; then
   file_set="fcst"
   first_time=$((TIME_OFFSET_HRS + LBC_SPEC_INTVL_HRS))
-  if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-    cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-    CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-    FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
-  fi
+  case $cyc in
+    00 )
+      FCST_LEN_HRS=6
+    ;;
+    06 )
+      FCST_LEN_HRS=72
+    ;;
+    12 )
+      FCST_LEN_HRS=72
+    ;;
+    18 )
+      FCST_LEN_HRS=6
+    ;;
+  esac
   last_time=$((TIME_OFFSET_HRS + FCST_LEN_HRS))
   fcst_hrs="${first_time} ${last_time} ${LBC_SPEC_INTVL_HRS}"
   file_names=${EXTRN_MDL_FILES_LBCS[@]}

--- a/scripts/exregional_make_ics.sh
+++ b/scripts/exregional_make_ics.sh
@@ -85,7 +85,7 @@ fi
 #-----------------------------------------------------------------------
 #
 if [ $RUN_ENVIR = "nco" ]; then
-    extrn_mdl_staging_dir="${DATAROOT}/get_extrn_ics.${share_pid}"
+    extrn_mdl_staging_dir="${DATAROOT}/aqm_get_extrn_ics_${cyc}.${share_pid}"
     extrn_mdl_var_defns_fp="${extrn_mdl_staging_dir}/${NET}.${cycle}.${EXTRN_MDL_NAME_ICS}.ICS.${EXTRN_MDL_VAR_DEFNS_FN}.sh"
 else
     extrn_mdl_staging_dir="${COMIN}/${EXTRN_MDL_NAME_ICS}/for_ICS${SLASH_ENSMEM_SUBDIR}"

--- a/scripts/exregional_make_lbcs.sh
+++ b/scripts/exregional_make_lbcs.sh
@@ -84,7 +84,7 @@ fi
 #-----------------------------------------------------------------------
 #
 if [ $RUN_ENVIR = "nco" ]; then
-    extrn_mdl_staging_dir="${DATAROOT}/get_extrn_lbcs.${share_pid}"
+    extrn_mdl_staging_dir="${DATAROOT}/aqm_get_extrn_lbcs_${cyc}.${share_pid}"
     extrn_mdl_var_defns_fp="${extrn_mdl_staging_dir}/${NET}.${cycle}.${EXTRN_MDL_NAME_LBCS}.LBCS.${EXTRN_MDL_VAR_DEFNS_FN}.sh"
 else
     extrn_mdl_staging_dir="${COMIN}/${EXTRN_MDL_NAME_LBCS}/for_LBCS${SLASH_ENSMEM_SUBDIR}"
@@ -98,11 +98,21 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-  cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-  CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-  FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
-fi
+case $cyc in
+  00 )
+    FCST_LEN_HRS=6
+  ;;
+  06 )
+    FCST_LEN_HRS=72
+  ;;
+  12 )
+    FCST_LEN_HRS=72
+  ;;
+  18 )
+    FCST_LEN_HRS=6
+  ;;
+esac
+
 LBC_SPEC_FCST_HRS=()
 for i_lbc in $(seq ${LBC_SPEC_INTVL_HRS} ${LBC_SPEC_INTVL_HRS} $(( FCST_LEN_HRS+LBC_SPEC_INTVL_HRS )) ); do
   LBC_SPEC_FCST_HRS+=("$i_lbc")

--- a/scripts/exregional_nexus_emission.sh
+++ b/scripts/exregional_nexus_emission.sh
@@ -89,7 +89,7 @@ mkdir -p "$DATAinput"
 USE_GFS_SFC="FALSE"
 
 if [ "${RUN_ENVIR}" = "nco" ]; then
-  GFS_SFC_INPUT="${DATAROOT}/nexus_gfs_sfc.${share_pid}"
+  GFS_SFC_INPUT=${GFS_SFC_INPUT:-${DATAROOT}/aqm_nexus_gfs_sfc_${cyc}.${share_pid}}
 else
   GFS_SFC_INPUT="${COMIN}/GFS_SFC"
 fi
@@ -130,11 +130,21 @@ hh="${cyc}"
 yyyymmdd="${PDY}"
 
 NUM_SPLIT_NEXUS=$( printf "%02d" ${NUM_SPLIT_NEXUS} )
-if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-  cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-  CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-  FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
-fi
+
+case $cyc in
+  00 )
+    FCST_LEN_HRS=6
+  ;;
+  06 )
+    FCST_LEN_HRS=72
+  ;;
+  12 )
+    FCST_LEN_HRS=72
+  ;;
+  18 )
+    FCST_LEN_HRS=6
+  ;;
+esac
 
 if [ "${NUM_SPLIT_NEXUS}" = "01" ]; then
   start_date=$( $DATE_UTIL --utc --date "${yyyymmdd} ${hh} UTC" "+%Y%m%d%H" )

--- a/scripts/exregional_nexus_gfs_sfc.sh
+++ b/scripts/exregional_nexus_gfs_sfc.sh
@@ -56,11 +56,22 @@ yyyymmdd=${GFS_SFC_CDATE:0:8}
 yyyymm=${GFS_SFC_CDATE:0:6}
 yyyy=${GFS_SFC_CDATE:0:4}
 hh=${GFS_SFC_CDATE:8:2}
-if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-  cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-  CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-  FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
-fi
+
+case $cyc in
+  00 )
+    FCST_LEN_HRS=6
+  ;;
+  06 )
+    FCST_LEN_HRS=72
+  ;;
+  12 )
+    FCST_LEN_HRS=72
+  ;;
+  18 )
+    FCST_LEN_HRS=6
+  ;;
+esac
+
 fcst_len_hrs_offset=$(( FCST_LEN_HRS + TIME_OFFSET_HRS ))
 #
 #-----------------------------------------------------------------------

--- a/scripts/exregional_nexus_post_split.sh
+++ b/scripts/exregional_nexus_post_split.sh
@@ -59,11 +59,22 @@ hh="${cyc}"
 yyyymmdd="${PDY}"
 
 NUM_SPLIT_NEXUS=$( printf "%02d" ${NUM_SPLIT_NEXUS} )
-if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-  cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-  CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-  FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
-fi
+
+case $cyc in
+  00 )
+    FCST_LEN_HRS=6
+  ;;
+  06 )
+    FCST_LEN_HRS=72
+  ;;
+  12 )
+    FCST_LEN_HRS=72
+  ;;
+  18 )
+    FCST_LEN_HRS=6
+  ;;
+esac
+
 start_date=$( $DATE_UTIL --utc --date "${yyyymmdd} ${hh} UTC" "+%Y%m%d%H" )
 end_date=$( $DATE_UTIL --utc --date "${yyyymmdd} ${hh} UTC + ${FCST_LEN_HRS} hours" "+%Y%m%d%H" )
 

--- a/scripts/exregional_point_source.sh
+++ b/scripts/exregional_point_source.sh
@@ -53,11 +53,21 @@ This is the ex-script for the task that runs PT_SOURCE.
 #
 eval ${PRE_TASK_CMDS}
 
-if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-  cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-  CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-  FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
-fi
+case $cyc in
+  00 )
+    FCST_LEN_HRS=6
+  ;;
+  06 )
+    FCST_LEN_HRS=72
+  ;;
+  12 )
+    FCST_LEN_HRS=72
+  ;;
+  18 )
+    FCST_LEN_HRS=6
+  ;;
+esac
+
 nstep=$(( FCST_LEN_HRS+1 ))
 yyyymmddhh="${PDY}${cyc}"
 

--- a/scripts/exregional_post_stat_o3.sh
+++ b/scripts/exregional_post_stat_o3.sh
@@ -109,11 +109,20 @@ else
 fi
 POST_STEP
 
-if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-  cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-  CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-  FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
-fi
+case $cyc in
+  00 )
+    FCST_LEN_HRS=6
+  ;;
+  06 )
+    FCST_LEN_HRS=72
+  ;;
+  12 )
+    FCST_LEN_HRS=72
+  ;;
+  18 )
+    FCST_LEN_HRS=6
+  ;;
+esac
 
 fhr=01
 while [ ${fhr} -le ${FCST_LEN_HRS} ]; do

--- a/scripts/exregional_pre_post_stat.sh
+++ b/scripts/exregional_pre_post_stat.sh
@@ -53,10 +53,22 @@ This is the ex-script for the task that runs POST-UPP-STAT.
 #
 eval ${PRE_TASK_CMDS}
 
-if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-  cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-  CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-  FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
+if [ "${FCST_LEN_HRS}" = "-1" ]; then
+  case $cyc in
+    00 )
+      FCST_LEN_HRS=6
+    ;;
+    06 )
+      FCST_LEN_HRS=72
+    ;;
+    12 )
+      FCST_LEN_HRS=72
+    ;;
+    18 )
+      FCST_LEN_HRS=6
+    ;;
+  esac
+
   if [ "${RUN_TASK_RUN_POST}" = "TRUE" ]; then
     rm -f "${COMIN}/${TN_RUN_POST}_${PDY}${cyc}_task_complete.txt"
   fi

--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -81,11 +81,21 @@ else
   All executables will be submitted with command \'${RUN_CMD_FCST}\'."
 fi
 
-if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-  cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
-  CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
-  FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
-fi
+case $cyc in
+  00 )
+    FCST_LEN_HRS=6
+  ;;
+  06 )
+    FCST_LEN_HRS=72
+  ;;
+  12 )
+    FCST_LEN_HRS=72
+  ;;
+  18 )
+    FCST_LEN_HRS=6
+  ;;
+esac
+
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -167,7 +167,7 @@ fi
 # Set the names of the forecast model's write-component output files.
 #
 if [ "${RUN_ENVIR}" = "nco" ]; then
-    DATAFCST=$DATAROOT/run_fcst${dot_ensmem/./_}.${share_pid}
+    DATAFCST=${DATAFCST:-${DATAROOT}/run_fcst${dot_ensmem/./_}.${share_pid}}
 else
     DATAFCST="${COMIN}${SLASH_ENSMEM_SUBDIR}"
 fi
@@ -304,9 +304,9 @@ done
 rm -rf ${DATA_FHR}
 
 # Delete the forecast directory
-if [ $RUN_ENVIR = "nco" ] && [ $KEEPDATA = "FALSE" ]; then
-   rm -rf $DATAFCST
-fi
+# if [ $RUN_ENVIR = "nco" ] && [ $KEEPDATA = "FALSE" ]; then
+#   rm -rf $DATAFCST
+# fi
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/config.aqm.nco.realtime.yaml
+++ b/ush/config.aqm.nco.realtime.yaml
@@ -34,7 +34,7 @@ nco:
   model_ver: v7.0
   RUN: aqm_nco_aqmna13km
   OPSROOT: /path/to/custom/opsroot
-  KEEPDATA: false
+  KEEPDATA: NO
 workflow_switches:
   RUN_TASK_MAKE_GRID: false
   RUN_TASK_MAKE_OROG: false

--- a/ush/config_defaults.yaml
+++ b/ush/config_defaults.yaml
@@ -963,7 +963,7 @@ nco:
   SENDDBN_NTC: false
   SENDCOM: false
   SENDWEB: false
-  KEEPDATA: true
+  KEEPDATA: YES
   MAILTO: ""
   MAILCC: ""
 
@@ -2961,7 +2961,7 @@ cpl_aqm_parm:
   # AQM_LBCS_FILES:
   # File name of chemical LBCs
   #
-  # DCOMINgefs:
+  # COMINgefs:
   # Path to the directory containing GEFS aerosol LBC files
   #
   # AQM_GEFS_FILE_PREFIX:
@@ -3038,7 +3038,7 @@ cpl_aqm_parm:
   DCOMINchem_lbcs: ""
   AQM_LBCS_FILES: "am4_bndy_c793.2019<MM>.v1.nc"
 
-  DCOMINgefs: ""
+  COMINgefs: ""
   AQM_GEFS_FILE_PREFIX: "geaer"
   AQM_GEFS_FILE_CYC: ""
 
@@ -3052,4 +3052,6 @@ cpl_aqm_parm:
   DCOMINpt_src: "/path/to/point/source/base/directory"
 
   DCOMINairnow: "/path/to/airnow/obaservation/data"
-  AQM_AIRNOW_HIST_DIR: "/path/to/historical/airnow/data/dir"
+    #AQM_AIRNOW_HIST_DIR: "/path/to/historical/airnow/data/dir"
+  COMINbicor: "/path/to/historical/airnow/data/dir"
+  COMOUTbicor: "/path/to/historical/airnow/data/dir"

--- a/ush/job_preamble.sh
+++ b/ush/job_preamble.sh
@@ -7,7 +7,7 @@
 #
 #-----------------------------------------------------------------------
 #
-export share_pid=${WORKFLOW_ID}_${PDY}${cyc}
+export share_pid=${share_pid:-${PDY}${cyc}}
 if [ $# -ne 0 ]; then
     export pid=$share_pid
     export jobid=${job}.${pid}
@@ -121,8 +121,8 @@ export -f POST_STEP
 #
 #-----------------------------------------------------------------------
 #
+[[ "$WORKFLOW_MANAGER" = "rocoto" ]] && export COMROOT=$COMROOT
 if [ "${RUN_ENVIR}" = "nco" ]; then
-    export COMROOT=$COMROOT
     export COMIN="${COMIN:-$(compath.py -o ${NET}/${model_ver}/${RUN}.${PDY}/${cyc})}"
     export COMOUT="${COMOUT:-$(compath.py -o ${NET}/${model_ver}/${RUN}.${PDY}/${cyc})}"
     export COMINm1="${COMINm1:-$(compath.py -o ${NET}/${model_ver}/${RUN}.${PDYm1})}"
@@ -130,7 +130,7 @@ if [ "${RUN_ENVIR}" = "nco" ]; then
     export COMINgfs="${COMINgfs:-$(compath.py ${envir}/gfs/${gfs_ver})}"
     export COMINgefs="${COMINgefs:-$(compath.py ${envir}/gefs/${gefs_ver})}"
 
-    export KEEPDATA="${KEEPDATA:-$KEEPDATA}"
+#    export KEEPDATA="${KEEPDATA:-$KEEPDATA}"
 else
     export COMIN="${COMIN_BASEDIR}/${PDY}${cyc}"
     export COMOUT="${COMOUT_BASEDIR}/${PDY}${cyc}"
@@ -161,19 +161,11 @@ fi
 #-----------------------------------------------------------------------
 #
 function job_postamble() {
-
     # Remove temp directory
-    if [ "${RUN_ENVIR}" = "nco" ] && [ "${KEEPDATA}" = "FALSE" ]; then
+    if [ "${RUN_ENVIR}" = "nco" ] && [ "${KEEPDATA}" = "NO" ]; then
+        echo "DATA clean up for directory: ${DATA}"
 	cd ${DATAROOT}
-	# Remove current data directory
-	if [ $# -eq 0 ]; then
-	    rm -rf $DATA
-	# Remove all current and shared data directories
-	elif [ "$1" = "TRUE" ]; then
-            rm -rf $DATA
-	    share_pid="${WORKFLOW_ID}_${PDY}${cyc}"
-            rm -rf *${share_pid}
-	fi
+        rm -rf $DATA
     fi
 
     # Print exit message

--- a/ush/machine/wcoss2.yaml
+++ b/ush/machine/wcoss2.yaml
@@ -9,9 +9,9 @@ platform:
   MET_BIN_EXEC: bin
   MET_INSTALL_DIR: /apps/ops/para/libs/intel/19.1.3.304/met/10.1.1
   DOMAIN_PREGEN_BASEDIR: /lfs/h2/emc/lam/noscrub/UFS_SRW_App/develop/FV3LAM_pregen
-  QUEUE_DEFAULT: dev
-  QUEUE_FCST: dev
-  QUEUE_HPSS: dev_transfer
+  QUEUE_DEFAULT: devhigh
+  QUEUE_FCST: devhigh
+  QUEUE_HPSS: devhigh
   RUN_CMD_FCST: mpiexec -n ${PE_MEMBER01} -ppn ${PPN_RUN_FCST} --cpu-bind core -depth ${OMP_NUM_THREADS_RUN_FCST}
   RUN_CMD_POST: mpiexec -n ${nprocs}
   RUN_CMD_PRDGEN: mpiexec -n ${nprocs} --cpu-bind core cfp
@@ -44,10 +44,13 @@ cpl_aqm_parm:
   DCOMINcanopy: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/canopy
   DCOMINfire: /lfs/h2/emc/physics/noscrub/kai.wang/RAVE_fire/RAVE_NA_NRT
   DCOMINchem_lbcs: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/LBCS/AQM_NA13km_AM4_v1
-  DCOMINgefs: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/GEFS_DATA
+    #DCOMINgefs: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/GEFS_DATA
+  COMINgefs: /lfs/h1/ops/prod/com/gefs/v12.3 
   DCOMINpt_src: /lfs/h2/emc/physics/noscrub/Youhua.Tang/nei2016v1-pt/v2023-01-PT
   DCOMINairnow: /lfs/h1/ops/prod/dcom
-  AQM_AIRNOW_HIST_DIR: /lfs/h2/emc/physics/noscrub/jianping.huang/Bias_correction/aqmv7.0
+    #AQM_AIRNOW_HIST_DIR: /lfs/h2/emc/physics/noscrub/jianping.huang/Bias_correction/aqmv7.0e
+  COMINbicor: /lfs/h2/emc/physics/noscrub/jianping.huang/Bias_correction/aqmv7.0g
+  COMOUTbicor: /lfs/h2/emc/physics/noscrub/jianping.huang/Bias_correction/aqmv7.0g
   NEXUS_INPUT_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/nexus_emissions
   NEXUS_FIX_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/nexus/fix
   NEXUS_GFS_SFC_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/GFS_DATA

--- a/ush/preamble.sh
+++ b/ush/preamble.sh
@@ -87,8 +87,11 @@ fi
 #-----------------------------------------------------------------------
 #
 STRICT=${STRICT:-"TRUE"}
-TRACE=${DEBUG:-"FALSE"}
-
+if [ "${RUN_ENVIR}" = "nco" ]; then
+  TRACE="TRUE"
+else
+  TRACE=${DEBUG:-"FALSE"}
+fi
 if [[ $STRICT == "TRUE" ]]; then
     # Exit on error and undefined variable
     set -euo pipefail

--- a/versions/run.ver.wcoss2
+++ b/versions/run.ver.wcoss2
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+export aqm_ver=v7.0.75
+export gfs_ver=v16.3
+export gefs_ver=v12.3
+
 export PrgEnv_intel_ver=8.1.0
 export intel_ver=19.1.3.304
 export craype_ver=2.7.13
@@ -37,9 +41,6 @@ export nemsiogfs_ver=2.5.3
 export python_ver=3.8.6
 export rocoto_ver=1.3.5
 export envvar_ver=1.0
-
-export gfs_ver=v16.3
-export gefs_ver=v12.3
 
 export udunits_ver=2.2.28
 export gsl_ver=2.7


### PR DESCRIPTION
Background:
This merge is for Github issue #797 to bring the current development version ecflow updates into the production/AQM.v7 #cf184119. This version of the ecflow is not to be used for NCO code delivery.
There will be incremental updates following this merge. Once the AQM package is ready for implementation, the ecflow workflow will be configured for NCO code delivery in a later update.

Condition of the production/AQM.v7 #cf184119:
Here is a list of known issues from the production/AQM.v7 #cf184119:
- forecast restart does not reproduce.
- forecast job does not create field_table, data_table, and input.nml configuration file within its DATA directory. It reads these configuration files from the workflow configuration directory. There are files will need to be modified if forecast job configuration change is necessary.
- data_table file used in the forecast job is a size zero file. 
- emission jobs have known internal issues which result in incorrect output from the science point of view.
- lbcs job executable has known unstable silent failed condition.
- bias correction jobs unable to reproduce due to exception handling issues.
- There are four jobs that write output in its DATA location for other jobs to access. Therefore these four jobs can not remove the DATA when the job is completed. There are nexus_gfs_sfc, forecast, get_extrn_ics, and get_extrn_lbcs

The scrope of this merge:
This merge is to bring AQM ecflow workflow into the production/AQM.v7.
The merged AQM ecflow workflow will have all jobs completed with exit code 0 status.
This merge does not address AQM package internal issues outlined in the condition of the production/AQM.v7 #cf184119 session above.
The goal of this merge is not to fix EE2 issues of the AQM package.

Change log:
- Adding ecflow code delivery instruction in docs
- Adding ecflow workflow within AQM package in ecf directory
- Adding ecflow workflow control directory in parm/config
- Modified ush/preamble.sh to enable TRACE for NCO
- Modified ush/machine/wcoss2.yaml for EMC realtime
- Modified the ush/config.aqm.nco.realtime.yaml to use NCO standard of KEEPDATA as YES/NO
- Modified the ush/config_defaults.yaml to: 
  Use NCO standard of KEEPDATA. 
  Fixed bug with COMINgefs configuration.
  Match COMINbicor and COMOUTbicor with AQM realtime parallel
  Remove extra AQM_AIRNOW_HIST_DIR
- Modified ush/job_preamble.sh to:
  Use updated share_pid for DATA directory assignment.
  Remove unnecessary COMROOT assignment for nco environment.
  Remove unnecessary KEEPDATA logic.
  The DATA cleanup logic in job_postamble function does not work for the NCO environment during some emergency, production switch, and rerun conditions. Modified job_postamble function to do DATA clean up for those jobs that called it. There are four jobs that use DATA store output files for other jobs to access. These four jobs will not be using job_postamble to clean out the DATA.
- Modified versions/run.ver.wcoss2 to include aqm_ver and arrange the model version in the head of the file.
- Add jobs/JAQM_MANAGER to enable EMC retro development parallel
- Add jobs/JDATA_CLEANUP to enable NCO DATA cleanup for job nexus_gfs_sfc, forecast, get_extrn_ics, and get_extrn_lbcs.
- Modified the following J-Jobs to use COMIN assigned by NCO ecflow workflow for INPUT_DATA value within NCO environment
  jobs/JREGIONAL_AQM_ICS
  jobs/JREGIONAL_AQM_LBCS
  jobs/JREGIONAL_MAKE_ICS
  jobs/JREGIONAL_MAKE_LBCS
  jobs/JREGIONAL_NEXUS_EMISSION
  jobs/JREGIONAL_NEXUS_POST_SPLIT
  jobs/JREGIONAL_POINT_SOURCE
- Modified the following J-Jobs to use necessary environment variables.
  jobs/JREGIONAL_BIAS_CORRECTION_O3
  jobs/JREGIONAL_BIAS_CORRECTION_PM25
  jobs/JREGIONAL_FIRE_EMISSION
  jobs/JREGIONAL_POST_STAT_O3
  jobs/JREGIONAL_POST_STAT_PM25
- Modified jobs/JREGIONAL_GET_EXTRN_MDL_FILES: 
  Fixed application logic for ICS_OR_LBCS exception handling issue.
  Updated staging directory location naming to be consistent.
  Removed from DATA cleaning function job_postamble because the DATA of this job will be removed from DATA_CLEANUP job.
- Modified jobs/JREGIONAL_NEXUS_GFS_SFC:
  Removed from DATA cleaning function job_postamble because the DATA of this job will be removed from DATA_CLEANUP job.
- Modified jobs/JREGIONAL_RUN_FCST:
  Removed from DATA cleaning function job_postamble because the DATA of this job will be removed from DATA_CLEANUP job.
- Modified jobs/JREGIONAL_RUN_POST:
  Use DATAFCST from workflow assignment if default is set.
  Fixed application logic for FCST_LEN_HRS value from array assignment.
  Removed wired in rocoto developer logic for file *_task_complete.txt
  Update application logic to use job_postamble.
- Add scripts/exaqm_manager.sh for j-job JAQM_MANAGER
- Add scripts/exdata_cleanup.sh for j-job JDATA_CLEANUP
- Modified scripts/exregional_aqm_lbcs.sh: 
  Fixed application logic in FCST_LEN_HRS assignment.
  Fixed AQM_MOFILE_FP path assignment issue.
- Modified scripts/exregional_bias_correction_o3.sh
  Fixed application logic in FCST_LEN_HRS assignment.
  Replace AQM_AIRNOW_HIST_DIR with NCO standard COMINbicor
  Fixed application logic in write output file
- Modified scripts/exregional_bias_correction_pm25.sh
  Fixed application logic in FCST_LEN_HRS assignment.
  Replace AQM_AIRNOW_HIST_DIR with NCO standard COMINbicor
  Fixed application logic in write output file
- Fixed application logic in FCST_LEN_HRS assignment.
  scripts/exregional_get_extrn_mdl_files.sh
  scripts/exregional_nexus_gfs_sfc.sh 
  scripts/exregional_nexus_post_split.sh 
  scripts/exregional_point_source.sh
  scripts/exregional_post_stat_o3.sh
  scripts/exregional_pre_post_stat.sh
  scripts/exregional_run_fcst.sh 
- Modified scripts/exregional_make_ics.sh
  Use NCO standard naming for DATA location
- Modified scripts/exregional_make_lbcs.sh
  Use NCO standard naming for DATA location
  Fixed application logic in FCST_LEN_HRS assignment.
- Modified scripts/exregional_nexus_emission.sh
  Fixed application logic in FCST_LEN_HRS assignment.
  Use NCO standard naming for DATA location
- Modified scripts/exregional_run_post.sh  
  Use NCO standard naming for DATA location
  Remove unconditional remove of the forecast DATA because it will be handled by data_cleanup job

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [x] wcoss2.intel

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


