### PR TITLE
[develop] Update the ufs-weather-model hash to June 16 and the UPP hash to May 12 versions

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -12,7 +12,7 @@ protocol = git
 repo_url = https://github.com/ufs-community/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = e202ff3
+hash = 04a67f0
 local_path = sorc/ufs-weather-model
 required = True
 
@@ -21,7 +21,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 7d9597c
+hash = 2e2430a
 local_path = sorc/UPP
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
* Externals.cfg - Update ufs-weather-model hash to https://github.com/ufs-community/ufs-weather-model/commit/04a67f0e91844fbd3fbd39b51b46ddfd7bde72f6 (June 16) and UPP hash to [2e2430a](https://github.com/NOAA-EMC/UPP/commit/2e2430afdcd115a761b68ecd784ee01ae6e5177f) (May 12)

### Type of change
- [x] New feature (non-breaking change which adds functionality)

## TESTS CONDUCTED: 
- [x] derecho.intel - AQM, Coverage, and UFS-Fire WE2E tests
- [x] gaeac6.intel - AQM, Comprehensive, and UFS-Fire WE2E tests
- [x] hercules.intel - AQM, Comprehensive, and UFS-Fire WE2E tests
- [x] orion.intel - AQM, Comprehensive, and UFS-Fire WE2E tests
- [x] ursa.gnu - Coverage and UFS-Fire WE2E tests
- [x] ursa.intel - AQM, Coverage, and UFS-Fire WE2E tests

## DEPENDENCIES:
None

## DOCUMENTATION:
N/A

## ISSUE: 
N/A

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] My changes do not require updates to the documentation (explain).
  - [x] Hash update PR only
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes