### PR TITLE
[release/public-v3.0.0] set OMP_NUM_THREADS_RUN_FCST: 1 for noaacloud platforms

### DIFF
--- a/ush/machine/noaacloud.yaml
+++ b/ush/machine/noaacloud.yaml
@@ -35,6 +35,8 @@ platform:
   FIXupp: /contrib/EPIC/UFS_SRW_data/v3p0/fix/fix_upp
   FIXcrtm: /contrib/EPIC/UFS_SRW_data/v3p0/fix/fix_crtm
   EXTRN_MDL_DATA_STORES: aws nomads
+task_run_fcst:
+  OMP_NUM_THREADS_RUN_FCST: 1
 data:
   ics_lbcs:
     FV3GFS:


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Overcome excessive resources request on cloud platforms by setting  OMP_NUM_THREADS_RUN_FCST: 1 on cloud platforms as following in machine

In its current configuration, some tests cannot enter the queue due to excessive node request, e.g. 116 nodes with 14 tasks-per-node for CONUS_3km grids. 

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
Azure - Original comprehensive suite run with 61 tests has 6 failed, after re-running individual tests 

- [ ] derecho.intel
- [ ] gaea.intel
- [ ] gaea-c6.intel
- [ ] hera.gnu
- [ ] hera.intel
- [ ] hercules.intel
- [ ] jet.intel
- [ ] orion.intel
- [ ] wcoss2.intel
- [x] NOAA Cloud
       Azure - complete, successful 60 tests out of 61 (61/6 failed, 5 tests successful after being re-run individually), 98% success rate
       AWS - 100% comprehensive suite tests, re-run in several chunks
       GCP - comprehensive suite run: 57/61 successful test (93%), attached log. Reached to ParallelWorks on the problems with re-running the remaining tests (run_fcst jobs freeze, no errors reported, die due to time limit)
- [ ] Jenkins
- [ ] fundamental test suite
- [x] comprehensive tests (comprehensive.noaacloud)

## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
- ufs-community/regional_workflow/pull/<pr_number>
- ufs-community/UFS_UTILS/pull/<pr_number>
- ufs-community/ufs-weather-model/pull/<pr_number> -->

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->

## ISSUE: 
In its current configuration, some tests cannot enter the queue due to excessive node request, e.g. 116 nodes with 14 tasks-per-node for CONUS_3km grids. 

## CHECKLIST
<!-- Add an X to check off a box. -->
- [ ] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [ ] Work In Progress
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
@EdwardSnyder-NOAA 

Log files: 
**Azure**
[Comprehensive_Azure_1.txt](https://github.com/user-attachments/files/19432252/Comprehensive_Azure_1.txt)

[Comprehensive_Azure1_WE2E_summary_20250321222538.txt](https://github.com/user-attachments/files/19432260/Comprehensive_Azure1_WE2E_summary_20250321222538.txt)

[Test_complete1_WE2E_summary_20250322133348.txt](https://github.com/user-attachments/files/19432271/Test_complete1_WE2E_summary_20250322133348.txt)   
[Test_complete2_WE2E_summary_20250322162212.txt](https://github.com/user-attachments/files/19432284/Test_complete2_WE2E_summary_20250322162212.txt)
[Test_complete3_WE2E_summary_20250322173958.txt](https://github.com/user-attachments/files/19432288/Test_complete3_WE2E_summary_20250322173958.txt)
[Test_complete4_WE2E_summary_20250322183638.txt](https://github.com/user-attachments/files/19432293/Test_complete4_WE2E_summary_20250322183638.txt)
[Test_complete5_WE2E_summary_20250323045049.txt](https://github.com/user-attachments/files/19432304/Test_complete5_WE2E_summary_20250323045049.txt)

**GCP**:
[Comprehensive_GCP1_WE2E_summary_20250322230759.txt](https://github.com/user-attachments/files/19432534/Comprehensive_GCP1_WE2E_summary_20250322230759.txt)

**AWS**:

[Comprehensive_AWS_WE2E_summary_20250322175812.txt](https://github.com/user-attachments/files/19432549/Comprehensive_AWS_WE2E_summary_20250322175812.txt)
Failed tests re-ran:
[add1_WE2E_summary_20250326025058.txt](https://github.com/user-attachments/files/19460945/add1_WE2E_summary_20250326025058.txt)
[add2_WE2E_summary_20250326020822.txt](https://github.com/user-attachments/files/19460958/add2_WE2E_summary_20250326020822.txt)
[add3_WE2E_summary_20250326025816.txt](https://github.com/user-attachments/files/19460954/add3_WE2E_summary_20250326025816.txt)
[add4_WE2E_summary_20250326041921.txt](https://github.com/user-attachments/files/19460967/add4_WE2E_summary_20250326041921.txt)
The remaining tests WE2E_summary - from @EdwardSnyder-NOAA :
[add5_we2e_summary_20250325233311.txt](https://github.com/user-attachments/files/19468872/add5_we2e_summary_20250325233311.txt)
[add6_we2e_summary_20250325234218.txt](https://github.com/user-attachments/files/19468881/add6_we2e_summary_20250325234218.txt)