### PR TITLE
[develop] Update ufs-weather-model and UPP hashes

### DIFF
--- a/.cicd/Jenkinsfile
+++ b/.cicd/Jenkinsfile
@@ -12,10 +12,10 @@ pipeline {
     parameters {
         // Allow job runner to filter based on platform
         // Use the line below to enable all PW clusters
-        // choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac6', 'hera', 'ursa', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2use1', 'gclusternoaav2usc1'], description: 'Specify the platform(s) to use')
+        // choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac6', 'ursa', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2use1', 'gclusternoaav2usc1'], description: 'Specify the platform(s) to use')
         // Use the line below to enable the PW AWS cluster
-        // choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac6', 'hera', 'ursa', 'orion', 'hercules', 'pclusternoaav2use1'], description: 'Specify the platform(s) to use')
-        choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac6', 'hera', 'ursa', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2use1', 'gclusternoaav2usc1'], description: 'Specify the platform(s) to use')
+        // choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac6', 'ursa', 'orion', 'hercules', 'pclusternoaav2use1'], description: 'Specify the platform(s) to use')
+        choice(name: 'SRW_PLATFORM_FILTER', choices: ['all', 'derecho', 'gaeac6', 'ursa', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2use1', 'gclusternoaav2usc1'], description: 'Specify the platform(s) to use')
         // Allow job runner to filter based on compiler
         choice(name: 'SRW_COMPILER_FILTER', choices: ['all', 'gnu', 'intel'], description: 'Specify the compiler(s) to use to build')
         // Workflow Wrapper test depth {0..9}, 0=none, 1=simple, 9=all [default]
@@ -117,7 +117,7 @@ pipeline {
                 axes {
                     axis {
                         name 'SRW_PLATFORM'
-                        values 'derecho', 'gaeac6', 'hera', 'ursa', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2use1', 'gclusternoaav2usc1'
+                        values 'derecho', 'gaeac6', 'ursa', 'orion', 'hercules', 'pclusternoaav2use1', 'azclusternoaav2use1', 'gclusternoaav2usc1'
                     }
 
                     axis {

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -32,8 +32,6 @@
 
 - [ ] derecho.intel
 - [ ] gaeac6.intel
-- [ ] hera.gnu
-- [ ] hera.intel
 - [ ] hercules.intel
 - [ ] orion.intel
 - [ ] ursa.gnu

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -12,7 +12,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = b8f9428
+hash = 06afcd6
 local_path = sorc/ufs-weather-model
 required = True
 
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 1a16f94
+hash = 8d41f98
 local_path = sorc/UPP
 required = True
 

--- a/tests/WE2E/run_we2e_tests.py
+++ b/tests/WE2E/run_we2e_tests.py
@@ -51,9 +51,9 @@ def run_we2e_tests(homedir, args) -> None:
     # Derecho requires long delay between calls to rocotorun due to system-level cacheing of
     # job statuses
     if machine=="derecho":
-        if args.delay < 60:
+        if args.delay < 150:
             logging.info("Derecho requires 60 second delay between calls to rocotorun")
-            args.delay=60
+            args.delay=150
 
     # Check for invalid input
     if run_envir:


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Update ufs-weather-model hash to [06afcd6](https://github.com/ufs-community/ufs-weather-model/commit/06afcd655244c5f4c3f528770181020c132bf953) (Feb 2) and UPP hash to [8d41f98](https://github.com/NOAA-EMC/UPP/commit/8d41f98e66ea858c163a387aaa0c6179851a1466) (Nov 21)
- Change Rocoto delay on Derecho from 1 minute to 2.5 minutes (to allow for single tests to run)
- Removed Hera testing from `Jenkinsfile`
- Removed `hera.gnu` and `hera.intel` from `TESTS CONDUCTED` section of the `PULL_REQUEST_TEMPLATE`

### Type of change
- [x] New feature (non-breaking change which adds functionality)

## TESTS CONDUCTED: 
- [x] derecho.intel - AQM, Coverage and UFS Fire WE2E tests
- [ ] gaeac6.intel
- [x] hercules.intel - AQM, Comprehensive, and UFS Fire WE2E tests
- [x] orion.intel - AQM, Comprehensive and UFS Fire WE2E tests
- [ ] ursa.gnu
- [ ] ursa.intel

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE: 
N/A

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] My changes do not require updates to the documentation (explain).
   - Only hash updates
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes