### PR TITLE
[develop] Add modulefiles/tasks/cheyenne/run_vx.local.lua to allow fundamental tests to pass on Cheyenne

### DIFF
--- a/modulefiles/tasks/cheyenne/run_vx.local.lua
+++ b/modulefiles/tasks/cheyenne/run_vx.local.lua
@@ -1,0 +1,12 @@
+--[[
+Loading intel is really only necessary when running verification tasks
+with the COMPILER experiment parameter set to "gnu" because in that case,
+the intel libraries aren't loaded, but the MET/METplus vx software still
+needs them because it's built using the intel compiler.  Both the unload
+and load("intel") lines can be removed if/when there is a version of
+MET/METplus built using GNU.
+--]]
+unload("build_cheyenne_gnu")
+load("intel/2021.2")
+unload("python")
+load("python_srw")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Currently, the `grid_RRFS_CONUS_25km_ics_NAM_lbcs_NAM_suite_GFS_v16` fundamental test fails on Cheyenne GNU.  The failure is due to needing an Intel compiler to be loaded to run MET/METplus.  This PR adds a new `run_vx.local.lua` modulefile for Cheyenne that will load the Intel compiler and allow the `grid_RRFS_CONUS_25km_ics_NAM_lbcs_NAM_suite_GFS_v16` test to run successfully on GNU.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
- [ ] hera.intel
- [ ] orion.intel
- [X] cheyenne.intel
- [X] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [X] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## ISSUE: 
Fixes #817

## CHECKLIST
<!-- Add an X to check off a box. -->
- [X] My code follows the style guidelines in the Contributor's Guide
- [X] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes do not require updates to the documentation (explain).
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published