### PR TITLE
[develop] fixes to enable stochastic physics

### DIFF
--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -444,7 +444,7 @@ fi
 #-----------------------------------------------------------------------
 #
 STOCH="FALSE"
-if [ "${DO_ENSEMBLE}" = "TRUE" ] && ([ "${DO_SPP}" = "TRUE" ] || [ "${DO_SPPT}" = "TRUE" ] || [ "${DO_SHUM}" = "TRUE" ] || \
+if ([ "${DO_SPP}" = "TRUE" ] || [ "${DO_SPPT}" = "TRUE" ] || [ "${DO_SHUM}" = "TRUE" ] || \
    [ "${DO_SKEB}" = "TRUE" ] || [ "${DO_LSM_SPP}" =  "TRUE" ]); then
      STOCH="TRUE"
 fi
@@ -461,7 +461,7 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-if [ "$STOCH" == "TRUE" ]; then
+if ([ "$STOCH" == "TRUE" ] && [ "${DO_ENSEMBLE}" = "TRUE" ]); then
   python3 $USHdir/set_FV3nml_ens_stoch_seeds.py \
       --path-to-defns ${GLOBAL_VAR_DEFNS_FP} \
       --cdate "$CDATE" || print_err_msg_exit "\

--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -449,7 +449,7 @@ if [ "${DO_ENSEMBLE}" = "TRUE" ] && ([ "${DO_SPP}" = "TRUE" ] || [ "${DO_SPPT}" 
      STOCH="TRUE"
 fi
 if [ "${STOCH}" == "TRUE" ]; then
-  ln_vrfy -sf ${FV3_NML_STOCH_FP} ${DATA}/${FV3_NML_FN}
+  cp_vrfy ${FV3_NML_STOCH_FP} ${DATA}/${FV3_NML_FN}
  else
   ln_vrfy -sf ${FV3_NML_FP} ${DATA}/${FV3_NML_FN}
 fi
@@ -462,7 +462,6 @@ fi
 #-----------------------------------------------------------------------
 #
 if [ "$STOCH" == "TRUE" ]; then
-  cp_vrfy ${DATA}/${FV3_NML_FN} ${DATA}/${FV3_NML_FN}_base
   python3 $USHdir/set_FV3nml_ens_stoch_seeds.py \
       --path-to-defns ${GLOBAL_VAR_DEFNS_FP} \
       --cdate "$CDATE" || print_err_msg_exit "\

--- a/tests/test_python/test_set_FV3nml_ens_stoch_seeds.py
+++ b/tests/test_python/test_set_FV3nml_ens_stoch_seeds.py
@@ -51,14 +51,14 @@ class Testing(unittest.TestCase):
         mkdir_vrfy("-p", self.mem_dir)
         cp_vrfy(
             os.path.join(PARMdir, "input.nml.FV3"),
-            os.path.join(EXPTDIR, "input.nml_base"),
+            os.path.join(EXPTDIR, "input.nml"),
         )
 
 
         set_env_var("USHdir", USHdir)
         set_env_var("ENSMEM_INDX", 2)
         set_env_var("FV3_NML_FN", "input.nml")
-        set_env_var("FV3_NML_FP", os.path.join(EXPTDIR, "input.nml_base"))
+        set_env_var("FV3_NML_FP", os.path.join(EXPTDIR, "input.nml"))
         set_env_var("DO_SHUM", True)
         set_env_var("DO_SKEB", True)
         set_env_var("DO_SPPT", True)

--- a/tests/test_python/test_set_FV3nml_ens_stoch_seeds.py
+++ b/tests/test_python/test_set_FV3nml_ens_stoch_seeds.py
@@ -51,14 +51,14 @@ class Testing(unittest.TestCase):
         mkdir_vrfy("-p", self.mem_dir)
         cp_vrfy(
             os.path.join(PARMdir, "input.nml.FV3"),
-            os.path.join(EXPTDIR, "input.nml"),
+            os.path.join(self.mem_dir, "input.nml"),
         )
 
 
         set_env_var("USHdir", USHdir)
         set_env_var("ENSMEM_INDX", 2)
         set_env_var("FV3_NML_FN", "input.nml")
-        set_env_var("FV3_NML_FP", os.path.join(EXPTDIR, "input.nml"))
+        set_env_var("FV3_NML_FP", os.path.join(self.mem_dir, "input.nml"))
         set_env_var("DO_SHUM", True)
         set_env_var("DO_SKEB", True)
         set_env_var("DO_SPPT", True)

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -718,7 +718,7 @@ def generate_FV3LAM_wflow(
     #
     #-----------------------------------------------------------------------
     #
-    if DO_ENSEMBLE and any((DO_SPP, DO_SPPT, DO_SHUM, DO_SKEB, DO_LSM_SPP)):
+    if any((DO_SPP, DO_SPPT, DO_SHUM, DO_SKEB, DO_LSM_SPP)):
 
         set_namelist(
             [

--- a/ush/set_FV3nml_ens_stoch_seeds.py
+++ b/ush/set_FV3nml_ens_stoch_seeds.py
@@ -100,7 +100,7 @@ def set_FV3nml_ens_stoch_seeds(cdate):
     print_info_msg(
         dedent(
             f"""
-            The variable 'settings' specifying seeds in '{FV3_NML_FP}'
+            The variable 'settings' specifying seeds in '{fv3_nml_ensmem_fp}'
             has been set as follows:
 
             settings =\n\n"""

--- a/ush/set_FV3nml_ens_stoch_seeds.py
+++ b/ush/set_FV3nml_ens_stoch_seeds.py
@@ -57,7 +57,7 @@ def set_FV3nml_ens_stoch_seeds(cdate):
     #
     # -----------------------------------------------------------------------
     #
-    fv3_nml_ensmem_fp = f"{os.getcwd()}{os.sep}{FV3_NML_FN}_base"
+    fv3_nml_ensmem_fp = f"{os.getcwd()}{os.sep}{FV3_NML_FN}"
 
     ensmem_num = int(ENSMEM_INDX)
 
@@ -93,7 +93,7 @@ def set_FV3nml_ens_stoch_seeds(cdate):
     if DO_LSM_SPP:
         iseed_lsm_spp = cdate_i * 1000 + ensmem_num * 10 + 9
 
-        settings["nam_sppperts"] = {"iseed_lndp": [iseed_lsm_spp]}
+        settings["nam_sfcperts"] = {"iseed_lndp": [iseed_lsm_spp]}
 
     settings_str = cfg_to_yaml_str(settings)
 
@@ -111,7 +111,7 @@ def set_FV3nml_ens_stoch_seeds(cdate):
 
     try:
         set_namelist(
-            ["-q", "-n", FV3_NML_FP, "-u", settings_str, "-o", fv3_nml_ensmem_fp]
+            ["-q", "-n", fv3_nml_ensmem_fp, "-u", settings_str, "-o", fv3_nml_ensmem_fp]
         )
     except:
         print_err_msg_exit(


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
These changes allow ensemble mode to use seeds generated to be unique to the forecast cycle and ensemble member, and they also allow stochastic physics to be turned on in deterministic mode.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## TESTS CONDUCTED: 
A configuration was created which turned on all stochastic physics schemes (SPP, SPPT, SKEB, SHUB) _except_ land surface perturbations. This test was successful and shown to use differing stochastic physics seeds for each ensemble member in the output forecasts. Other tests were run by @JeffBeck-NOAA showing that a deterministic forecast may now be run with stochastic physics.

Note: Land surface perturbations were left off because the current default settings for it in config_defaults.yaml no longer seem to work.

- [X] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)


## DOCUMENTATION:
It was previously discussed with @MichaelLueken and @gspetro-NOAA that stochastic physics should be noted to no longer work in the documentation. Hopefully this PR does away with that need.

## ISSUE: 
This PR fixes issue #818.

## CONTRIBUTORS (optional): 
@JeffBeck-NOAA 

