### PR TITLE
[develop] Fix crontab bug for Cheyenne and Derecho, update PR template for new platforms

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -32,9 +32,12 @@
 
 - [ ] hera.intel
 - [ ] orion.intel
+- [ ] hercules.intel
 - [ ] cheyenne.intel
 - [ ] cheyenne.gnu
+- [ ] derecho.intel
 - [ ] gaea.intel
+- [ ] gaeac5.intel
 - [ ] jet.intel
 - [ ] wcoss2.intel
 - [ ] NOAA Cloud (indicate which platform)

--- a/ush/get_crontab_contents.py
+++ b/ush/get_crontab_contents.py
@@ -35,11 +35,10 @@ def get_crontab_contents(called_from_cron, machine, debug):
     # themselves being called as cron jobs.  In that case, we must instead
     # call the system version of crontab at /usr/bin/crontab.
     #
+    crontab_cmd = "crontab"
     if machine == "CHEYENNE" or machine == "DERECHO":
         if called_from_cron:
             crontab_cmd = "/usr/bin/crontab"
-    else:
-        crontab_cmd = "crontab"
 
     print_info_msg(
         f"""


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The option to create an experiment with the option `USE_CRON_TO_RELAUNCH=True` is currently broken on Cheyenne and Derecho due to some bad python logic. This PR fixes that issue.

I also took the opportunity to update the PR template to include the new supported platforms (Derecho, Hercules, and Gaea C5)

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
Ran WE2E fundamental tests with the option `--launch=cron` on three platforms. Previously failing on Cheyenne an Derecho, these tasks all succeed except for the `grid_RRFS_CONUS_25km_ics_NAM_lbcs_NAM_suite_GFS_v16` test on Cheyenne: this is a pre-existing failure (see Issue #933)

- [x] hera.intel
- [x] cheyenne.intel
- [x] derecho.intel

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE: 
Fixes #932 

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

