### PR TITLE
[release/public-v3.0.0] Correct build issue on Gaea C5 and C6 for the release branch

### DIFF
--- a/modulefiles/build_gaeac5_intel.lua
+++ b/modulefiles/build_gaeac5_intel.lua
@@ -23,8 +23,8 @@ load("srw_common")
 load(pathJoin("nco", os.getenv("nco_ver") or "5.0.6"))
 load(pathJoin("prod_util", os.getenv("prod_util_ver") or "2.1.1"))
 
-unload("darshan-runtime/3.4.0")
-unload("cray-pmi/6.1.10")
+unload("darshan-runtime")
+unload("cray-libsci")
 
 setenv("CFLAGS","-diag-disable=10441")
 setenv("FFLAGS","-diag-disable=10441")

--- a/modulefiles/build_gaeac6_intel.lua
+++ b/modulefiles/build_gaeac6_intel.lua
@@ -23,8 +23,8 @@ load("srw_common")
 load(pathJoin("nco", os.getenv("nco_ver") or "5.0.6"))
 load(pathJoin("prod_util", os.getenv("prod_util_ver") or "2.1.1"))
 
-unload("darshan-runtime/3.4.4")
-unload("cray-pmi/6.1.13")
+unload("darshan-runtime")
+unload("cray-libsci")
 
 setenv("CFLAGS","-diag-disable=10441")
 setenv("FFLAGS","-diag-disable=10441")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The SRW App's `release/public-v3.0.0` release branch is failing to build on Gaea C5 and Gaea C6.  The necessary fixes have been made to both `modulefiles/build_gaeac5_intel.lua` and `modulefiles/build_gaeac6_intel.lua` to allow the release branch to build successfully on both of these systems.

These changes were identified by @RatkoVasic-NOAA and merged into develop with PR #1261.  These changes are for the release branch.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
Comprehensive tests were run on Gaea C6 and Fundamental tests were run on Gaea C5
- [ ] derecho.intel
- [x] gaea-c5.intel
- [x] gaea-c6.intel
- [ ] hera.gnu
- [ ] hera.intel
- [ ] hercules.intel
- [ ] jet.intel
- [ ] orion.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [x] fundamental test suite
- [x] comprehensive tests (specify *which* if a subset was used)

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] My changes do not require updates to the documentation (explain).
    - Only changes to modulefiles
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes

## CONTRIBUTORS (optional): 
@RatkoVasic-NOAA for originally discovering the issue and opening an emergency PR to correct the Gaea-C6 issue in develop.