### PR TITLE
[develop] Add -n 1 to allow the use of the service partition

### DIFF
--- a/parm/wflow/aqm_prep.yaml
+++ b/parm/wflow/aqm_prep.yaml
@@ -23,6 +23,7 @@ default_aqm_task: &default_aqm
 task_nexus_gfs_sfc:
   <<: *default_aqm
   command: '&LOAD_MODULES_RUN_TASK_FP; "nexus_gfs_sfc" "&JOBSdir;/JREGIONAL_NEXUS_GFS_SFC"'
+  native: '{% if platform.get("SCHED_NATIVE_CMD_HPSS") %}{{ platform.SCHED_NATIVE_CMD_HPSS }}{% else %}{{ platform.SCHED_NATIVE_CMD}}{% endif %}'
   partition: '{% if platform.get("PARTITION_HPSS") %}&PARTITION_HPSS;{% else %}None{% endif %}'
   join: !cycstr '&LOGDIR;/{{ jobname }}_@Y@m@d@H&LOGEXT;'
   memory: 2G

--- a/parm/wflow/verify_pre.yaml
+++ b/parm/wflow/verify_pre.yaml
@@ -30,6 +30,7 @@ task_get_obs_ccpa:
     OBS_DIR: '&CCPA_OBS_DIR;'
     OBTYPE: 'CCPA'
     FHR: '{% for h in range(0, workflow.FCST_LEN_HRS+1) %}{{ " %02d" % h  }}{% endfor %}'
+  native: '{% if platform.get("SCHED_NATIVE_CMD_HPSS") %}{{ platform.SCHED_NATIVE_CMD_HPSS }}{% else %}{{ platform.SCHED_NATIVE_CMD}}{% endif %}'
   partition: '{% if platform.get("PARTITION_HPSS") %}&PARTITION_HPSS;{% else %}None{% endif %}'
   queue: "&QUEUE_HPSS;"
   walltime: 00:45:00
@@ -42,6 +43,7 @@ task_get_obs_nohrsc:
     OBS_DIR: '&NOHRSC_OBS_DIR;'
     OBTYPE: 'NOHRSC'
     FHR: '{% for h in range(0, workflow.FCST_LEN_HRS+1) %}{{ " %02d" % h  }}{% endfor %}'
+  native: '{% if platform.get("SCHED_NATIVE_CMD_HPSS") %}{{ platform.SCHED_NATIVE_CMD_HPSS }}{% else %}{{ platform.SCHED_NATIVE_CMD}}{% endif %}'
   partition: '{% if platform.get("PARTITION_HPSS") %}&PARTITION_HPSS;{% else %}None{% endif %}'
   queue: "&QUEUE_HPSS;"
   walltime: 00:45:00
@@ -55,6 +57,7 @@ task_get_obs_mrms:
     OBTYPE: 'MRMS'
     VAR: 'REFC RETOP'
     FHR: '{% for h in range(0, workflow.FCST_LEN_HRS+1) %}{{ " %02d" % h  }}{% endfor %}'
+  native: '{% if platform.get("SCHED_NATIVE_CMD_HPSS") %}{{ platform.SCHED_NATIVE_CMD_HPSS }}{% else %}{{ platform.SCHED_NATIVE_CMD}}{% endif %}'
   partition: '{% if platform.get("PARTITION_HPSS") %}&PARTITION_HPSS;{% else %}None{% endif %}'
   queue: "&QUEUE_HPSS;"
   walltime: 00:45:00
@@ -68,6 +71,7 @@ task_get_obs_ndas:
     FHR: '{% for h in range(0, workflow.FCST_LEN_HRS+1) %}{{ " %02d" % h  }}{% endfor %}'
   command: '&LOAD_MODULES_RUN_TASK_FP; "get_obs" "&JOBSdir;/JREGIONAL_GET_VERIF_OBS"'
   queue: "&QUEUE_HPSS;"
+  native: '{% if platform.get("SCHED_NATIVE_CMD_HPSS") %}{{ platform.SCHED_NATIVE_CMD_HPSS }}{% else %}{{ platform.SCHED_NATIVE_CMD}}{% endif %}'
   partition: '{% if platform.get("PARTITION_HPSS") %}&PARTITION_HPSS;{% else %}None{% endif %}'
   walltime: 02:00:00
 

--- a/ush/machine/hera.yaml
+++ b/ush/machine/hera.yaml
@@ -21,6 +21,7 @@ platform:
   RUN_CMD_NEXUS: srun -n ${nprocs} --export=ALL
   RUN_CMD_AQMLBC: srun --export=ALL -n ${NUMTS}
   SCHED_NATIVE_CMD: --export=NONE
+  SCHED_NATIVE_CMD_HPSS: -n 1 --export=NONE
   PRE_TASK_CMDS: '{ ulimit -s unlimited; ulimit -a; }'
   TEST_EXTRN_MDL_SOURCE_BASEDIR: /scratch1/NCEPDEV/nems/role.epic/UFS_SRW_data/develop/input_model_data
   TEST_AQM_INPUT_BASEDIR: /scratch1/NCEPDEV/nems/role.epic/UFS_SRW_data/develop/aqm_data

--- a/ush/machine/jet.yaml
+++ b/ush/machine/jet.yaml
@@ -19,6 +19,7 @@ platform:
   RUN_CMD_SERIAL: time
   RUN_CMD_UTILS: srun --export=ALL
   SCHED_NATIVE_CMD: --export=NONE
+  SCHED_NATIVE_CMD_HPSS: -n 1 --export=NONE
   PRE_TASK_CMDS: '{ ulimit -s unlimited; ulimit -a; }'
   TEST_EXTRN_MDL_SOURCE_BASEDIR: /mnt/lfs4/HFIP/hfv3gfs/role.epic/UFS_SRW_data/develop/input_model_data
   TEST_PREGEN_BASEDIR: /mnt/lfs4/HFIP/hfv3gfs/role.epic/UFS_SRW_data/develop/FV3LAM_pregen


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Following the Slurm update on Hera and Jet, the `service` partition is no longer usable within the SRW App.  This PR will make the necessary changes to allow the `service` partition to once again function properly, by adding `-n 1` to the `SCHED_NATIVE_CMD_HPSS` variable in the Hera and Jet machine yaml files, and updating the `native` entry in the `parm/wflow/verify_pre.yaml` file's `get_*` tasks.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
- [X] hera.intel
- [X] jet.intel
- [X] fundamental test suite

## ISSUE: 
Fixes #1011

## CHECKLIST
- [X] My code follows the style guidelines in the Contributor's Guide
- [X] I have performed a self-review of my own code using the Code Reviewer's Guide
- [X] My changes do not require updates to the documentation (explain).
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes