### PR TITLE
[develop] Update UFS-WM hash to 11/14 version and UPP hash to 09/30 version.

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -12,7 +12,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 547be6d
+hash = 6b0f516
 local_path = sorc/ufs-weather-model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -12,7 +12,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 38a29a6
+hash = 547be6d
 local_path = sorc/ufs-weather-model
 required = True
 
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 81b38a8
+hash = 6f5dd62
 local_path = sorc/UPP
 required = True
 

--- a/modulefiles/build_derecho_intel.lua
+++ b/modulefiles/build_derecho_intel.lua
@@ -6,7 +6,7 @@ the CISL machine Derecho (Cray) using Intel@2021.10.0
 whatis([===[Loads libraries needed for building the UFS SRW App on Derecho ]===])
 
 prepend_path("MODULEPATH","/lustre/desc1/scratch/epicufsrt/contrib/modulefiles_extra")
-prepend_path("MODULEPATH", "/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.6.0/envs/fms-2024.01/install/modulefiles/Core")
 
 load(pathJoin("stack-intel", os.getenv("stack_intel_ver") or "2021.10.0"))
 load(pathJoin("stack-cray-mpich", os.getenv("stack_cray_mpich_ver") or "8.1.25"))

--- a/modulefiles/build_gaea_intel.lua
+++ b/modulefiles/build_gaea_intel.lua
@@ -5,7 +5,7 @@ the NOAA RDHPC machine Gaea C5 using Intel-2023.1.0
 
 whatis([===[Loads libraries needed for building the UFS SRW App on Gaea C5 ]===])
 
-prepend_path("MODULEPATH","/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH","/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/fms-2024.01/install/modulefiles/Core")
 stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
 load(pathJoin("stack-intel", stack_intel_ver))
 

--- a/modulefiles/build_hera_gnu.lua
+++ b/modulefiles/build_hera_gnu.lua
@@ -7,7 +7,7 @@ whatis([===[Loads libraries needed for building the UFS SRW App on Hera using GN
 
 prepend_path("MODULEPATH", "/scratch2/NCEPDEV/stmp1/role.epic/installs/gnu/modulefiles")
 prepend_path("MODULEPATH", "/scratch2/NCEPDEV/stmp1/role.epic/installs/openmpi/modulefiles")
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/stmp1/role.epic/spack-stack/spack-stack-1.6.0_gnu13/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/stmp1/role.epic/spack-stack/spack-stack-1.6.0_gnu13/envs/fms-2024.01/install/modulefiles/Core")
 
 load("stack-gcc/13.3.0")
 load("stack-openmpi/4.1.6")

--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -8,7 +8,7 @@ whatis([===[Loads libraries needed for building the UFS SRW App on Hera ]===])
 prepend_path("MODULEPATH","/contrib/sutils/modulefiles")
 load("sutils")
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/fms-2024.01/install/modulefiles/Core")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 load(pathJoin("stack-intel", stack_intel_ver))

--- a/modulefiles/build_hercules_intel.lua
+++ b/modulefiles/build_hercules_intel.lua
@@ -5,7 +5,7 @@ the MSU machine Hercules using intel-oneapi-compilers/2022.2.1
 
 whatis([===[Loads libraries needed for building the UFS SRW App on Hercules ]===])
 
-prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/fms-2024.01/install/modulefiles/Core")
 
 load("stack-intel/2021.9.0")
 load("stack-intel-oneapi-mpi/2021.9.0")

--- a/modulefiles/build_jet_intel.lua
+++ b/modulefiles/build_jet_intel.lua
@@ -5,7 +5,7 @@ the NOAA RDHPC machine Jet using Intel-2021.5.0
 
 whatis([===[Loads libraries needed for building the UFS SRW App on Jet ]===])
 
-prepend_path("MODULEPATH","/contrib/spack-stack/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH","/contrib/spack-stack/spack-stack-1.6.0/envs/fms-2024.01/install/modulefiles/Core")
 
 load("stack-intel/2021.5.0")
 load("stack-intel-oneapi-mpi/2021.5.1")

--- a/modulefiles/build_noaacloud_intel.lua
+++ b/modulefiles/build_noaacloud_intel.lua
@@ -5,7 +5,7 @@ the NOAA cloud using Intel-oneapi
 
 whatis([===[Loads libraries needed for building the UFS SRW App on NOAA cloud ]===])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.6.0/envs/fms-2024.01/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/apps/modules/modulefiles")
 load("gnu")
 load("stack-intel")

--- a/modulefiles/build_orion_intel.lua
+++ b/modulefiles/build_orion_intel.lua
@@ -5,7 +5,7 @@ the MSU machine Orion using intel-oneapi-compilers/2021.9.0
 
 whatis([===[Loads libraries needed for building the UFS SRW App on Orion ]===])
 
-prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/fms-2024.01/install/modulefiles/Core")
 
 load("stack-intel/2021.9.0")
 load("stack-intel-oneapi-mpi/2021.9.0")

--- a/modulefiles/srw_common.lua
+++ b/modulefiles/srw_common.lua
@@ -6,7 +6,7 @@ load("netcdf-c/4.9.2")
 load("netcdf-fortran/4.6.1")
 load("parallelio/2.5.10")
 load("esmf/8.6.0")
-load("fms/2023.04")
+load("fms/2024.01")
 
 load("bacio/2.4.1")
 load("crtm/2.4.0.1")

--- a/parm/metplus/STATAnalysisConfig_skill_score
+++ b/parm/metplus/STATAnalysisConfig_skill_score
@@ -14,7 +14,6 @@ model = ["FV3_WoFS_v0_SUBCONUS_3km_test_mem000", "FV3_GFS_v16_SUBCONUS_3km"];
 fcst_lead = [ "6", "12",
               "6", "12",
               "6", "12",
-              "6", "12",
                    "12",
                    "12",
                    "12",
@@ -51,24 +50,22 @@ obs_init_inc    = [];
 obs_init_exc    = [];
 obs_init_hour   = [];
 
-fcst_var = [ "PRMSL", "PRMSL",
-             "WIND",  "WIND",
-             "DPT",   "DPT",
-             "TMP",   "TMP",
-                      "WIND",
-                      "WIND",
-                      "WIND",
-                      "TMP",
-                      "TMP",
-                      "TMP",
-                      "SPFH",
-                      "SPFH",
-                      "SPFH"
+fcst_var = [ "WIND", "WIND",
+             "DPT",  "DPT",
+             "TMP",  "TMP",
+                     "WIND",
+                     "WIND",
+                     "WIND",
+                     "TMP",
+                     "TMP",
+                     "TMP",
+                     "SPFH",
+                     "SPFH",
+                     "SPFH"
            ];
 obs_var  = [];
 
-fcst_lev = [ "Z0",  "Z0",
-             "Z10", "Z10",
+fcst_lev = [ "Z10", "Z10",
              "Z2",  "Z2",
              "Z2",  "Z2",
                     "P250",
@@ -102,7 +99,6 @@ line_type = [ "SL1L2" ];
 column    = [ "RMSE" ];
             
 weight    = [ 10.0, 8.0,
-              10.0, 8.0,
               10.0, 8.0,
               10.0, 8.0,
                     4.0,

--- a/tests/WE2E/test_configs/grids_extrn_mdls_suites_community/config.grid_RRFS_AK_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16_plot.yaml
+++ b/tests/WE2E/test_configs/grids_extrn_mdls_suites_community/config.grid_RRFS_AK_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16_plot.yaml
@@ -22,5 +22,7 @@ task_get_extrn_lbcs:
   EXTRN_MDL_NAME_LBCS: FV3GFS
   LBC_SPEC_INTVL_HRS: 6
   USE_USER_STAGED_EXTRN_FILES: true
+task_run_fcst:
+  OMP_NUM_THREADS_RUN_FCST: 1
 task_plot_allvars:
   PLOT_DOMAINS: ["regional"]


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Update ufs-weather-model hash to [6b0f516](https://github.com/ufs-community/ufs-weather-model/commit/6b0f516557811eac82c17b852efb82a35892b022) (November 14, 2024)
- Update UPP hash to [6f5dd62](https://github.com/NOAA-EMC/UPP/commit/6f5dd627d124ae94bb5ed7f5afd22f82c470b1b7) (September 30, 2024)
- Use the `fms-2024.01` spack stack environment (replacing `upp-addon-env`) for Tier-1 platform modulefiles
- Replace `fms/2023.04` with `fms/2024.01` in `modulefiles/srw_common.lua`
- Removed `PRMSL` from `parm/metplus/STATAnalysisConfig_skill_score` in order to calculate the skill-score (`PRMSL` was replaced with `MSLET` in the `postxconfig-NT-fv3lam.txt` file)
- The `grid_RRFS_AK_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16_plot` WE2E test was requiring over 6 hours in the `run_fcst` task to complete while using GNU executables.  Running with a single thread (`OMP_NUM_THREADS_RUN_FCST: 1`) allows the test to run using both GNU and Intel compilers without issue.

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## TESTS CONDUCTED: 
- [x] derecho.intel - Fundamental, Comprehensive, and Fire sample config (`ush/config.fire.yaml`) tests were run
- [x] gaea.intel - Fundamental and Comprehensive tests were run
- [x] hera.gnu - Fundamental and Comprehensive tests were run
- [x] hera.intel - Fundamental, Comprehensive, AQM WE2E, and AQM sample config (`ush/config.aqm.yaml`) tests were run
- [x] hercules.intel - Fundamental, Comprehensive, AQM WE2E, and AQM sample config (`ush/config.aqm.yaml`) tests were run
- [x] jet.intel - Fundamental, Comprehensive, and Fire WE2E tests were run
- [x] orion.intel - Fundamental, Comprehensive, AQM WE2E, and AQM sample config (`ush/config.aqm.yaml`) tests were run
- [x] fundamental test suite
- [x] comprehensive tests (specify *which* if a subset was used)

## DOCUMENTATION:
No modifications are required in the documentation

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes