### PR TITLE
[develop] Fix for Issue 1243

### DIFF
--- a/tests/WE2E/test_configs/custom_grids/config.custom_ESGgrid_Great_Lakes_snow_8km.yaml
+++ b/tests/WE2E/test_configs/custom_grids/config.custom_ESGgrid_Great_Lakes_snow_8km.yaml
@@ -60,4 +60,4 @@ verification:
   NDAS_OBS_DIR: '{{ workflow.EXPTDIR }}/NDAS_obs'
   NOHRSC_OBS_DIR: '{{ workflow.EXPTDIR }}/NOHRSC_obs'
   VX_FCST_MODEL_NAME: Michigan_Ontario_snow_8km
-  VX_FIELD_GROUPS: [ "APCP", "REFC", "RETOP", "SFC", "UPA", "ASNOW" ]
+  VX_FIELD_GROUPS: [ "APCP", "REFC", "RETOP", "ASNOW" ]

--- a/tests/WE2E/test_configs/verification/config.MET_verification_smoke_only_vx.yaml
+++ b/tests/WE2E/test_configs/verification/config.MET_verification_smoke_only_vx.yaml
@@ -18,7 +18,7 @@ rocoto:
         walltime: 01:00:00
 verification:
   VX_FCST_MODEL_NAME: RRFS_smoke_test
-  VX_FIELD_GROUPS: [ "SFC", "AOD", "PM25", "PM10"]
+  VX_FIELD_GROUPS: [ "AOD", "PM25", "PM10" ]
   VX_FCST_INPUT_BASEDIR: '{{ platform.WE2E_TEST_DATA }}/input_model_data/RRFS'
   FCST_SUBDIR_TEMPLATE: '{init?fmt=%Y%m%d%H}'
   FCST_FN_TEMPLATE: 'rrfs.t00z.prslev.f{lead?fmt=%HHH}.conus.grib2'

--- a/tests/WE2E/test_configs/verification/config.MET_verification_smoke_only_vx.yaml
+++ b/tests/WE2E/test_configs/verification/config.MET_verification_smoke_only_vx.yaml
@@ -1,7 +1,7 @@
 metadata:
   description: |-
     This test checks the capability of the workflow to run verification tasks
-    for smoke data (AERONET AOD and AIRNOW PM). Also does SFC and NOHRSC snow verification
+    for smoke data (AERONET AOD and AIRNOW PM) using RRFS prototype data.
 user:
   RUN_ENVIR: community
 workflow:

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -752,7 +752,11 @@ def setup(USHdir, user_config_fn="config.yaml", debug: bool = False):
         #
         # -----------------------------------------------------------------------
         #
-        # Remove all verification (meta)tasks for which no fields are specified.
+        # Remove all verification (meta)tasks which are not needed for the specified
+        # list of verification field groups.
+        # Note that if the metatask specification depends on the field group, it
+        # does not need to be listed here because those metatasks will be removed
+        # later by clean_rocoto_dict()
         #
         # -----------------------------------------------------------------------
         #
@@ -780,28 +784,21 @@ def setup(USHdir, user_config_fn="config.yaml", debug: bool = False):
         vx_field_groups_all_by_obtype["MRMS"] = ["REFC", "RETOP"]
         vx_metatasks_all_by_obtype["MRMS"] \
         = ["task_get_obs_mrms",
-           "metatask_GridStat_REFC_RETOP_all_mems",
-           "metatask_GenEnsProd_EnsembleStat_REFC_RETOP",
-           "metatask_GridStat_REFC_RETOP_ensprob"]
+           "metatask_GridStat_REFC_RETOP_all_mems"]
     
         vx_field_groups_all_by_obtype["NDAS"] = ["SFC", "UPA"]
         vx_metatasks_all_by_obtype["NDAS"] \
         = ["task_get_obs_ndas",
            "task_run_MET_Pb2nc_obs_NDAS",
-           "metatask_PointStat_SFC_UPA_all_mems",
-           "metatask_GenEnsProd_EnsembleStat_SFC_UPA",
            "metatask_PointStat_SFC_UPA_ensmeanprob"]
 
         vx_field_groups_all_by_obtype["AERONET"] = ["AOD"]
         vx_metatasks_all_by_obtype["AERONET"] \
-        = ["task_get_obs_aeronet",
-           "metatask_ASCII2nc_obs"]
+        = ["task_get_obs_aeronet"]
 
         vx_field_groups_all_by_obtype["AIRNOW"] = ["PM25", "PM10"]
         vx_metatasks_all_by_obtype["AIRNOW"] \
-        = ["task_get_obs_airnow",
-           "metatask_ASCII2nc_obs",
-           "metatask_PcpCombine_fcst_PM_all_mems"]
+        = ["task_get_obs_airnow"]
 
         # If there are no field groups specified for verification, remove those
         # tasks that are common to all observation types.
@@ -1877,16 +1874,28 @@ def clean_rocoto_dict(rocotodict):
     """Removes any invalid entries from ``rocotodict``. Examples of invalid entries are:
 
     1. A task dictionary containing no "command" key
-    2. A metatask dictionary containing no task dictionaries
+    2. A metatask definition dependent on a variable with no entries
+    3. A metatask dictionary containing no task dictionaries
 
     Args:
         rocotodict (dict): A dictionary containing Rocoto workflow settings
     """
 
-    # Loop 1: search for tasks with no command key, iterating over metatasks
+
+    # Loop 1: search for tasks with no command key, iterating over metatasks, and popping metatasks with
+    # var keys having empty values
     for key in list(rocotodict.keys()):
         if key.split("_", maxsplit=1)[0] == "metatask":
             clean_rocoto_dict(rocotodict[key])
+            # After checking for metatasks with no command key, now check for empty var entries
+            if rocotodict.get(key).get('var'):
+                for varkey in list(rocotodict[key]['var'].keys()):
+                    if not rocotodict[key]['var'][varkey]:
+                        popped = rocotodict.pop(key)
+                        logging.warning(f"Invalid metatask {key} removed due to empty/unset var: {varkey}")
+                        logging.debug(f"Removed entry:\n{popped}")
+                        break
+
         elif key.split("_", maxsplit=1)[0] in ["task"]:
             if not rocotodict[key].get("command"):
                 popped = rocotodict.pop(key)


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR introduces two improvements in `setup.py` to fix problems with workflow generation.

1. Introduce new logic in the `clean_rocoto_dict()` function to eliminate metatasks that have empty variable definitions. This could happen, for example, for metatasks like `metatask_PointStat` that correspond to tasks for multiple types of observations: if none of those observation types are used, the metatask will have invalid sub-tasks and/or submetatasks that rely on variable definitions (such as `FIELD_GROUP`) that are blank.
2. Better populate the list of tasks in the logic that deactivates tasks for observation types that are not used.

I have also updated two verification tests to remove NDAS observations, since previously all verification tests had NDAS and this was masking one of the failure conditions.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
Ran fundamental test suite and all verification tests (including new mods, confirming issue fixed) on Hera (Intel)

- [ ] derecho.intel
- [ ] gaea.intel
- [ ] gaea-c6.intel
- [ ] hera.gnu
- [x] hera.intel
- [ ] hercules.intel
- [ ] jet.intel
- [ ] orion.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE: 
Fixes #1243 

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes do not require updates to the documentation (explain).
  - Bug fix only.
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
