### PR TITLE
[develop] Update ufs-weather-model and UPP hashes to February versions

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -12,7 +12,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 06afcd6
+hash = a796a4f
 local_path = sorc/ufs-weather-model
 required = True
 
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 8d41f98
+hash = 7d9597c
 local_path = sorc/UPP
 required = True
 

--- a/ush/config.smoke_dust.yaml
+++ b/ush/config.smoke_dust.yaml
@@ -47,6 +47,10 @@ task_run_fcst:
     DT_ATMOS: 36
   QUILTING: true
 task_run_post:
+  upp:
+    execution:
+      batchargs:
+        walltime: 00:20:00
   envvars:
     POST_OUTPUT_DOMAIN_NAME: conus3km
     USE_CUSTOM_POST_CONFIG_FILE: false


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
* Externals.cfg - Update ufs-weather-model hash to a796a4f (February 10) and UPP hash to 7d9597c (February 6)
* ush/config.smoke_dust.yaml - Increase run_post task's walltime from 15 minutes to 20 minutes to allow for the increase in walltime in UPP

### Type of change
- [x] New feature (non-breaking change which adds functionality)

## TESTS CONDUCTED: 
- [x] derecho.intel - AQM, Coverage, and UFS Fire WE2E tests
- [x] gaeac6.intel - AQM, Comprehensive, UFS Fire, and Fall Ozone Use Case tests
- [x] hercules.intel - AQM, Comprehensive, UFS Fire, and AEROMMA Use Case tests
- [x] orion.intel - AQM, Comprehensive, UFS Fire, and Fall Ozone Use Case tests
- [x] ursa.gnu - Fundamental and UFS Fire WE2E tests
- [x] ursa.intel - AQM, Comprehensive, UFS Fire, AEROMMA and Fall Ozone Use Case tests

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE: 
N/A

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] My changes do not require updates to the documentation (explain).
   - [x] These changes are only updating hashes in Externals.cfg
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes