### PR TITLE
[release/public-v3.0.0] Force cycle to be decimal integer

### DIFF
--- a/scripts/exregional_get_extrn_mdl_files.sh
+++ b/scripts/exregional_get_extrn_mdl_files.sh
@@ -137,7 +137,7 @@ elif [ "${ICS_OR_LBCS}" = "LBCS" ]; then
   first_time=$((TIME_OFFSET_HRS + LBC_SPEC_INTVL_HRS))
 
   if [ ${#FCST_LEN_CYCL[@]} -gt 1 ]; then
-    cyc_mod=$(( ${cyc} - ${DATE_FIRST_CYCL:8:2} ))
+    cyc_mod=$(( 10#${cyc} - ${DATE_FIRST_CYCL:8:2} ))
     CYCLE_IDX=$(( ${cyc_mod} / ${INCR_CYCL_FREQ} ))
     FCST_LEN_HRS=${FCST_LEN_CYCL[$CYCLE_IDX]}
   fi


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
* When getting LBCs, force cycle variable to be a decimal integer. The cycle variable padded with 0 was being treated as octal thus failing on the 08z and 09z cycles.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
- [x] gaea-c6.intel
- [x] hera.intel
- [x] Jenkins
- [x] fundamental test suite
- [x] coverage test suite

As this PR is a copy of @LiamWedell-NOAA's PR #1213, fundamental tests were run on Gaea-C6 and Hera Intel.  The Jenkins coverage tests were also run on all Tier-1 platform and successfully passed for PR #1213.

## DEPENDENCIES:

## DOCUMENTATION:
Small bug fix, no new documentation needed

## ISSUE: 

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes

## CONTRIBUTORS (optional): 
This is a copy of PR #1213, originally opened by @LiamWedell-NOAA

