### PR TITLE
[production/AQM.v7] Update CODEOWNERS to reflect maintainer for production/AQM.v7 branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in the repo.
 #*       @defunkt
-*       @chan-hoo @RatkoVasic-NOAA @BenjaminBlake-NOAA
+*       @BrianCurtis-NOAA
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners


### PR DESCRIPTION
Remove develop branch CODEOWNERS for @BrianCurtis-NOAA as maintainer for only production/AQM.v7 branch