### PR TITLE
[develop:] Updated UFS_UTILS, ufs-weather-model hashes; use of new sfc_data.nc format (v2) for the FV3atm

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,18 +1,17 @@
 [ufs_utils]
 protocol = git
-repo_url = https://github.com/NOAA-EPIC/UFS_UTILS
+repo_url = https://github.com/ufs-community/UFS_UTILS
 # Specify either a branch name or a hash but not both.
-#branch = release/srw-v3.0.0
-hash = 1ee0fee
+#branch = develop
+hash = e718003
 local_path = sorc/UFS_UTILS
 required = True
 
 [ufs-weather-model]
 protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
-# Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 3a5e52e
+hash = d57779f 
 local_path = sorc/ufs-weather-model
 required = True
 

--- a/parm/FV3.input.yml
+++ b/parm/FV3.input.yml
@@ -86,6 +86,7 @@ FV3_HRRR:
     iaer: 5111
     icliq_sw: 2
     iovr: 3
+    kice: 9
     lsm: 3
     lsoil_lsm: 9
     sfclay_compute_flux: True
@@ -209,6 +210,7 @@ FV3_HRRR_gf:
     isubc_lw: 2
     isubc_sw: 2
     ivegsrc: 1
+    kice: 9
     ldiag3d: false
     ldiag_ugwp: false
     lgfdlmprad: false
@@ -273,6 +275,7 @@ FV3_RAP:
     iaer: 5111
     icliq_sw: 2
     iovr: 3
+    kice: 9
     lsm: 3
     lsoil_lsm: 9
     sfclay_compute_flux: False

--- a/scripts/exregional_make_ics.sh
+++ b/scripts/exregional_make_ics.sh
@@ -528,7 +528,7 @@ case "${EXTRN_MDL_NAME_ICS}" in
   tg3_from_soil=False
   ;;
 
-"HRRR"|"RRFS")
+"HRRR")
   external_model="HRRR"
 
   fn_grib2="${EXTRN_MDL_FNS[0]}"
@@ -544,8 +544,28 @@ case "${EXTRN_MDL_NAME_ICS}" in
   vgfrc_from_climo=True
   minmax_vgfrc_from_climo=True
   lai_from_climo=True
-  tg3_from_soil=True
+  tg3_from_soil=False
   convert_nst=False
+  ;;
+
+"RRFS")
+  external_model="RRFS"
+
+  fn_grib2="${EXTRN_MDL_FNS[0]}"
+  input_type="grib2"
+#
+# Path to the RRFS/HRRRX geogrid file.
+#
+  geogrid_file_input_grid="${FIXgsm}/geo_em.d01.nc_HRRRX"
+# Note that vgfrc, shdmin/shdmax (minmax_vgfrc), and lai fields are only available in HRRRX
+# files after mid-July 2019, and only so long as the record order didn't change afterward
+  vgtyp_from_climo=False
+  sotyp_from_climo=False
+  vgfrc_from_climo=True
+  minmax_vgfrc_from_climo=True
+  lai_from_climo=False
+  tg3_from_soil=True
+  convert_nst=True
   ;;
 
 "RAP")

--- a/scripts/exregional_make_ics.sh
+++ b/scripts/exregional_make_ics.sh
@@ -563,7 +563,7 @@ case "${EXTRN_MDL_NAME_ICS}" in
   sotyp_from_climo=False
   vgfrc_from_climo=True
   minmax_vgfrc_from_climo=True
-  lai_from_climo=False
+  lai_from_climo=True
   tg3_from_soil=True
   convert_nst=True
   ;;

--- a/scripts/exregional_make_lbcs.sh
+++ b/scripts/exregional_make_lbcs.sh
@@ -409,8 +409,13 @@ case "${EXTRN_MDL_NAME_LBCS}" in
   input_type="grib2"
   ;;
 
-"HRRR"|"RRFS")
+"HRRR")
   external_model="HRRR"
+  input_type="grib2"
+  ;;
+
+"RRFS")
+  external_model="RRFS"
   input_type="grib2"
   ;;
 

--- a/scripts/exregional_make_orog.sh
+++ b/scripts/exregional_make_orog.sh
@@ -184,12 +184,12 @@ DATA="${DATA:-${raw_dir}/tmp}"
 mkdir -p "${DATA}"
 cd "${DATA}"
 #
-# Copy topography and related data files from the system directory (FIXorg)
+# Copy topography and landcover data files from the system directory (FIXorg)
 # to the temporary directory.
 #
-cp ${FIXorg}/thirty.second.antarctic.new.bin fort.15
-cp ${FIXorg}/landcover30.fixed .
-cp ${FIXorg}/gmted2010.30sec.int fort.235
+cp ${FIXorg}/topography.antarctica.ramp.30s.nc .
+cp ${FIXorg}/landcover.umd.30s.nc .
+cp ${FIXorg}/topography.gmted2010.30s.nc .
 #
 #-----------------------------------------------------------------------
 #
@@ -227,13 +227,11 @@ blat=0
 input_redirect_fn="INPS"
 orogfile="none"
 
-echo $mtnres $lonb $latb $jcap $NR $NF1 $NF2 $efac $blat > "${input_redirect_fn}"
 #
 # The following two inputs are read in as strings, so they must be quoted
 # in the input file.
 #
 echo "\"${grid_fp}\"" >> "${input_redirect_fn}"
-echo "\"$orogfile\"" >> "${input_redirect_fn}"
 echo ".false." >> "${input_redirect_fn}" #MASK_ONLY
 echo "none" >> "${input_redirect_fn}" #MERGE_FILE
 cat "${input_redirect_fn}"

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -315,12 +315,13 @@ def generate_FV3LAM_wflow(
     # Set npz, which is just LEVP minus 1.
     npz = LEVP - 1
     #
-    # For the physics suites that use RUC LSM, set the parameter kice to 9,
+    # For the physics suites that use RUC LSM and when restarting a run 
+    # (COLDSTART: false), set the parameter kice to 9,
     # Otherwise, leave it unspecified (which means it gets set to the default
     # value in the forecast model).
     #
     kice = None
-    if SDF_USES_RUC_LSM:
+    if SDF_USES_RUC_LSM and not COLDSTART:
         kice = 9
     #
     # Set lsoil, which is the number of input soil levels provided in the
@@ -337,7 +338,7 @@ def generate_FV3LAM_wflow(
     # Also, may want to set lsm here as well depending on SDF_USES_RUC_LSM.
     #
     lsoil = 4
-    if EXTRN_MDL_NAME_ICS in ("HRRR", "RAP") and SDF_USES_RUC_LSM:
+    if EXTRN_MDL_NAME_ICS in ("HRRR", "RRFS", "RAP") and SDF_USES_RUC_LSM:
         lsoil = 9
     if CCPP_PHYS_SUITE == "FV3_GFS_v15_thompson_mynn_lam3km":
         lsoil = ""


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Updated UFS_UTILS and ufs-weather-model hashes to a recent develop
   - use new format for the surface data, sfc_data.nc (V2), to prepare initial conditions for the FV3atm. The new format includes two dimensions for a vertical coordinate:
        -  zaxis_1 for soil levels (i.e., 4 or 9);
        - zaxis_2 for ice levels (2 ). This is hard-coded at the moment, in ./UFS_UTILS/sorc/chgres_cube.fd/write_data.F90. Chgres_cube prepares data for coldstart. 
 In SRW, kice is set to 9 for RUC_LSM and a restart (not COLDSTART).
- Use updated topography and landcover data for make_orog task from the netcdf files, instead of older binary files.
${FIXorg}/topography.antarctica.ramp.30s.nc
${FIXorg}/landcover.umd.30s.nc 
${FIXorg}/topography.gmted2010.30s.nc

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## TESTS CONDUCTED: 
```
----------------------------------------------------------------------------------------------------
Experiment name                                                  | Status    | Core hours used 
----------------------------------------------------------------------------------------------------
grid_RRFS_CONUScompact_25km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta_2  COMPLETE              18.44
(*)grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2_20250  DEAD                   3.41
(*)grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v17_p8_plot  DEAD                   3.04
(**)grid_RRFS_CONUScompact_25km_ics_HRRR_lbcs_HRRR_suite_HRRR_2025021  DEAD                  12.93
grid_SUBCONUS_Ind_3km_ics_HRRR_lbcs_RAP_suite_WoFS_v0_20250212120  COMPLETE              34.20
grid_RRFS_CONUS_25km_ics_NAM_lbcs_NAM_suite_GFS_v16_2025021212075  COMPLETE              81.57
------------------------------------------------------------------------------------------------
```
(*) - get errors in make_ics, make_lbcs:
```
 - FATAL ERROR: UNRECOGNIZED INPUT DATA TYPE.
 - IOSTAT IS:   
```
(**) - cold start vertical coordinate kice=2, need kice=9 for RUC_LSM, yet to find an approach to reconcile

- [ ] derecho.intel
- [ ] gaea.intel
- [ ] gaea-c6.intel
- [ ] hera.gnu
- [ ] hera.intel
- [ ] hercules.intel
- [ ] jet.intel
- [x] orion.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:


## DOCUMENTATION:


## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here (Remember, issues must always be created before starting work on a PR branch!). For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/ufs-community/other_repository/pull/63" -->

## CHECKLIST
<!-- Add an X to check off a box. -->
- [ ] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

