### PR TITLE
[release/public-v2.2.0] spack-stack 1.4.1 integration for Gaea C5 platform

### DIFF
--- a/modulefiles/build_gaea-c5_intel.lua
+++ b/modulefiles/build_gaea-c5_intel.lua
@@ -5,18 +5,17 @@ the NOAA RDHPC machine Gaea C5 using Intel-2023.1.0
 
 whatis([===[Loads libraries needed for building the UFS SRW App on Gaea C5 ]===])
 
-load(pathJoin("cmake", os.getenv("cmake_ver") or "3.23.1"))
+prepend_path("MODULEPATH", "/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.4.1/envs/unified-env-intel-2023.1.0/install/modulefiles/Core")
 
-prepend_path("MODULEPATH","/lustre/f2/dev/role.epic/contrib/C5/hpc-stack/intel-classic-2023.1.0/modulefiles/stack")
-load(pathJoin("hpc", os.getenv("hpc_ver") or "1.2.0"))
-load(pathJoin("intel-classic", os.getenv("intel_classic_ver") or "2023.1.0"))
-load(pathJoin("cray-mpich", os.getenv("cray_mpich_ver") or "8.1.25"))
-load(pathJoin("hpc-intel-classic", os.getenv("hpc_intel_classic_ver") or "2023.1.0"))
-load(pathJoin("hpc-cray-mpich", os.getenv("hpc_cray_mpich_ver") or "8.1.25"))
+load("PrgEnv-intel/8.3.3")
+load("stack-intel/2023.1.0")
+load("stack-cray-mpich/8.1.25")
+load("cmake/3.23.1")
 
 load("srw_common")
 
 unload("darshan-runtime/3.4.0")
+unload("cray-pmi/6.1.10")
 setenv("CFLAGS","-diag-disable=10441")
 setenv("FFLAGS","-diag-disable=10441")
 
@@ -27,4 +26,3 @@ setenv("CMAKE_C_COMPILER","cc")
 setenv("CMAKE_Fortran_COMPILER","ftn")
 setenv("CMAKE_CXX_COMPILER","CC")
 setenv("CMAKE_Platform","gaea-c5.intel")
-

--- a/modulefiles/tasks/gaea-c5/python_srw.lua
+++ b/modulefiles/tasks/gaea-c5/python_srw.lua
@@ -3,3 +3,5 @@ prepend_path("MODULEPATH","/lustre/f2/dev/role.epic/contrib/C5/miniconda3/module
 load(pathJoin("miniconda3", os.getenv("miniconda3_ver") or "4.12.0"))
 
 setenv("SRW_ENV", "workflow_tools")
+
+load("darshan-runtime/3.4.0")

--- a/modulefiles/tasks/gaea-c5/run_vx.local.lua
+++ b/modulefiles/tasks/gaea-c5/run_vx.local.lua
@@ -1,6 +1,25 @@
 --[[
 Compiler-specific modules are used for met and metplus libraries
 --]]
-load(pathJoin("met", os.getenv("met_ver") or "10.1.2"))
-load(pathJoin("metplus", os.getenv("metplus_ver") or "4.1.3"))
+local met_ver = (os.getenv("met_ver") or "10.1.1")
+local metplus_ver = (os.getenv("metplus_ver") or "4.1.1")
+if (mode() == "load") then
+  load(pathJoin("met", met_ver))
+  load(pathJoin("metplus",metplus_ver))
+end
+local base_met = os.getenv("met_ROOT") or os.getenv("MET_ROOT")
+local base_metplus = os.getenv("metplus_ROOT") or os.getenv("METPLUS_ROOT")
+
+setenv("MET_INSTALL_DIR", base_met)
+setenv("MET_BIN_EXEC",    pathJoin(base_met,"bin"))
+setenv("MET_BASE",        pathJoin(base_met,"share/met"))
+setenv("MET_VERSION",     met_ver)
+setenv("METPLUS_VERSION", metplus_ver)
+setenv("METPLUS_ROOT",    base_metplus)
+setenv("METPLUS_PATH",    base_metplus)
+
+if (mode() == "unload") then
+  unload(pathJoin("met", met_ver))
+  unload(pathJoin("metplus",metplus_ver))
+end
 load("python_srw")

--- a/modulefiles/wflow_gaea-c5.lua
+++ b/modulefiles/wflow_gaea-c5.lua
@@ -12,8 +12,6 @@ load(pathJoin("miniconda3", os.getenv("miniconda3_ver") or "4.12.0"))
 prepend_path("MODULEPATH","/lustre/f2/dev/role.epic/contrib/C5/rocoto/modulefiles")
 load("rocoto")
 
-pushenv("MKLROOT", "/opt/intel/oneapi/mkl/2023.1.0/")
-
 if mode() == "load" then
    LmodMsgRaw([===[Please do the following to activate conda:
        > conda activate workflow_tools


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
 Integrate spack-stack/1.4.1 modules into Gaea C5 platform. 
Spack-stack is based on intel-classic/2023.1.0 compiler and cray-mpich/8.1.25; stack environment built is
/lustre/f2/dev/wpo/role.epic/contrib/spack-stack/c5/spack-stack-1.4.1/envs/unified-env-intel-2023.1.0/

Fundamental tests pass completely:
```
All 7 experiments finished
Calculating core-hour usage and printing final summary
----------------------------------------------------------------------------------------------------
Experiment name                                                  | Status    | Core hours used 
----------------------------------------------------------------------------------------------------
grid_RRFS_CONUScompact_25km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta    COMPLETE              20.13
nco_grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_timeoffset_suite_  COMPLETE              26.52
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2        COMPLETE              13.59
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v17_p8_plot  COMPLETE              28.23
grid_RRFS_CONUScompact_25km_ics_HRRR_lbcs_HRRR_suite_HRRR          COMPLETE              35.30
grid_SUBCONUS_Ind_3km_ics_HRRR_lbcs_RAP_suite_WoFS_v0              COMPLETE              33.77
grid_RRFS_CONUS_25km_ics_NAM_lbcs_NAM_suite_GFS_v16                COMPLETE              50.15
----------------------------------------------------------------------------------------------------
Total                                                              COMPLETE             207.69
```

A detailed summary of log WE2E_summary_20231012211458.txt is attached. 
In comprehensive tests suite, some of the failures do occur, in tasks such as `get_obs_<xxxx>`, `get_extrn_ics`, `get_extrn_lbcs`; comprehensive tests are still running.

Files changed:
modulefiles/build_gaea-c5_intel.lua   (unload modules darshan-runtime, cray-pmi)
modulefiles/wflow_gaea-c5.lua
modulefiles/tasks/gaea-c5/python_srw.lua (loads module  darshan-runtime)
modulefiles/tasks/gaea-c5/run_vx.local.lua

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 

<!-- Add an X to check off a box. -->

- [ ] hera.intel
- [ ] orion.intel
- [ ] hercules.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] derecho.intel
- [ ] gaea.intel
- [x] gaeac5.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [x] fundamental test suite
- [x] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->

## ISSUE: 
Resolves the issue 

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [ ] bug
- [x] enhancement
- [ ] documentation
- [x] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 

@RatkoVasic-NOAA 

[WE2E_summary_20231012211458.txt](https://github.com/ufs-community/ufs-srweather-app/files/12889544/WE2E_summary_20231012211458.txt)