### PR TITLE
[main_aqm] Added emissions option for persistence and fixed interpolation artifacts

### DIFF
--- a/parm/config.smoke_dust.yaml
+++ b/parm/config.smoke_dust.yaml
@@ -71,5 +71,6 @@ global:
 smoke_dust_parm:
   DO_SMOKE_DUST: true
   EBB_DCYCLE: 1
+  PERSISTENCE: true
   SMOKE_DUST_FILE_PREFIX: SMOKE_RRFS_data
 

--- a/parm/config_defaults.yaml
+++ b/parm/config_defaults.yaml
@@ -2540,6 +2540,9 @@ smoke_dust_parm:
   # EBB_DCYCLE:
   # 1: for retro, 2: for forecast
   #
+  # PERSISTENCE:
+  # Flag turning on/off emissions persistence method, if off same day FRP is used
+  #
   # COMINsmoke_default:
   # Path to the directory containing smoke and dust files
   #
@@ -2553,6 +2556,7 @@ smoke_dust_parm:
   #
   DO_SMOKE_DUST: false
   EBB_DCYCLE: 1
+  PERSISTENCE: True 
   COMINsmoke_default: ""
   COMINrave_default: ""
   SMOKE_DUST_FILE_PREFIX: "SMOKE_RRFS_data"

--- a/scripts/exsrw_smoke_dust.sh
+++ b/scripts/exsrw_smoke_dust.sh
@@ -116,7 +116,8 @@ else
     "${DATA_SHARE}" \
     "${PREDEF_GRID_NAME}" \
     "${EBB_DCYCLE}" \
-    "${RESTART_INTERVAL}"
+    "${RESTART_INTERVAL}"\
+    "${PERSISTENCE}" \
   export err=$?
   if [ $err -ne 0 ]; then
     message_txt="generate_fire_emissions.py failed with return code $err"

--- a/ush/generate_fire_emissions.py
+++ b/ush/generate_fire_emissions.py
@@ -19,7 +19,7 @@ import interp_tools as i_tools
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Workflow
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-def generate_emiss_workflow(staticdir, ravedir, intp_dir, predef_grid, ebb_dcycle, restart_interval):
+def generate_emiss_workflow(staticdir, ravedir, intp_dir, predef_grid, ebb_dcycle, restart_interval, persistence):
    
    # staticdir: path to FIX files
    # ravedir: path to RAVE fire data files (hourly), typically workding directory (DATA)
@@ -40,7 +40,7 @@ def generate_emiss_workflow(staticdir, ravedir, intp_dir, predef_grid, ebb_dcycl
    vars_emis = ["FRP_MEAN","FRE"]
    cols, rows = (2700, 3950) if predef_grid == 'RRFS_NA_3km' else (1092, 1820) 
    print('PREDEF GRID',predef_grid,'cols,rows',cols,rows)
-   print('WARNING, EBB_DCYCLE set to', ebb_dcycle, 'emissions are comes from same day satellite obs')   
+   print('WARNING, EBB_DCYCLE set to', ebb_dcycle, 'and persistence=', persistence, 'if persistence is false, emissions comes from same day satellite obs')   
    #used later when working with ebb_dcyle 1 or 2
    ebb_dcycle = float(ebb_dcycle)
 
@@ -68,7 +68,7 @@ def generate_emiss_workflow(staticdir, ravedir, intp_dir, predef_grid, ebb_dcycl
    # ----------------------------------------------------------------------
    # Sort raw RAVE, create source and target filelds, and compute emissions 
    # ----------------------------------------------------------------------
-   fcst_dates = i_tools.date_range(current_day, ebb_dcycle)
+   fcst_dates = i_tools.date_range(current_day, ebb_dcycle, persistence)
    intp_avail_hours, intp_non_avail_hours, inp_files_2use = i_tools.check_for_intp_rave(intp_dir, fcst_dates, rave_to_intp)
    rave_avail, rave_avail_hours, rave_nonavail_hours_test, first_day = i_tools.check_for_raw_rave(RAVE, intp_non_avail_hours, intp_avail_hours)
    srcfield, tgtfield, tgt_latt, tgt_lont, srcgrid, tgtgrid, src_latt, tgt_area = i_tools.creates_st_fields(grid_in, grid_out, intp_dir, rave_avail_hours) 
@@ -109,7 +109,7 @@ if __name__ == '__main__':
         print('Welcome to interpolating RAVE and processing fire emissions!')
         print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
         print('')
-        generate_emiss_workflow(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6])
+        generate_emiss_workflow(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6],sys.argv[7])
         print('')
         print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
         print('Successful Completion. Bye!')


### PR DESCRIPTION
Added emissions option for persistence and fixed interpolation artifacts
Updates made to the main_aqm branch

## DESCRIPTION OF CHANGES: 
Added an option to create smoke emissions using a persistence approach or same-day satellite detections. Added fix to interpolation artifacts on the domain edges (see below)
![interpol_fix](https://github.com/user-attachments/assets/02078100-3bf4-4298-9f67-31d775fdcd8a)

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## TESTS CONDUCTED: 
- [ ] derecho.intel
- [ ] gaea.intel
- [ ] hera.gnu
- [x] hera.intel
- [ ] hercules.intel
- [ ] jet.intel
- [ ] orion.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## CHECKLIST
<!-- Add an X to check off a box. -->
- [ ] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published


