### PR TITLE
[develop] Adding AQM modulefiles/tasks for Gaea C5 and C6.

### DIFF
--- a/modulefiles/tasks/gaeac5/aqm_ics.local.lua
+++ b/modulefiles/tasks/gaeac5/aqm_ics.local.lua
@@ -1,0 +1,1 @@
+load("python_srw_aqm")

--- a/modulefiles/tasks/gaeac5/aqm_lbcs.local.lua
+++ b/modulefiles/tasks/gaeac5/aqm_lbcs.local.lua
@@ -1,0 +1,1 @@
+load("python_srw_aqm")

--- a/modulefiles/tasks/gaeac5/fire_emission.local.lua
+++ b/modulefiles/tasks/gaeac5/fire_emission.local.lua
@@ -1,0 +1,1 @@
+load("python_srw_aqm")

--- a/modulefiles/tasks/gaeac5/nexus_emission.local.lua
+++ b/modulefiles/tasks/gaeac5/nexus_emission.local.lua
@@ -1,0 +1,1 @@
+load("python_srw_aqm")

--- a/modulefiles/tasks/gaeac5/nexus_post_split.local.lua
+++ b/modulefiles/tasks/gaeac5/nexus_post_split.local.lua
@@ -1,0 +1,1 @@
+load("python_srw_aqm")

--- a/modulefiles/tasks/gaeac5/plot_allvars.local.lua
+++ b/modulefiles/tasks/gaeac5/plot_allvars.local.lua
@@ -1,4 +1,3 @@
 unload("python")
 load("conda")
-
 setenv("SRW_GRAPHICS_ENV", "srw_graphics")

--- a/modulefiles/tasks/gaeac5/point_source.local.lua
+++ b/modulefiles/tasks/gaeac5/point_source.local.lua
@@ -1,0 +1,1 @@
+load("python_srw_aqm")

--- a/modulefiles/tasks/gaeac6/aqm_ics.local.lua
+++ b/modulefiles/tasks/gaeac6/aqm_ics.local.lua
@@ -1,0 +1,1 @@
+load("python_srw_aqm")

--- a/modulefiles/tasks/gaeac6/aqm_lbcs.local.lua
+++ b/modulefiles/tasks/gaeac6/aqm_lbcs.local.lua
@@ -1,0 +1,1 @@
+load("python_srw_aqm")

--- a/modulefiles/tasks/gaeac6/fire_emission.local.lua
+++ b/modulefiles/tasks/gaeac6/fire_emission.local.lua
@@ -1,0 +1,1 @@
+load("python_srw_aqm")

--- a/modulefiles/tasks/gaeac6/nexus_emission.local.lua
+++ b/modulefiles/tasks/gaeac6/nexus_emission.local.lua
@@ -1,0 +1,1 @@
+load("python_srw_aqm")

--- a/modulefiles/tasks/gaeac6/nexus_post_split.local.lua
+++ b/modulefiles/tasks/gaeac6/nexus_post_split.local.lua
@@ -1,0 +1,1 @@
+load("python_srw_aqm")

--- a/modulefiles/tasks/gaeac6/plot_allvars.local.lua
+++ b/modulefiles/tasks/gaeac6/plot_allvars.local.lua
@@ -1,4 +1,3 @@
 unload("python")
 load("conda")
-
 setenv("SRW_GRAPHICS_ENV", "srw_graphics")

--- a/modulefiles/tasks/gaeac6/point_source.local.lua
+++ b/modulefiles/tasks/gaeac6/point_source.local.lua
@@ -1,0 +1,1 @@
+load("python_srw_aqm")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Adding AQM modulefiles/tasks for Gaea C5 and C6.  These are copied from hercules modulefiles/tasks.  Tasks involving these modules appear to complete successfully on Gaea C5.   But there are other outstanding issues in AQM workflow on Gaea in  #1241 , as well as other procedures to use "srw_aqm" environment instead of "srw_app" to potentially avoid using these local modulefiles/tasks for AQM.  

### Type of change
- [x ] New feature (non-breaking change which adds functionality)

## TESTS CONDUCTED: 
- [X ] gaea.intel
