### PR TITLE
[develop] Remove the <exclusive> flags from aqm_prep.yaml and plot.yaml

### DIFF
--- a/.cicd/Jenkinsfile
+++ b/.cicd/Jenkinsfile
@@ -12,10 +12,10 @@ pipeline {
     parameters {
         // Allow job runner to filter based on platform
         // Use the line below to enable all PW clusters
-        // choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac5', 'gaeac6','hera', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2use1', 'gclusternoaav2usc1'], description: 'Specify the platform(s) to use')
+        // choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac6','hera', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2use1', 'gclusternoaav2usc1'], description: 'Specify the platform(s) to use')
         // Use the line below to enable the PW AWS cluster
-        // choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac5', 'gaeac6', 'hera', 'orion', 'hercules', 'pclusternoaav2use1'], description: 'Specify the platform(s) to use')
-        choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac5', 'gaeac6', 'hera', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2use1', 'gclusternoaav2usc1'], description: 'Specify the platform(s) to use')
+        // choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac6', 'hera', 'orion', 'hercules', 'pclusternoaav2use1'], description: 'Specify the platform(s) to use')
+        choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac6', 'hera', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2use1', 'gclusternoaav2usc1'], description: 'Specify the platform(s) to use')
         // Allow job runner to filter based on compiler
         choice(name: 'SRW_COMPILER_FILTER', choices: ['all', 'gnu', 'intel'], description: 'Specify the compiler(s) to use to build')
         // Workflow Wrapper test depth {0..9}, 0=none, 1=simple, 9=all [default]
@@ -117,7 +117,7 @@ pipeline {
                 axes {
                     axis {
                         name 'SRW_PLATFORM'
-                        values 'derecho', 'gaeac5', 'gaeac6', 'hera', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2use1', 'gclusternoaav2usc1'
+                        values 'derecho', 'gaeac6', 'hera', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2use1', 'gclusternoaav2usc1'
                     }
 
                     axis {
@@ -131,7 +131,7 @@ pipeline {
                     exclude {
                             axis {
                             name 'SRW_PLATFORM'
-                            values 'derecho', 'gaeac5', 'gaeac6', 'orion', 'hercules', 'pclusternoaav2use1' , 'azclusternoaav2use1', 'gclusternoaav2usc1'
+                            values 'derecho', 'gaeac6', 'orion', 'hercules', 'pclusternoaav2use1' , 'azclusternoaav2use1', 'gclusternoaav2usc1'
                         }
 
                         axis {

--- a/.cicd/scripts/srw_metric.sh
+++ b/.cicd/scripts/srw_metric.sh
@@ -91,7 +91,7 @@ srw_project=${SRW_PROJECT}
 if [[ ${RUN_WE2E_OPT} == true ]]; then
     [[ -d ${we2e_experiment_base_dir} ]] && rm -rf ${we2e_experiment_base_dir}
     cd ${workspace}/tests/WE2E
-    ./run_WE2E_tests.py -t ${we2e_test_name} -m ${platform,,} -a ${srw_project} --expt_basedir "metric_test" --exec_subdir=install_intel/exec -q
+    ./run_we2e_tests.py -t ${we2e_test_name} -m ${platform,,} -a ${srw_project} --expt_basedir "metric_test" --exec_subdir=install_intel/exec -q
 fi
 cd ${workspace}
 

--- a/modulefiles/wflow_derecho.lua
+++ b/modulefiles/wflow_derecho.lua
@@ -5,8 +5,8 @@ on the CISL machine Derecho (Cray)
 
 whatis([===[Loads libraries for running the UFS SRW Workflow on Derecho ]===])
 
-append_path("MODULEPATH","/glade/work/epicufsrt/contrib/derecho/rocoto/modulefiles")
-load("rocoto")
+append_path("MODULEPATH","/glade/work/epicufsrt/contrib/derecho/modulefiles")
+load("rocoto/1.3.7-fix")
 
 unload("python")
 

--- a/modulefiles/wflow_gaeac6.lua
+++ b/modulefiles/wflow_gaeac6.lua
@@ -6,8 +6,8 @@ the NOAA RDHPC machine Gaea C6
 whatis([===[Loads libraries needed for running the UFS SRW App on gaea c6 ]===])
 
 unload("python")
-prepend_path("MODULEPATH","/ncrc/proj/epic/rocoto/modulefiles/")
-load("rocoto")
+prepend_path("MODULEPATH","/ncrc/proj/epic/c6/modulefiles/")
+load("rocoto/1.3.7-fix")
 load("conda")
 
 pushenv("MKLROOT", "/opt/intel/oneapi/mkl/2023.2.0/")

--- a/modulefiles/wflow_gaeac6.lua
+++ b/modulefiles/wflow_gaeac6.lua
@@ -7,7 +7,7 @@ whatis([===[Loads libraries needed for running the UFS SRW App on gaea c6 ]===])
 
 unload("python")
 prepend_path("MODULEPATH","/ncrc/proj/epic/c6/modulefiles/")
-load("rocoto")
+load("rocoto/1.3.7-fix")
 load("conda")
 
 pushenv("MKLROOT", "/opt/intel/oneapi/mkl/2023.2.0/")

--- a/modulefiles/wflow_gaeac6.lua
+++ b/modulefiles/wflow_gaeac6.lua
@@ -6,7 +6,7 @@ the NOAA RDHPC machine Gaea C6
 whatis([===[Loads libraries needed for running the UFS SRW App on gaea c6 ]===])
 
 unload("python")
-prepend_path("MODULEPATH","/ncrc/proj/epic/rocoto/modulefiles/")
+prepend_path("MODULEPATH","/ncrc/proj/epic/c6/modulefiles/")
 load("rocoto")
 load("conda")
 

--- a/parm/wflow/aqm_prep.yaml
+++ b/parm/wflow/aqm_prep.yaml
@@ -92,7 +92,6 @@ task_nexus_post_split:
     <<: *default_vars
     nprocs: '{{ task_nexus_post_split.execution.batchargs.nodes * task_nexus_post_split.execution.batchargs.tasks_per_node }}'
   nodes: '{{ task_nexus_post_split.execution.batchargs.nodes }}:ppn={{ task_nexus_post_split.execution.batchargs.tasks_per_node }}'
-  exclusive: "True"
   walltime: '{{ task_nexus_post_split.execution.batchargs.walltime }}'
   dependency:
     metataskdep:

--- a/parm/wflow/plot.yaml
+++ b/parm/wflow/plot.yaml
@@ -32,7 +32,6 @@ metatask_plot_allvars:
         fhr: '#fhr#'
       native: '{{ platform.SCHED_NATIVE_CMD }}'
       nodes: '{{ task_plot_allvars.execution.batchargs.nodes }}:ppn={{ task_plot_allvars.execution.batchargs.tasks_per_node }}'
-      exclusive: '{{ task_plot_allvars.execution.batchargs.exclusive }}'
       partition: '{{ "&PARTITION_DEFAULT;" if platform.get("PARTITION_DEFAULT") }}'
       queue: '&QUEUE_DEFAULT;'
       walltime: '{{ task_plot_allvars.execution.batchargs.walltime }}'

--- a/ush/config_defaults.yaml
+++ b/ush/config_defaults.yaml
@@ -2037,7 +2037,6 @@ task_plot_allvars:
     batchargs:
       nodes: 1
       tasks_per_node: 1
-      exclusive: True
       walltime: 01:00:00
   #-------------------------------------------------------------------------
   # Path to the reference experiment's COMOUT directory. This is where the GRIB2 files 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
* parm/wflow/aqm_prep.yaml - remove <exclusive> flag entry
* parm/wflow/plot.yaml - remove <exclusive> flag entry
* ush/config_defaults.yaml - remove <exclusive> flag from task_plot_allvars
* modulefiles/wflow_gaeac6.lua - Update modulefile path and rocoto version to `1.3.7-fix`
* modulefiles/wflow_derecho.lua - Update modulefile path and rocoto version to `1.3.7-fix`
* .cicd/Jenkinsfile - Removed Gaea C5 from the machines that are tested
* .cicd/scripts/srw_metric.sh - Updated run_WE2E_tests.py to run_we2e_tests.py

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
Fundamental tests were run on Hera.  The AQM WE2E test and AQM sample configuration (`ush/config.aqm.yaml`) were run on Hera.  The plotting WE2E tests were run on Hera.  All tests successfully passed following the removal of the `<exclusive>` flag.  Additional testing on Derecho and Gaea C6 will be completed once the Rocoto versions have been updated to 1.3.7 on both machines.
- [ ] derecho.intel
- [ ] gaeac5.intel
- [x] gaeac6.intel
- [ ] hera.gnu
- [x] hera.intel
- [ ] hercules.intel
- [ ] jet.intel
- [ ] orion.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [x] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## ISSUE: 
Resolves #1268 and #1282

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] My changes do not require updates to the documentation (explain).
   - This update removes <exclusive> flags, which don't appear in the documentation.
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes

## CONTRIBUTORS (optional): 
@mkavulich @christinaholtNOAA @natalie-perlin