### PR TITLE
[develop] fix: explicitly set conda path

### DIFF
--- a/devbuild.sh
+++ b/devbuild.sh
@@ -228,6 +228,8 @@ if [ "${BUILD_CONDA}" = "on" ] ; then
   fi
 
   source ${CONDA_BUILD_DIR}/etc/profile.d/conda.sh
+  # Avoid potential conda path mangling
+  export PATH="${CONDA_BUILD_DIR}/bin:${PATH}"
   # Put some additional packages in the base environment on MacOS systems
   if [ "${os}" == "MacOSX" ] ; then
     mamba install -y bash coreutils sed

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -229,7 +229,7 @@ if [ "${BUILD_CONDA}" = "on" ] ; then
 
   source ${CONDA_BUILD_DIR}/etc/profile.d/conda.sh
   # Avoid potential conda path mangling
-  export PATH="${CONDA_BUILD_DIR}/bin:${PATH}"
+  PATH="${CONDA_BUILD_DIR}/bin:${PATH}"
   # Put some additional packages in the base environment on MacOS systems
   if [ "${os}" == "MacOSX" ] ; then
     mamba install -y bash coreutils sed

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -228,8 +228,10 @@ if [ "${BUILD_CONDA}" = "on" ] ; then
   fi
 
   source ${CONDA_BUILD_DIR}/etc/profile.d/conda.sh
-  # Avoid potential conda path mangling
-  PATH="${CONDA_BUILD_DIR}/bin:${PATH}"
+  # Avoid potential conda path issues on gaeac6
+  if [ "${PLATFORM}" = "gaeac6" ]; then
+    PATH="${CONDA_BUILD_DIR}/bin:${PATH}"
+  fi
   # Put some additional packages in the base environment on MacOS systems
   if [ "${os}" == "MacOSX" ] ; then
     mamba install -y bash coreutils sed


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

@drnimbusrain encountered a strange issue on `gaeac6` where sourcing `conda.sh` results in a mangled `PATH`. The problem is deep in the generated `conda.sh` file. With a prepended mangled `PATH`, the conda-installed Python cannot be found, and the build fails in the following `mamba` step.

The fix here always explicitly prepends to `PATH` the `conda/bin` directory. Another option is to detect if Python is not in the path and adjust accordingly.

As far as I know, @drnimbusrain is the only user affected by this, but it may prevent future build issues. We verified that this fix addresses his issue.

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [ ] derecho.intel
- [ ] gaea.intel
- [x] gaea-c6.intel
- [ ] hera.gnu
- [ ] hera.intel
- [ ] hercules.intel
- [ ] jet.intel
- [ ] orion.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

## CONTRIBUTORS (optional): 
@drnimbusrain

