### PR TITLE
[develop] Bug fix to support the %H format in METplus via printf.

### DIFF
--- a/ush/bash_utils/eval_METplus_timestr_tmpl.sh
+++ b/ush/bash_utils/eval_METplus_timestr_tmpl.sh
@@ -167,7 +167,18 @@ cannot be empty:
       fmt="${METplus_time_fmt}"
       ;;
     "%H")
-      fmt="%02.0f"
+#
+# The "%H" format needs to be treated differently depending on if it's
+# formatting a "lead" time type or another (e.g. "init" or "vald") because
+# for "lead", the printf function is used below (which doesn't understand
+# the "%H" format) whereas for the others, the date utility is used (which
+# does understand "%H").
+#
+      if [ "${METplus_time_type}" = "lead" ]; then
+        fmt="%02.0f"
+      else
+        fmt="${METplus_time_fmt}"
+      fi
       ;;
     "%HHH")
 #

--- a/ush/bash_utils/eval_METplus_timestr_tmpl.sh
+++ b/ush/bash_utils/eval_METplus_timestr_tmpl.sh
@@ -163,8 +163,11 @@ cannot be empty:
 #-----------------------------------------------------------------------
 #
   case "${METplus_time_fmt}" in
-    "%Y%m%d%H"|"%Y%m%d"|"%H%M%S"|"%H")
+    "%Y%m%d%H"|"%Y%m%d"|"%H%M%S")
       fmt="${METplus_time_fmt}"
+      ;;
+    "%H")
+      fmt="%02.0f"
       ;;
     "%HHH")
 #


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more paragraphs describing the problem, solution, and required changes. -->
This bug was encountered when verifying forecast output that has a 2-digit forecast hour in its name.  It turns out specifying the METplus format `%H` to obtain a 2-digit forecast hour in the workflow/verification configuration variable `FCST_FN_TEMPLATE` (and others) causes an error in the shell script `eval_METplus_timestr_tmpl.sh` because bash's `printf` utility does not support the `%H` format.  This fixes that error using a similar approach to the `%HHH` format for obtaining 3-digit hours.

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [x] hera.intel
- [ ] orion.intel
- [ ] hercules.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] derecho.intel
- [ ] gaea.intel
- [ ] gaeac5.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

The full set of WE2E tests involving vx were run on Hera.  These are:
```
MET_ensemble_verification
MET_ensemble_verification_only_vx
MET_ensemble_verification_only_vx_time_lag
MET_ensemble_verification_winter_wx
MET_verification
MET_verification_only_vx
MET_verification_winter_wx
```
All passed.

## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
None

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->
None needed.

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
@willmayfield and @michelleharrold encountered this bug, and @mkavulich pinpointed the script it was originating from.
