### PR TITLE
[develop] Updating GFSv17_p8 field table for AQMv8 chemical tracers.

### DIFF
--- a/parm/field_table_aqm.FV3_GFS_v17_p8
+++ b/parm/field_table_aqm.FV3_GFS_v17_p8
@@ -3,52 +3,52 @@
  "TRACER", "atmos_mod", "sphum"
            "longname",     "specific humidity"
            "units",        "kg/kg"
-       "profile_type", "fixed", "surface_value=3.e-6" /
+           "profile_type", "fixed", "surface_value=3.e-6" /
 # prognostic cloud water mixing ratio
  "TRACER", "atmos_mod", "liq_wat"
            "longname",     "cloud water mixing ratio"
            "units",        "kg/kg"
-       "profile_type", "fixed", "surface_value=1.e30" /
+           "profile_type", "fixed", "surface_value=1.e30" /
 # prognostic ice water mixing ratio
  "TRACER", "atmos_mod", "ice_wat"
            "longname",     "cloud ice mixing ratio"
            "units",        "kg/kg"
-       "profile_type", "fixed", "surface_value=1.e30" /
+           "profile_type", "fixed", "surface_value=1.e30" /
 # prognostic rain water mixing ratio
  "TRACER", "atmos_mod", "rainwat"
            "longname",     "rain water mixing ratio"
            "units",        "kg/kg"
-       "profile_type", "fixed", "surface_value=1.e30" /
+           "profile_type", "fixed", "surface_value=1.e30" /
 # prognostic snow water mixing ratio
  "TRACER", "atmos_mod", "snowwat"
            "longname",     "snow water mixing ratio"
            "units",        "kg/kg"
-       "profile_type", "fixed", "surface_value=1.e30" /
+           "profile_type", "fixed", "surface_value=1.e30" /
 # prognostic Grau water mixing ratio
  "TRACER", "atmos_mod", "graupel"
            "longname",     "graupel mixing ratio"
            "units",        "kg/kg"
-       "profile_type", "fixed", "surface_value=1.e30" /
+           "profile_type", "fixed", "surface_value=1.e30" /
 # prognostic cloud ice number concentration
  "TRACER", "atmos_mod", "ice_nc"
            "longname",     "cloud ice water number concentration"
            "units",        "/kg"
-       "profile_type", "fixed", "surface_value=0.0" /
+           "profile_type", "fixed", "surface_value=0.0" /
 # prognostic rain number concentration
  "TRACER", "atmos_mod", "rain_nc"
            "longname",     "rain number concentration"
            "units",        "/kg"
-       "profile_type", "fixed", "surface_value=0.0" /
+           "profile_type", "fixed", "surface_value=0.0" /
 # prognostic ozone mixing ratio tracer
  "TRACER", "atmos_mod", "o3mr"
            "longname",     "ozone mixing ratio"
            "units",        "kg/kg"
-       "profile_type", "fixed", "surface_value=1.e30" /
+           "profile_type", "fixed", "surface_value=1.e30" /
 # prognostic subgrid scale turbulent kinetic energy
  "TRACER", "atmos_mod", "sgs_tke"
            "longname",     "subgrid scale turbulent kinetic energy"
            "units",        "m2/s2"
-       "profile_type", "fixed", "surface_value=0.0" /
+           "profile_type", "fixed", "surface_value=0.0" /
 # prognostic air quality tracers
  "TRACER", "atmos_mod", "NO2"
            "longname",  "NO2"
@@ -280,6 +280,21 @@
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "APIN"
+           "longname",  "APIN"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "TERPNRO2"
+           "longname",  "TERPNRO2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "MTNO3"
+           "longname",  "MTNO3"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "BENZENE"
            "longname",  "BENZENE"
            "units",     "ppmV"
@@ -345,6 +360,11 @@
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "CLO"
+           "longname",  "CLO"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "FMCL"
            "longname",  "FMCL"
            "units",     "ppmV"
@@ -357,6 +377,11 @@
            "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "CLNO2"
            "longname",  "CLNO2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "CLNO3"
+           "longname",  "CLNO3"
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
@@ -465,9 +490,34 @@
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ASO4J"
-           "longname",  "ASO4J"
-           "units",     "ug/kg"
+ "TRACER", "atmos_mod", "SVAVB1"
+           "longname",  "SVAVB1"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SVAVB2"
+           "longname",  "SVAVB2"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SVAVB3"
+           "longname",  "SVAVB3"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "SVAVB4"
+           "longname",  "SVAVB4"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "DMS"
+           "longname",  "DMS"
+           "units",     "ppmV"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "MSA"
+           "longname",  "MSA"
+           "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "ASO4I"
@@ -475,8 +525,13 @@
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ANH4J"
-           "longname",  "ANH4J"
+ "TRACER", "atmos_mod", "ASO4J"
+           "longname",  "ASO4J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASO4K"
+           "longname",  "ASO4K"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
@@ -485,8 +540,13 @@
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ANO3J"
-           "longname",  "ANO3J"
+ "TRACER", "atmos_mod", "ANH4J"
+           "longname",  "ANH4J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ANH4K"
+           "longname",  "ANH4K"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
@@ -495,83 +555,38 @@
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "AALK1J"
-           "longname",  "AALK1J"
+ "TRACER", "atmos_mod", "ANO3J"
+           "longname",  "ANO3J"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "AALK2J"
-           "longname",  "AALK2J"
+ "TRACER", "atmos_mod", "ANO3K"
+           "longname",  "ANO3K"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "AXYL1J"
-           "longname",  "AXYL1J"
+ "TRACER", "atmos_mod", "ANAI"
+           "longname",  "ANAI"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "AXYL2J"
-           "longname",  "AXYL2J"
+ "TRACER", "atmos_mod", "ANAJ"
+           "longname",  "ANAJ"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "AXYL3J"
-           "longname",  "AXYL3J"
+ "TRACER", "atmos_mod", "ACLI"
+           "longname",  "ACLI"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ATOL1J"
-           "longname",  "ATOL1J"
+ "TRACER", "atmos_mod", "ACLJ"
+           "longname",  "ACLJ"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ATOL2J"
-           "longname",  "ATOL2J"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ATOL3J"
-           "longname",  "ATOL3J"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ABNZ1J"
-           "longname",  "ABNZ1J"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ABNZ2J"
-           "longname",  "ABNZ2J"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ABNZ3J"
-           "longname",  "ABNZ3J"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "APAH1J"
-           "longname",  "APAH1J"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "APAH2J"
-           "longname",  "APAH2J"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "APAH3J"
-           "longname",  "APAH3J"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ATRP1J"
-           "longname",  "ATRP1J"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ATRP2J"
-           "longname",  "ATRP2J"
+ "TRACER", "atmos_mod", "ACLK"
+           "longname",  "ACLK"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
@@ -595,23 +610,23 @@
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "AECJ"
-           "longname",  "AECJ"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "AECI"
            "longname",  "AECI"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "AOTHRJ"
-           "longname",  "AOTHRJ"
+ "TRACER", "atmos_mod", "AECJ"
+           "longname",  "AECJ"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "AOTHRI"
            "longname",  "AOTHRI"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AOTHRJ"
+           "longname",  "AOTHRJ"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
@@ -695,8 +710,8 @@
            "units",     "m2/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "AH2OJ"
-           "longname",  "AH2OJ"
+ "TRACER", "atmos_mod", "AORGH2OJ"
+           "longname",  "AORGH2OJ"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
@@ -705,58 +720,8 @@
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "AH3OPJ"
-           "longname",  "AH3OPJ"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "AH3OPI"
-           "longname",  "AH3OPI"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ANAJ"
-           "longname",  "ANAJ"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ANAI"
-           "longname",  "ANAI"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ACLJ"
-           "longname",  "ACLJ"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ACLI"
-           "longname",  "ACLI"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ASEACAT"
-           "longname",  "ASEACAT"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ACLK"
-           "longname",  "ACLK"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ASO4K"
-           "longname",  "ASO4K"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ANH4K"
-           "longname",  "ANH4K"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ANO3K"
-           "longname",  "ANO3K"
+ "TRACER", "atmos_mod", "AH2OJ"
+           "longname",  "AH2OJ"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
@@ -765,8 +730,23 @@
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AH3OPI"
+           "longname",  "AH3OPI"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AH3OPJ"
+           "longname",  "AH3OPJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "AH3OPK"
            "longname",  "AH3OPK"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASEACAT"
+           "longname",  "ASEACAT"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
@@ -790,6 +770,36 @@
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AMTNO3J"
+           "longname",  "AMTNO3J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AMTHYDJ"
+           "longname",  "AMTHYDJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "APOCI"
+           "longname",  "APOCI"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "APOCJ"
+           "longname",  "APOCJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "APNCOMI"
+           "longname",  "APNCOMI"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "APNCOMJ"
+           "longname",  "APNCOMJ"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "APCSOJ"
            "longname",  "APCSOJ"
            "units",     "ug/kg"
@@ -800,23 +810,23 @@
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ASVPO1I"
-           "longname",  "ASVPO1I"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ASVPO2I"
-           "longname",  "ASVPO2I"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "ALVPO1J"
            "longname",  "ALVPO1J"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVPO1I"
+           "longname",  "ASVPO1I"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "ASVPO1J"
            "longname",  "ASVPO1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVPO2I"
+           "longname",  "ASVPO2I"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
@@ -840,23 +850,13 @@
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ALVOO2I"
-           "longname",  "ALVOO2I"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ASVOO1I"
-           "longname",  "ASVOO1I"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "ASVOO2I"
-           "longname",  "ASVOO2I"
-           "units",     "ug/kg"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "ALVOO1J"
            "longname",  "ALVOO1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ALVOO2I"
+           "longname",  "ALVOO2I"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
@@ -865,8 +865,18 @@
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVOO1I"
+           "longname",  "ASVOO1I"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "ASVOO1J"
            "longname",  "ASVOO1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "ASVOO2I"
+           "longname",  "ASVOO2I"
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
@@ -880,88 +890,108 @@
            "units",     "ug/kg"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AAVB1J"
+           "longname",  "AAVB1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AAVB2J"
+           "longname",  "AAVB2J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AAVB3J"
+           "longname",  "AAVB3J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AAVB4J"
+           "longname",  "AAVB4J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AMT1J"
+           "longname",  "AMT1J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AMT2J"
+           "longname",  "AMT2J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AMT3J"
+           "longname",  "AMT3J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AMT4J"
+           "longname",  "AMT4J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AMT5J"
+           "longname",  "AMT5J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
+ "TRACER", "atmos_mod", "AMT6J"
+           "longname",  "AMT6J"
+           "units",     "ug/kg"
+           "tracer_usage", "chemistry"
+           "profile_type", "fixed", "surface_value=1.e-7" /
  "TRACER", "atmos_mod", "NH3"
            "longname",  "NH3"
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_ALK1"
-           "longname",  "SV_ALK1"
+ "TRACER", "atmos_mod", "SVISO1"
+           "longname",  "SVISO1"
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_ALK2"
-           "longname",  "SV_ALK2"
+ "TRACER", "atmos_mod", "SVISO2"
+           "longname",  "SVISO2"
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_XYL1"
-           "longname",  "SV_XYL1"
+ "TRACER", "atmos_mod", "SVSQT"
+           "longname",  "SVSQT"
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_XYL2"
-           "longname",  "SV_XYL2"
+ "TRACER", "atmos_mod", "LVPCSOG"
+           "longname",  "LVPCSOG"
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_TOL1"
-           "longname",  "SV_TOL1"
+ "TRACER", "atmos_mod", "SVMT1"
+           "longname",  "SVMT1"
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_TOL2"
-           "longname",  "SV_TOL2"
+ "TRACER", "atmos_mod", "SVMT2"
+           "longname",  "SVMT2"
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_BNZ1"
-           "longname",  "SV_BNZ1"
+ "TRACER", "atmos_mod", "SVMT3"
+           "longname",  "SVMT3"
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_BNZ2"
-           "longname",  "SV_BNZ2"
+ "TRACER", "atmos_mod", "SVMT4"
+           "longname",  "SVMT4"
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_PAH1"
-           "longname",  "SV_PAH1"
+ "TRACER", "atmos_mod", "SVMT5"
+           "longname",  "SVMT5"
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_PAH2"
-           "longname",  "SV_PAH2"
-           "units",     "ppmV"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_TRP1"
-           "longname",  "SV_TRP1"
-           "units",     "ppmV"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_TRP2"
-           "longname",  "SV_TRP2"
-           "units",     "ppmV"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_ISO1"
-           "longname",  "SV_ISO1"
-           "units",     "ppmV"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_ISO2"
-           "longname",  "SV_ISO2"
-           "units",     "ppmV"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "SV_SQT"
-           "longname",  "SV_SQT"
-           "units",     "ppmV"
-           "tracer_usage", "chemistry"
-           "profile_type", "fixed", "surface_value=1.e-7" /
- "TRACER", "atmos_mod", "LV_PCSOG"
-           "longname",  "LV_PCSOG"
+ "TRACER", "atmos_mod", "SVMT6"
+           "longname",  "SVMT6"
            "units",     "ppmV"
            "tracer_usage", "chemistry"
            "profile_type", "fixed", "surface_value=1.e-7" /
@@ -986,3 +1016,8 @@
            "units",        "ug/m3"
            "tracer_usage", "chemistry", "type=diagnostic"
            "profile_type", "fixed", "surface_value=0.0" /
+# non-prognostic cloud amount
+ "TRACER", "atmos_mod", "cld_amt"
+           "longname",     "cloud amount"
+           "units",        "1"
+           "profile_type", "fixed", "surface_value=1.e30" /


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updating the GFSv17_p8 aqm field table for updated chemical tracers to support running these physics with AQMv8.  

### Type of change
- [X ] New feature (non-breaking change which adds functionality)

## TESTS CONDUCTED: 
- [ ] derecho.intel
- [ X] gaeac6.intel
- [ ] hera.gnu
- [ ] hera.intel
- [ ] hercules.intel
- [ ] orion.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:
None.

## DOCUMENTATION:


## ISSUE: 

## CHECKLIST
- [X] My code follows the style guidelines in the Contributor's Guide
- [X ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ X] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes do not require updates to the documentation (explain).
- [X ] My changes generate no new warnings
- [X ] New and existing tests pass with my changes
- [X ] Any dependent changes have been merged and published

## LABELS (optional): 
- [ ] Work In Progress
- [ ] bug
- [X ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
@KaiWang-NOAA
@benkozi 

