### PR TITLE
[develop] Fix overwriting user-defined WRTCMP* values.

### DIFF
--- a/ush/setup.py
+++ b/ush/setup.py
@@ -742,7 +742,8 @@ def setup(USHdir, user_config_fn="config.yaml", debug: bool = False):
                 else:
                     fcst_config[param] = value
             elif param.startswith("WRTCMP"):
-                fcst_config[param] = value
+                if fcst_config.get(param) == "":
+                    fcst_config[param] = value
             elif param == "GRID_GEN_METHOD":
                 workflow_config[param] = value
             else:


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more paragraphs describing the problem, solution, and required changes. -->

This change is needed so that when users provide their own WRTCMP* variables in config.yaml alongside a pre-defined domain, their changes do not get overwritten.

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [x] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [x] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)


EDIT: I didn't mention how I tested that this does what it is supposed to do.

I generated a test config.yaml through the WE2E run tests script and then edited the fully formed config.yaml in ush to add one of the WRTCMP* entries and confirm that it was indeed overwritten in the var_defns.sh file when I ran the ush generate workflow script.

The additional entry looked like this:
```
task_run_forecast:
  WRTCMP_stdlat2: nonsense
```

I did not follow that up to make sure that the entry propagated to other configuration files. I assumed that SRW internals know what to do with that value once it's "properly" set.


## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
- ufs-community/regional_workflow/pull/<pr_number>
- ufs-community/UFS_UTILS/pull/<pr_number>
- ufs-community/ufs-weather-model/pull/<pr_number> -->

n/a

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->

n/a

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here (Remember, issues must always be created before starting work on a PR branch!). For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/ufs-community/other_repository/pull/63" -->

This is related to a problem @natalie-perlin was reporting in this week's meeting. I didn't see an obvious Issue related to the problem, though.

## CHECKLIST
<!-- Add an X to check off a box. -->
- [ ] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

