### PR TITLE
[develop] Update wrapper scripts

### DIFF
--- a/.cicd/Jenkinsfile
+++ b/.cicd/Jenkinsfile
@@ -149,7 +149,7 @@ pipeline {
                     stage('Functional WorkflowTaskTests') {
                         steps {
                             echo "Running simple workflow script task tests on ${env.SRW_PLATFORM} (using ${env.WORKSPACE})"
-                            sh 'bash --login "${WORKSPACE}/.cicd/scripts/srw_ftest.sh"'
+                            sh 'bash --login "${WORKSPACE}/.cicd/scripts/wrapper_srw_ftest.sh"'
                         }
                     }
 

--- a/.cicd/scripts/qsub_srw_ftest.sh
+++ b/.cicd/scripts/qsub_srw_ftest.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# This is a pbs job card for the srw_ftest.sh script
+# and is called by the wrapper_srw_ftest.sh script
+# 
+#PBS -N srw_ftest_run
+#PBS -A ${SRW_PROJECT}
+#PBS -q batch
+#PBS -l nodes=1:ppn=24
+#PBS -l walltime=00:30:00
+#PBS -o log_wrap.%j.log
+#PBS -e err_wrap.%j.err 
+
+bash ${WORKSPACE}/.cicd/scripts/srw_ftest.sh

--- a/.cicd/scripts/qsub_srw_ftest.sh
+++ b/.cicd/scripts/qsub_srw_ftest.sh
@@ -5,9 +5,10 @@
 # 
 #PBS -N srw_ftest_run
 #PBS -A ${SRW_PROJECT}
-#PBS -q batch
-#PBS -l nodes=1:ppn=24
+#PBS -q main
+#PBS -l select=1:ncpus=24:mpiprocs=24:ompthreads=1
 #PBS -l walltime=00:30:00
+#PBS -V
 #PBS -o log_wrap.%j.log
 #PBS -e err_wrap.%j.err 
 

--- a/.cicd/scripts/sbatch_srw_ftest.sh
+++ b/.cicd/scripts/sbatch_srw_ftest.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# This is a sbatch job card for the srw_ftest.sh script
+# and is called by the srw_ftest_wrapper.sh script
+# 
+#SBATCH --job-name=wrapper_test
+#SBATCH --account=${SRW_PROJECT}
+#SBATCH --qos=batch
+#SBATCH --nodes=1
+#SBATCH --tasks-per-node=24
+#SBATCH --cpus-per-task=1
+#SBATCH -t 00:30:00
+#SBATCH -o log_wrap.%j.log
+#SBATCH -e err_wrap.%j.err 
+
+bash ${WORKSPACE}/.cicd/scripts/srw_ftest.sh

--- a/.cicd/scripts/srw_ftest.sh
+++ b/.cicd/scripts/srw_ftest.sh
@@ -19,7 +19,7 @@
 [[ -n ${ACCOUNT} ]] || ACCOUNT="no_account"
 [[ -n ${BRANCH} ]] || BRANCH="develop"
 [[ -n ${TASKS} ]] || TASKS=""
-[[ -n ${TASK_DEPTH} ]] || TASK_DEPTH=4
+[[ -n ${TASK_DEPTH} ]] || TASK_DEPTH=9
 [[ -n ${FORGIVE_CONDA} ]] || FORGIVE_CONDA=true
 set -e -u -x
 
@@ -63,6 +63,9 @@ echo "EXPTDIR=${EXPTDIR}"
 sed "s|^workflow:|workflow:\n  EXPT_BASEDIR: ${workspace}/expt_dirs|1" -i ush/config.yaml
 sed "s|^workflow:|workflow:\n  EXEC_SUBDIR: ${workspace}/install_${SRW_COMPILER}/exec|1" -i ush/config.yaml
 
+# Decrease forecast length since we are running all the steps
+sed "s|^  FCST_LEN_HRS: 12|  FCST_LEN_HRS: 6|g" -i ush/config.yaml
+
 # DATA_LOCATION differs on each platform ... find it.
 export DATA_LOCATION=$(grep TEST_EXTRN_MDL_SOURCE_BASEDIR ${workspace}/ush/machine/${SRW_PLATFORM,,}.yaml | awk '{printf "%s", $2}')
 echo "DATA_LOCATION=${DATA_LOCATION}"
@@ -103,10 +106,8 @@ cp ${workspace}/ush/wrappers/* .
 # Set parameters that the task scripts require ...
 export JOBSdir=${workspace}/jobs
 export USHdir=${workspace}/ush
-export PDY=20190615
-export cyc=18
-export subcyc=0
 export OMP_NUM_THREADS=1
+export nprocs=24
 
 [[ -n ${TASKS} ]] || TASKS=(
                 run_make_grid

--- a/.cicd/scripts/srw_ftest.sh
+++ b/.cicd/scripts/srw_ftest.sh
@@ -30,6 +30,7 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)
 declare workspace
 if [[ -n "${WORKSPACE}" ]]; then
     workspace="${WORKSPACE}"
+    cd $workspace
 else
     workspace="$(cd -- "${script_dir}/../.." && pwd)"
 fi

--- a/.cicd/scripts/srw_ftest.sh
+++ b/.cicd/scripts/srw_ftest.sh
@@ -16,7 +16,7 @@
 #    SRW_COMPILER=<intel|gnu>
 #
 # Optional:
-[[ -n ${ACCOUNT} ]] || ACCOUNT="no_account"
+[[ -n ${SRW_PROJECT} ]] || SRW_PROJECT="no_account"
 [[ -n ${BRANCH} ]] || BRANCH="develop"
 [[ -n ${TASKS} ]] || TASKS=""
 [[ -n ${TASK_DEPTH} ]] || TASK_DEPTH=9
@@ -58,8 +58,8 @@ pwd
 echo "BRANCH=${BRANCH}"
 
 # Set the ACCOUNT to use for this PLATFORM ...
-sed "s|^  ACCOUNT: \"\"|  ACCOUNT: \"${ACCOUNT}\"|1" -i ush/config_defaults.yaml
-sed "s|hera|${platform,,}|1" ush/config.community.yaml | sed "s|an_account|${ACCOUNT}|1" > ush/config.yaml
+sed "s|^  ACCOUNT: \"\"|  ACCOUNT: \"${SRW_PROJECT}\"|1" -i ush/config_defaults.yaml
+sed "s|hera|${platform,,}|1" ush/config.community.yaml | sed "s|an_account|${SRW_PROJECT}|1" > ush/config.yaml
 
 # Set directory paths ...
 export EXPTDIR=${workspace}/expt_dirs/test_community

--- a/.cicd/scripts/wrapper_srw_ftest.sh
+++ b/.cicd/scripts/wrapper_srw_ftest.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+############################
+#
+# This is a wrapper script for the srw_ftest.sh script. It was created so we can 
+# test all of the wrapper script tasks within the Jenkins pipeline. It determines which 
+# workflow manager is installed on the platform and calls the apprioprate job card:
+#    sbatch: sbatch_srw_ftest.sh
+#    pbs: qsub_srw_ftest.sh
+###########################
+
+# Set workflow cmd
+declare workflow_cmd
+if [[ "${SRW_PLATFORM}" == cheyenne ]] || [[ "${SRW_PLATFORM}" == derecho ]]; then
+  workflow_cmd=qsub  
+else
+  workflow_cmd=sbatch
+fi
+
+# Call job card
+echo "Running: ${workflow_cmd} -A ${SRW_PROJECT} ${WORKSPACE}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh"
+${workflow_cmd} -A ${SRW_PROJECT} ${WORKSPACE}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh

--- a/.cicd/scripts/wrapper_srw_ftest.sh
+++ b/.cicd/scripts/wrapper_srw_ftest.sh
@@ -17,6 +17,12 @@ else
   workflow_cmd=sbatch
 fi
 
+# Customize wrapper scripts
+if [[ "${SRW_PLATFORM}" == gaea ]]; then
+  sed -i '15i #SBATCH --clusters=c4' ${WORKSPACE}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh
+  sed -i 's|qos=batch|qos=windfall|g' ${WORKSPACE}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh
+fi
+
 # Call job card
 echo "Running: ${workflow_cmd} -A ${SRW_PROJECT} ${WORKSPACE}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh"
 ${workflow_cmd} -A ${SRW_PROJECT} ${WORKSPACE}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh

--- a/docs/UsersGuide/source/RunSRW.rst
+++ b/docs/UsersGuide/source/RunSRW.rst
@@ -1173,14 +1173,6 @@ The regional workflow can be run using standalone shell scripts in cases where t
       export EXPTDIR=`pwd`
       setenv EXPTDIR `pwd`
 
-#. Set the ``PDY`` and ``cyc`` environment variables. ``PDY`` refers to the first 8 characters (YYYYMMDD) of the ``DATE_FIRST_CYCL`` variable defined in the ``config.yaml``. ``cyc`` refers to the last two digits of ``DATE_FIRST_CYCL`` (HH) defined in ``config.yaml``. For example, if the ``config.yaml`` file defines ``DATE_FIRST_CYCL: '2019061518'``, the user should run:
-
-   .. code-block:: console 
-      
-      export PDY=20190615 && export cyc=18 
-   
-   before running the wrapper scripts.
-
 #. Copy the wrapper scripts from the ``ush`` directory into the experiment directory. Each workflow task has a wrapper script that sets environment variables and runs the job script.
 
    .. code-block:: console

--- a/ush/wrappers/run_fcst.sh
+++ b/ush/wrappers/run_fcst.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
-set -x
+set -xa
 source ${GLOBAL_VAR_DEFNS_FP}
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}
+export cyc=${DATE_FIRST_CYCL:8:2}
+export PDY=${DATE_FIRST_CYCL:0:8}
 export SLASH_ENSMEM_SUBDIR=""
 export ENSMEM_INDX=""
 

--- a/ush/wrappers/run_get_ics.sh
+++ b/ush/wrappers/run_get_ics.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
-set -x
+set -xa
 source ${GLOBAL_VAR_DEFNS_FP}
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}
+export cyc=${DATE_FIRST_CYCL:8:2}
+export PDY=${DATE_FIRST_CYCL:0:8}
 
 # get the ICS files
 export ICS_OR_LBCS="ICS"

--- a/ush/wrappers/run_get_lbcs.sh
+++ b/ush/wrappers/run_get_lbcs.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
-set -x
+set -xa
 source ${GLOBAL_VAR_DEFNS_FP}
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}
+export cyc=${DATE_FIRST_CYCL:8:2}
+export PDY=${DATE_FIRST_CYCL:0:8}
 
 # get the LBCS files
 export ICS_OR_LBCS="LBCS"

--- a/ush/wrappers/run_make_grid.sh
+++ b/ush/wrappers/run_make_grid.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
-set -x
+set -xaa
 source ${GLOBAL_VAR_DEFNS_FP}
 
 export CDATE=${DATE_FIRST_CYCL}

--- a/ush/wrappers/run_make_grid.sh
+++ b/ush/wrappers/run_make_grid.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
-set -xaa
+set -xa
 source ${GLOBAL_VAR_DEFNS_FP}
 
 export CDATE=${DATE_FIRST_CYCL}

--- a/ush/wrappers/run_make_ics.sh
+++ b/ush/wrappers/run_make_ics.sh
@@ -1,10 +1,13 @@
 #!/bin/sh
 export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
-set -x
+set -xa
 source ${GLOBAL_VAR_DEFNS_FP}
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}
+export cyc=${DATE_FIRST_CYCL:8:2}
+export PDY=${DATE_FIRST_CYCL:0:8}
 export SLASH_ENSMEM_SUBDIR=""
+export NWGES_DIR=${NWGES_BASEDIR}/${DATE_FIRST_CYCL:0:8}
 
 ${JOBSdir}/JREGIONAL_MAKE_ICS
 

--- a/ush/wrappers/run_make_lbcs.sh
+++ b/ush/wrappers/run_make_lbcs.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
-set -x
+set -xa
 source ${GLOBAL_VAR_DEFNS_FP}
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}
+export cyc=${DATE_FIRST_CYCL:8:2}
+export PDY=${DATE_FIRST_CYCL:0:8}
 export SLASH_ENSMEM_SUBDIR=""
-
+export NWGES_DIR=${NWGES_BASEDIR}/${DATE_FIRST_CYCL:0:8}
+export bcgrp="00"
+export bcgrpnum="1"
 ${JOBSdir}/JREGIONAL_MAKE_LBCS
 

--- a/ush/wrappers/run_make_orog.sh
+++ b/ush/wrappers/run_make_orog.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
-set -x
+set -xa
 source ${GLOBAL_VAR_DEFNS_FP}
 
 export CDATE=${DATE_FIRST_CYCL}

--- a/ush/wrappers/run_make_sfc_climo.sh
+++ b/ush/wrappers/run_make_sfc_climo.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
-set -x
+set -xa
 source ${GLOBAL_VAR_DEFNS_FP}
 
 export CDATE=${DATE_FIRST_CYCL}

--- a/ush/wrappers/run_post.sh
+++ b/ush/wrappers/run_post.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
-set -x
+set -xa
 source ${GLOBAL_VAR_DEFNS_FP}
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}
 export cyc=${DATE_FIRST_CYCL:8:2}
+export PDY=${DATE_FIRST_CYCL:0:8}
 export SLASH_ENSMEM_SUBDIR=""
 export ENSMEM_INDX=""
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The wrapper scripts are a set of scripts that run the tasks from a SRW experiment. They are used in a situation where rocoto is not installed or available to use. These set of wrapper scripts have become outdated and don't work in its current state. This PR was created to address this issue.

These are the steps I used to test the wrapper scripts:
- Copy the config.default.yaml to config.yaml. Update the machine and account variables and add the changes noted by (**) below:
```
task_get_extrn_ics:
  EXTRN_MDL_NAME_ICS: FV3GFS
  FV3GFS_FILE_FMT_ICS: grib2
  **USE_USER_STAGED_EXTRN_FILES: true
  **EXTRN_MDL_SOURCE_BASEDIR_ICS: /path/to/UFS_SRW_data/develop/input_model_data/FV3GFS/grib2/2019061518
task_get_extrn_lbcs:
  EXTRN_MDL_NAME_LBCS: FV3GFS
  LBC_SPEC_INTVL_HRS: 6
  FV3GFS_FILE_FMT_LBCS: grib2
  **USE_USER_STAGED_EXTRN_FILES: true
  **EXTRN_MDL_SOURCE_BASEDIR_LBCS: /path/to/UFS_SRW_data/develop/input_model_data/FV3GFS/grib2/2019061518
```

- Create the experiment by running the generate script
- salloc or qsub a compute node
- cd into the experiment and run: `export EXPTDIR=$PWD`
-  On Cheyenne, Gaea, and NOAA cloud export nprocs. Take the nprocs value for the run_fcst task which can be found in the `FV3LAM_wflow.xml` in the experiment directory. For the cloud, this is the command that was used: `export nprocs=24`
- module use /path/to/ufs-srweather-app/modulefiles
- module load build and wflow files
- run `conda activate workflow_tools` (note on Hera python wasn't setup properly so I had to run `conda deactivate` and rerun the activate command)
- Run scripts by hand:
    run_make_grid
    run_get_ics
    run_get_lbcs
    run_make_orog
    run_make_sfc_climo
    run_make_ics 
    run_make_lbcs
    run_fcst 
    run_post


### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [x] hera.intel path to expt dir: /scratch1/NCEPDEV/nems/Edward.Snyder/wrapper-test/expt_dirs/test_community
- [x] orion.intel path to expt dir: /work/noaa/epic/esnyder/wrapper-test/expt_dirs/test_community
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [x] NOAA Cloud (indicate which platform) (gcp) path to expt dir: /contrib/Edward.Snyder/wrapper-test/expt_dirs/test_community
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

Ran the ci/cd script on Hera and all the NOAA Cloud platforms.

## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
None.

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->
Removed a step from the wrapper script workflow documentation as these variables are included in the wrapper scripts now.

## ISSUE: 
This PR address issue #878.

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

