### PR TITLE
[develop] Fix `get_crontab_contents.py`

### DIFF
--- a/ush/get_crontab_contents.py
+++ b/ush/get_crontab_contents.py
@@ -224,7 +224,7 @@ def _parse_args(argv):
     )
 
     # Check that inputs are correct and consistent
-    args = parser._parse_args(argv)
+    args = parser.parse_args(argv)
 
     if args.remove:
         if args.line is None:


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Fix bug described in issue #1141: `get_crontab_contents.py` fails when run as a script

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
- [ ] derecho.intel
- [ ] gaea.intel
- [ ] hera.gnu
- [ ] hera.intel
- [ ] hercules.intel
- [x] jet.intel
  - Ran fundamental tests
  - Ran `get_crontab_contents.py` stand-alone before and after to confirm the fix.
- [ ] orion.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE: 
Fixes #1141

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

