### PR TITLE
[SRW-AQM] Updated spack-stack location for Hera Rocky8 and removed yafyaml.

### DIFF
--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -5,7 +5,7 @@ the NOAA RDHPC machine Hera using Intel-2022.1.2
 
 whatis([===[Loads libraries needed for building the SRW workflow on Hera ]===])
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-rocky8/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/scratch1/NCEPDEV/jcsda/jedipara/spack-stack/modulefiles")
 
 load(pathJoin("stack-intel", "2021.5.0"))
@@ -39,7 +39,6 @@ load(pathJoin("g2tmpl", "1.10.2"))
 load(pathJoin("ip", "4.3.0"))
 load(pathJoin("sp", "2.3.3"))
 load(pathJoin("gftl-shared", "1.5.0"))
-load(pathJoin("yafyaml", "0.5.1"))
 load(pathJoin("bufr", "12.0.0"))
 load(pathJoin("gfsio", "1.4.1"))
 load(pathJoin("landsfcutil", "2.4.1"))


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updated spack-stack location for Hera Rocky8 and removed yafyaml.

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
Build aqm_dev successfully on Hera with Rocky8.

<!-- Add an X to check off a box. -->

- [X ] hera.intel
- [ ] orion.intel
- [ ] hercules.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] derecho.intel
- [ ] gaea.intel
- [ ] gaeac5.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
- ufs-community/regional_workflow/pull/<pr_number>
- ufs-community/UFS_UTILS/pull/<pr_number>
- ufs-community/ufs-weather-model/pull/<pr_number> -->

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->

## ISSUE: 
#1057 

## LABELS (optional): 
- [ ] Work In Progress
- [ X] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted


