### PR TITLE
[develop] Update CI/CD pipeline to work properly on Gaea C6

### DIFF
--- a/.cicd/scripts/wrapper_srw_ftest.sh
+++ b/.cicd/scripts/wrapper_srw_ftest.sh
@@ -47,7 +47,11 @@ fi
 
 # Call job card and return job_id
 echo "Running: ${workflow_cmd} -A ${SRW_PROJECT} ${arg_1} ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh"
-job_id=$(${workflow_cmd} -A ${SRW_PROJECT} ${arg_1} ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh) | awk -F';' '{print $1}'
+if [[ "${SRW_PLATFORM}" == derecho ]]; then
+    job_id=$(${workflow_cmd} -A ${SRW_PROJECT} ${arg_1} ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh)
+else
+    job_id=$(${workflow_cmd} -A ${SRW_PROJECT} ${arg_1} ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh) | awk -F';' '{print $1}'
+fi
 
 echo "Waiting ten seconds for node to initialize"
 sleep 10

--- a/.cicd/scripts/wrapper_srw_ftest.sh
+++ b/.cicd/scripts/wrapper_srw_ftest.sh
@@ -47,7 +47,7 @@ fi
 
 # Call job card and return job_id
 echo "Running: ${workflow_cmd} -A ${SRW_PROJECT} ${arg_1} ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh"
-job_id=$(${workflow_cmd} -A ${SRW_PROJECT} ${arg_1} ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh)
+job_id=$(${workflow_cmd} -A ${SRW_PROJECT} ${arg_1} ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh) | awk -F';' '{print $1}'
 
 echo "Waiting ten seconds for node to initialize"
 sleep 10


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
* `.cicd/scripts/wrapper_srw_ftest.sh` - Updated `job_id` to include `| awk -F';' '{print $1}'` to allow the `Functional WorkflowTaskTests` stage to run on Gaea C6 following the SLURM update

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
- [x] gaeac6.intel
- [x] Jenkins
- [x] coverage test suite

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE: 
N/A

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] My changes do not require updates to the documentation (explain).
  - [x] This is an update to the Jenkins CI/CD scripts
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes

## CONTRIBUTORS
@kbooker79 - for discovering the appended `;c6` at the end of the `job_id` on Gaea C6 following the SLURM update and providing the fix.