### PR TITLE
[develop] SRW-AQM:  Bring back 'do_canopy' NL functionality.

### DIFF
--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -730,9 +730,7 @@ def setup_fv3_namelist(expt_config,debug):
                 "vsvoo1:0.0", "vsvoo2:0.0", "vsvoo3:0.0", "vsvpo1:0.0", "vsvpo2:0.0",
                 "vsvpo3:0.0", "xopn:0.0", "xylmn:0.0", "*:0.2" ]
         })
-        if DO_AQM_CANOPY:
-              if ( CCPP_PHYS_SUITE == "FV3_GFS_v16" or
-                   CCPP_PHYS_SUITE == "FV3_GFS_v17_p8"):
+        if DO_AQM_CANOPY and CCPP_PHYS_SUITE in ("FV3_GFS_v16",  "FV3_GFS_v17_p8"):
                   gfs_physics_nml_dict.update({
                   "do_canopy": True
                   })

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -730,6 +730,12 @@ def setup_fv3_namelist(expt_config,debug):
                 "vsvoo1:0.0", "vsvoo2:0.0", "vsvoo3:0.0", "vsvpo1:0.0", "vsvpo2:0.0",
                 "vsvpo3:0.0", "xopn:0.0", "xylmn:0.0", "*:0.2" ]
         })
+        if DO_AQM_CANOPY:
+              if ( CCPP_PHYS_SUITE == "FV3_GFS_v16" or
+                   CCPP_PHYS_SUITE == "FV3_GFS_v17_p8"):
+                  gfs_physics_nml_dict.update({
+                  "do_canopy": True
+                  })
 
     # If UFS_FIRE, activate appropriate flags
     if expt_config['fire'].get('UFS_FIRE'):

--- a/ush/generate_FV3LAM_wflow.py
+++ b/ush/generate_FV3LAM_wflow.py
@@ -731,9 +731,9 @@ def setup_fv3_namelist(expt_config,debug):
                 "vsvpo3:0.0", "xopn:0.0", "xylmn:0.0", "*:0.2" ]
         })
         if DO_AQM_CANOPY and CCPP_PHYS_SUITE in ("FV3_GFS_v16",  "FV3_GFS_v17_p8"):
-                  gfs_physics_nml_dict.update({
-                  "do_canopy": True
-                  })
+            gfs_physics_nml_dict.update({
+                "do_canopy": True
+            })
 
     # If UFS_FIRE, activate appropriate flags
     if expt_config['fire'].get('UFS_FIRE'):


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The SRW-AQM "do_canopy" flag was not populated from previous work in bringing all [aqm_dev] functionality to [develop] some time ago.  It is be needed to allow for inline AQM canopy effects to also occur simultaneously in UWM/FV3/ccpp-physics.  

### Type of change
- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)

## TESTS CONDUCTED: 
- [X ] gaea-c6.intel
- [X ] hera.intel

## DEPENDENCIES:
This "do_canopy" flag has dependencies with:
UWM:  https://github.com/ufs-community/ufs-weather-model/pull/2630 
AQM:  https://github.com/NOAA-EMC/AQM/pull/19
FV3:  https://github.com/NOAA-EMC/fv3atm/pull/928
ccpp-physics:  https://github.com/ufs-community/ccpp-physics/pull/253

## CHECKLIST
- [ ] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes do not require updates to the documentation (explain).
- [ X] My changes generate no new warnings
- [X ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
- [X ] bug
- [X ] enhancement


## CONTRIBUTORS (optional): 
@iri01

