### PR TITLE
[develop] Add Sonarqube stage to the Jenkinsfile for PLATFORM-926

### DIFF
--- a/.cicd/Jenkinsfile
+++ b/.cicd/Jenkinsfile
@@ -22,6 +22,17 @@ pipeline {
     }
 
     stages {
+        stage('Launch SonarQube') {
+            steps {
+                script {
+                    build job: '/ufs-srweather-app/ufs-srw-sonarqube', parameters: [
+                        string(name: 'BRANCH_NAME', value: env.CHANGE_BRANCH ?: 'develop'),
+                        string(name: 'FORK_NAME', value: env.CHANGE_FORK ?: '')
+                    ], wait: false
+                }
+            }
+        }
+
         // Uncomment the following block to re-enable PW clusters
         /*
         // Start the NOAA Parallel Works clusters, if necessary

--- a/.cicd/scripts/wrapper_srw_ftest.sh
+++ b/.cicd/scripts/wrapper_srw_ftest.sh
@@ -33,6 +33,12 @@ if [[ "${SRW_PLATFORM}" == gaea-c5 ]]; then
     sed -i 's|qos=batch|qos=normal|g' ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh
 fi
 
+if [[ "${SRW_PLATFORM}" == hera ]]; then
+    if [[ "${SRW_COMPILER}" == gnu ]]; then
+        sed -i 's|00:30:00|00:45:00|g' ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh
+    fi
+fi
+
 # Call job card and return job_id
 echo "Running: ${workflow_cmd} -A ${SRW_PROJECT} ${arg_1} ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh"
 job_id=$(${workflow_cmd} -A ${SRW_PROJECT} ${arg_1} ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh)


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The EPIC Platform team is tasked with adding a `Sonarqube` gate to the SRW App's Jenkins pipeline.  @ankimball has added the `Sonarqube` pipeline into Jenkins, and requested that the `Sonarqube` stage be added to the `Jenkinsfile` in the SRW App's GitHub repository.  This work is adding the `Sonarqube` stage to the `.cicd/Jenkinsfile`.

Additionally, a fix has been made to allow the `Functional Workflow Task Tests` stage to successfully run on Hera GNU (30 minute wall time isn't enough for the the community test to finish using GNU compiled executables).

### Type of change
- [x] New feature (non-breaking change which adds functionality)

## TESTS CONDUCTED: 
This is an update to the Jenkinsfile only.  There is no need to test this on any platform except for Jenkins.
- [x] Jenkins

## DEPENDENCIES:

None

## DOCUMENTATION:

None

## ISSUE:

[PLATFORM-926](https://jira.epic.oarcloud.noaa.gov/browse/PLATFORM-926)

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] My changes do not require updates to the documentation (explain).
This is an update to the Jenkinsfile only.  No documentation changes are required.
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes

## CONTRIBUTORS (optional): 
@ankimball for providing the Sonarqube stage modifications.