### PR TITLE
[release/public-v3.0.0] fix: grid indexing match for pregenerated weight files and fill value disconnect

### DIFF
--- a/tests/test_python/test_smoke_dust/test_core/test_preprocessor.py
+++ b/tests/test_python/test_smoke_dust/test_core/test_preprocessor.py
@@ -88,8 +88,8 @@ class DataForTest(BaseModel):
 
 @pytest.fixture(
     params=[
-        ExpectedData(flag="1", klass=SmokeDustCycleOne, hash="d124734dfce7ca914391e35a02e4a7d2"),
-        ExpectedData(flag="2", klass=SmokeDustCycleTwo, hash="6752199f1039edc936a942f3885af38b"),
+        ExpectedData(flag="1", klass=SmokeDustCycleOne, hash="26b20e27ca5287b62ca8e6ed517ec953"),
+        ExpectedData(flag="2", klass=SmokeDustCycleTwo, hash="5c1bb73c3f227c15eba3746ddab8732c"),
     ],
     ids=lambda p: f"ebb_dcycle={p.flag}",
 )

--- a/tests/test_python/test_smoke_dust/test_core/test_regrid.py
+++ b/tests/test_python/test_smoke_dust/test_core/test_regrid.py
@@ -186,4 +186,4 @@ class TestSmokeDustRegridProcessor:  # pylint: disable=too-few-public-methods
         assert len(interpolated_files) == 24
         for intp_file in interpolated_files:
             fpath = tmp_path / intp_file
-            assert create_file_hash(fpath) == "8e90b769137aad054a2e49559d209c4d"
+            assert create_file_hash(fpath) == "3605f5fc9bba74626b72b9adeadc0abe"

--- a/ush/smoke_dust/core/common.py
+++ b/ush/smoke_dust/core/common.py
@@ -98,7 +98,7 @@ def create_sd_variable(
             # is not opened in parallel this error message is returned:
             # RuntimeError: NetCDF: Parallel operation on file opened for non-parallel access
             pass
-        var_out[0, :, :] = sd_variable.fill_value_float
+        var_out[0, :, :] = sd_variable.fill_value_actual
         try:
             var_out.set_collective(False)
         except RuntimeError:

--- a/ush/smoke_dust/core/regrid/common.py
+++ b/ush/smoke_dust/core/regrid/common.py
@@ -68,8 +68,8 @@ class GridSpec(BaseModel):
     y_corner: Union[str, None] = None
     x_corner_dim: Union[NameListType, None] = None
     y_corner_dim: Union[NameListType, None] = None
-    x_index: int = 0
-    y_index: int = 1
+    x_index: int = 1
+    y_index: int = 0
 
     @model_validator(mode="after")
     def _validate_model_(self) -> "GridSpec":

--- a/ush/smoke_dust/core/regrid/processor.py
+++ b/ush/smoke_dust/core/regrid/processor.py
@@ -83,6 +83,18 @@ class SmokeDustRegridProcessor:
     def _dst_gwrap(self) -> GridWrapper:
         if self.__dst_gwrap is None:
             self.log("creating destination grid from RRFS grid file")
+            # The fixed weight files for these grids are generated with swapped x/y indices. The
+            # other grid fixed files use ESMF indexing default of (x,y).
+            if (
+                self._context.predef_grid
+                in (
+                    PredefinedGrid.RRFS_NA_3KM,
+                    PredefinedGrid.RRFS_CONUS_3KM,
+                )
+            ):
+                x_index, y_index = (1, 0)
+            else:
+                x_index, y_index = (0, 1)
             dst_nc2grid = NcToGrid(
                 path=self._context.grid_out,
                 spec=GridSpec(
@@ -94,6 +106,8 @@ class SmokeDustRegridProcessor:
                     y_corner="grid_lat",
                     x_corner_dim=("grid_x",),
                     y_corner_dim=("grid_y",),
+                    x_index=x_index,
+                    y_index=y_index,
                 ),
             )
             self.__dst_gwrap = dst_nc2grid.create_grid_wrapper()
@@ -105,12 +119,11 @@ class SmokeDustRegridProcessor:
             # We are translating metadata and some structure for the destination grid.
             dst_output_gwrap = copy(self._dst_gwrap)
             dst_output_gwrap.corner_dims = None
-            dst_output_gwrap.spec = GridSpec(
-                x_center="geolon", y_center="geolat", x_dim=("lon",), y_dim=("lat",)
-            )
+            spec = GridSpec(x_center="geolon", y_center="geolat", x_dim=("lon",), y_dim=("lat",))
+            dst_output_gwrap.spec = spec
             dst_output_gwrap.dims = deepcopy(self._dst_gwrap.dims)
-            dst_output_gwrap.dims.value[0].name = ("lon",)
-            dst_output_gwrap.dims.value[1].name = ("lat",)
+            dst_output_gwrap.dims.value[spec.x_index].name = ("lon",)
+            dst_output_gwrap.dims.value[spec.y_index].name = ("lat",)
             self.__dst_output_gwrap = dst_output_gwrap
         return self.__dst_output_gwrap
 
@@ -119,10 +132,7 @@ class SmokeDustRegridProcessor:
             self.log("creating regridder")
             self.log(f"{src_fwrap.value.data.shape=}", level=logging.DEBUG)
             self.log(f"{dst_fwrap.value.data.shape=}", level=logging.DEBUG)
-            if (
-                self._context.predef_grid == PredefinedGrid.RRFS_NA_13KM
-                or self._context.regrid_in_memory
-            ):
+            if self._context.predef_grid == PredefinedGrid.RRFS_NA_13KM:
                 # ESMF does not like reading the weights for this field combination (rc=-1). The
                 # error can be bypassed by creating weights in-memory.
                 self.log("creating regridding in-memory")

--- a/ush/smoke_dust/core/variable.py
+++ b/ush/smoke_dust/core/variable.py
@@ -13,6 +13,7 @@ class SmokeDustVariable(BaseModel):
     units: str = Field(description="Units for the variable.")
     fill_value_str: str = Field(description="Fill value for the variable in string format.")
     fill_value_float: float = Field(description="Fill value for the variable in float format.")
+    fill_value_actual: float = Field(description="Value to fill arrays with using numpy array set.")
 
 
 SmokeDustVariablesType = Tuple[SmokeDustVariable, ...]
@@ -50,6 +51,7 @@ SD_VARS = SmokeDustVariables(
             units="degrees_north",
             fill_value_str="-9999.f",
             fill_value_float=-9999.0,
+            fill_value_actual=-9999.0,
         ),
         SmokeDustVariable(
             name="geolon",
@@ -57,62 +59,71 @@ SD_VARS = SmokeDustVariables(
             units="degrees_east",
             fill_value_str="-9999.f",
             fill_value_float=-9999.0,
+            fill_value_actual=-9999.0,
         ),
         SmokeDustVariable(
             name="frp_avg_hr",
             long_name="Mean Fire Radiative Power",
             units="MW",
-            fill_value_str="0.f",
-            fill_value_float=0.0,
+            fill_value_str="-1.f",
+            fill_value_float=-1.0,
+            fill_value_actual=0.0,
         ),
         SmokeDustVariable(
             name="ebb_smoke_hr",
             long_name="EBB emissions",
             units="ug m-2 s-1",
-            fill_value_str="0.f",
-            fill_value_float=0.0,
+            fill_value_str="-1.f",
+            fill_value_float=-1.0,
+            fill_value_actual=0.0,
         ),
         SmokeDustVariable(
             name="frp_davg",
             long_name="Daily mean Fire Radiative Power",
             units="MW",
-            fill_value_str="0.f",
-            fill_value_float=0.0,
+            fill_value_str="-1.f",
+            fill_value_float=-1.0,
+            fill_value_actual=0.0,
         ),
         SmokeDustVariable(
             name="ebb_rate",
             long_name="Total EBB emission",
             units="ug m-2 s-1",
-            fill_value_str="0.f",
-            fill_value_float=0.0,
+            fill_value_str="-1.f",
+            fill_value_float=-1.0,
+            fill_value_actual=0.0,
         ),
         SmokeDustVariable(
             name="fire_end_hr",
             long_name="Hours since fire was last detected",
             units="hrs",
-            fill_value_str="0.f",
-            fill_value_float=0.0,
+            fill_value_str="-1.f",
+            fill_value_float=-1.0,
+            fill_value_actual=0.0,
         ),
         SmokeDustVariable(
             name="hwp_davg",
             long_name="Daily mean Hourly Wildfire Potential",
             units="none",
-            fill_value_str="0.f",
-            fill_value_float=0.0,
+            fill_value_str="-1.f",
+            fill_value_float=-1.0,
+            fill_value_actual=0.0,
         ),
         SmokeDustVariable(
             name="totprcp_24hrs",
             long_name="Sum of precipitation",
             units="m",
-            fill_value_str="0.f",
-            fill_value_float=0.0,
+            fill_value_str="-1.f",
+            fill_value_float=-1.0,
+            fill_value_actual=0.0,
         ),
         SmokeDustVariable(
             name="FRE",
             long_name="FRE",
             units="MJ",
-            fill_value_str="0.f",
-            fill_value_float=0.0,
+            fill_value_str="-1.f",
+            fill_value_float=-1.0,
+            fill_value_actual=0.0,
         ),
     )
 )


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
* Fixed files for `CONUS/NA_3km` were generated with different ESMF indices. Support this indexing for the original weight files.
* Fill values for dummy smoke ICs mask actual values. RRFS dummy ICs did not set the fill value when creating the netCDF variable.

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [ ] derecho.intel
- [ ] gaea.intel
- [ ] gaea-c6.intel
- [ ] hera.gnu
- [x] hera.intel
- [ ] hercules.intel
- [ ] jet.intel
- [ ] orion.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
- ufs-community/regional_workflow/pull/<pr_number>
- ufs-community/UFS_UTILS/pull/<pr_number>
- ufs-community/ufs-weather-model/pull/<pr_number> -->

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here (Remember, issues must always be created before starting work on a PR branch!). For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/ufs-community/other_repository/pull/63" -->

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
@JohanaRomeroAlvarez @LiamWedell-NOAA 

